### PR TITLE
format-all: added the --check argument

### DIFF
--- a/python/benchmarks/single-node-io.py
+++ b/python/benchmarks/single-node-io.py
@@ -345,6 +345,7 @@ if __name__ == "__main__":
         type=int,
         help="Number of threads to use (default: %(default)s).",
     )
+
     parser.add_argument(
         "--api",
         default=("cufile", "posix"),


### PR DESCRIPTION
Implements format checking. Use `scripts/format-all.py --check` to check the formatting of the whole project using: `isort, black, flake8, mypy, and clang-format`.