### PR TITLE
Remove dependency of the CUDA Runtime API

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -67,7 +67,6 @@ target_include_directories(
 )
 
 target_link_libraries(kvikio INTERFACE Threads::Threads)
-target_link_libraries(kvikio INTERFACE CUDA::cudart)
 target_link_libraries(kvikio INTERFACE CUDA::nvml)
 target_link_libraries(kvikio INTERFACE cuda)
 target_link_libraries(kvikio INTERFACE cufile::cuFile_interface)

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -14,4 +14,4 @@
 
 add_executable(basic_io basic_io.cpp)
 target_include_directories(basic_io PRIVATE ../include ${cuFile_INCLUDE_DIRS})
-target_link_libraries(basic_io PRIVATE kvikio ${cuFile_LIBRARIES} ${cuFileRDMA_LIBRARIES})
+target_link_libraries(basic_io PRIVATE kvikio CUDA::cudart ${cuFile_LIBRARIES} ${cuFileRDMA_LIBRARIES})

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -47,6 +47,9 @@ inline CUcontext get_context_from_device_pointer(const void* devPtr)
   return ctx;
 }
 
+/**
+ * @brief Push CUDA context on creation and pop it on destruction
+ */
 class PushAndPopContext {
  private:
   CUcontext _ctx;

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <iostream>
 #include <tuple>
 
 #include <cuda.h>
@@ -38,12 +39,52 @@ inline CUdeviceptr convert_void2deviceptr(const void* devPtr)
   return reinterpret_cast<CUdeviceptr>(devPtr);
 }
 
+inline CUcontext get_context_from_device_pointer(const void* devPtr)
+{
+  CUcontext ctx{};
+  auto dev = convert_void2deviceptr(devPtr);
+  CUDA_TRY(cuPointerGetAttribute(&ctx, CU_POINTER_ATTRIBUTE_CONTEXT, dev));
+  return ctx;
+}
+
+class PushAndPopContext {
+ private:
+  CUcontext _ctx;
+
+ public:
+  PushAndPopContext(CUcontext ctx) : _ctx{ctx} { CUDA_TRY(cuCtxPushCurrent(_ctx)); }
+  PushAndPopContext(const void* devPtr) : _ctx{get_context_from_device_pointer(devPtr)}
+  {
+    CUDA_TRY(cuCtxPushCurrent(_ctx));
+  }
+  PushAndPopContext(const PushAndPopContext&) = delete;
+  PushAndPopContext& operator=(PushAndPopContext const&) = delete;
+  PushAndPopContext(PushAndPopContext&&)                 = delete;
+  PushAndPopContext&& operator=(PushAndPopContext&&) = delete;
+  ~PushAndPopContext()
+  {
+    try {
+      CUDA_TRY(cuCtxPopCurrent(&_ctx), CUfileException);
+    } catch (CUfileException e) {
+      std::cerr << e.what() << std::endl;
+    }
+  }
+};
+
 // Find the base and offset of the memory allocation `devPtr` is in
-inline std::tuple<void*, std::size_t, std::size_t> get_alloc_info(const void* devPtr)
+inline std::tuple<void*, std::size_t, std::size_t> get_alloc_info(const void* devPtr,
+                                                                  CUcontext* ctx = nullptr)
 {
   auto dev = convert_void2deviceptr(devPtr);
   CUdeviceptr base_ptr{};
   std::size_t base_size{};
+  CUcontext _ctx{};
+  if (ctx != nullptr) {
+    _ctx = *ctx;
+  } else {
+    _ctx = get_context_from_device_pointer(devPtr);
+  }
+  PushAndPopContext context(_ctx);
   CUDA_TRY(cuMemGetAddressRange(&base_ptr, &base_size, dev));
   std::size_t offset = dev - base_ptr;
   /*NOLINTNEXTLINE(performance-no-int-to-ptr, cppcoreguidelines-pro-type-reinterpret-cast)*/

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -68,7 +68,7 @@ class PushAndPopContext {
   {
     try {
       CUDA_TRY(cuCtxPopCurrent(&_ctx), CUfileException);
-    } catch (CUfileException e) {
+    } catch (const CUfileException &e) {
       std::cerr << e.what() << std::endl;
     }
   }

--- a/python/setup.py
+++ b/python/setup.py
@@ -113,7 +113,7 @@ extensions = [
         sources=["kvikio/_lib/libkvikio.pyx"],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
-        libraries=["cuda", "cudart", "nvidia-ml"] + libcufile,
+        libraries=["cuda", "nvidia-ml"] + libcufile,
         language="c++",
         extra_compile_args=["-std=c++17"],
         depends=depends,

--- a/python/tests/test_basic_io.py
+++ b/python/tests/test_basic_io.py
@@ -102,7 +102,7 @@ def test_multiple_gpus(tmp_path):
         a1 = cupy.zeros(200, dtype=a0.dtype)
 
     filename = tmp_path / "test-file"
-    with kvikio.CuFile(filename, "w+") as f:
+    with kvikio.CuFile(filename, "w") as f:
         assert f.write(a0) == a0.nbytes
     with kvikio.CuFile(filename, "r") as f:
         assert f.read(a1) == a1.nbytes


### PR DESCRIPTION
Threads now use `cuPointerGetAttribute(CU_POINTER_ATTRIBUTE_CONTEXT)` to retrieve the appropriate CUDA context. This mean that we do not depend on the CUDA Runtime API any more :)