### PR TITLE
POSIX read/write 

### DIFF
--- a/cpp/include/kvikio/config.hpp
+++ b/cpp/include/kvikio/config.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace kvikio::config {  // TODO: should this be a singletone class instead?
+namespace {
+
+inline bool str_to_boolean(std::string str)
+{
+  try {
+    // Try parsing `str` as a integer
+    return static_cast<bool>(std::stoi(str));
+  } catch (...) {
+  }
+  // Convert to lowercase
+  std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+  // Try parsing `str` using std::boolalpha, which support "true" and "false"
+  bool ret = false;
+  std::istringstream(str) >> std::boolalpha >> ret;
+  return ret;
+}
+
+inline int _get_compat_mode_from_env()
+{
+  const char* str = std::getenv("KVIKIO_COMPAT_MODE");
+  if (str == nullptr) { return -1; }
+  return static_cast<int>(str_to_boolean(str));
+}
+
+/*NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)*/
+inline std::pair<bool, bool> _current_global_compat_mode{std::make_pair(false, false)};
+
+}  // namespace
+
+inline bool get_global_compat_mode()
+{
+  auto [initalized, value] = _current_global_compat_mode;
+  if (initalized) { return value; }
+  int env = _get_compat_mode_from_env();
+  if (env != -1) {
+    // Setting `KVIKIO_COMPAT_MODE` take precedence
+    return static_cast<bool>(env);
+  }
+  // TODO: check if running in an enviornment not compabtile with cuFile, such as WSL
+  //       see <https://github.com/rapidsai/kvikio/issues/11>
+  // TODO: probe cuFile to determent if GDS is available.
+  return false;
+}
+
+}  // namespace kvikio::config

--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <cstddef>
+#include <cstdlib>
+
+#include <cuda.h>
+
+#include <cstring>
+#include <kvikio/error.hpp>
+#include <kvikio/utils.hpp>
+
+namespace kvikio {
+namespace {
+
+inline constexpr std::size_t page_size  = 2 << 9;   // 4 KiB
+inline constexpr std::size_t chunk_size = 2 << 23;  // 16 MiB
+
+inline void pwrite_all(int fd, const void* buf, size_t count, off_t offset)
+{
+  off_t cur_offset      = offset;
+  size_t byte_remaining = count;
+  const char* buffer    = static_cast<const char*>(buf);
+  while (byte_remaining > 0) {
+    ssize_t nbytes_written = ::pwrite(fd, buffer, byte_remaining, cur_offset);
+    if (nbytes_written == -1) {
+      if (errno == EBADF) {
+        throw CUfileException{std::string{"POSIX error on pread at: "} + __FILE__ + ":" +
+                              CUFILE_STRINGIFY(__LINE__) + ": unsupported file open flags"};
+      }
+      throw CUfileException{std::string{"POSIX error on pwrite at: "} + __FILE__ + ":" +
+                            CUFILE_STRINGIFY(__LINE__) + ": " + strerror(errno)};
+    }
+    if (nbytes_written == 0) {
+      throw CUfileException{std::string{"POSIX error on pwrite at: "} + __FILE__ + ":" +
+                            CUFILE_STRINGIFY(__LINE__) + ": EOF"};
+    }
+
+    buffer += nbytes_written;
+    cur_offset += nbytes_written;
+    byte_remaining -= nbytes_written;
+  }
+}
+
+template <bool IsReadOperation>
+inline std::size_t posix_io(int fd,
+                            const void* devPtr_base,
+                            std::size_t size,
+                            std::size_t file_offset,
+                            std::size_t devPtr_offset)
+{
+  void* buf = nullptr;
+  {
+    // TODO: reuse memory allocations
+    int err = ::posix_memalign(&buf, page_size, chunk_size);
+    if (err != 0) {
+      throw CUfileException{std::string{"POSIX error at: "} + __FILE__ + ":" +
+                            CUFILE_STRINGIFY(__LINE__) + ": " + strerror(err)};
+    }
+  }
+  try {
+    CUdeviceptr devPtr      = convert_void2deviceptr(devPtr_base) + devPtr_offset;
+    off_t cur_file_offset   = convert_size2off(file_offset);
+    off_t byte_remaining    = convert_size2off(size);
+    const off_t chunk_size2 = convert_size2off(chunk_size);
+
+    while (byte_remaining > 0) {
+      const off_t nbytes_requested = std::min(chunk_size2, byte_remaining);
+      ssize_t nbytes_got           = nbytes_requested;
+      if constexpr (IsReadOperation) {
+        nbytes_got = ::pread(fd, buf, nbytes_requested, cur_file_offset);
+        if (nbytes_got == -1) {
+          if (errno == EBADF) {
+            throw CUfileException{std::string{"POSIX error on pread at: "} + __FILE__ + ":" +
+                                  CUFILE_STRINGIFY(__LINE__) + ": unsupported file open flags"};
+          }
+          throw CUfileException{std::string{"POSIX error on pread at: "} + __FILE__ + ":" +
+                                CUFILE_STRINGIFY(__LINE__) + ": " + strerror(errno)};
+        }
+        if (nbytes_got == 0) {
+          throw CUfileException{std::string{"POSIX error on pread at: "} + __FILE__ + ":" +
+                                CUFILE_STRINGIFY(__LINE__) + ": EOF"};
+        }
+        CUDA_TRY(cuMemcpyHtoD(devPtr, buf, nbytes_got));
+      } else {  // Is a write operation
+        CUDA_TRY(cuMemcpyDtoH(buf, devPtr, nbytes_requested));
+        pwrite_all(fd, buf, nbytes_requested, cur_file_offset);
+      }
+      cur_file_offset += nbytes_got;
+      devPtr += nbytes_got;
+      byte_remaining -= nbytes_got;
+    }
+  } catch (...) {
+    free(buf);
+    throw;
+  }
+  return size;
+}
+
+}  // namespace
+
+constexpr auto posix_read  = posix_io<true>;
+constexpr auto posix_write = posix_io<false>;
+
+}  // namespace kvikio

--- a/cpp/include/kvikio/thread_pool/default.hpp
+++ b/cpp/include/kvikio/thread_pool/default.hpp
@@ -25,10 +25,10 @@ namespace kvikio::default_thread_pool {  // TODO: should this be a singletone cl
 namespace {
 inline unsigned int get_num_threads_from_env()
 {
-  const char* nthreads = std::getenv("CUFILE_NTHREADS");
+  const char* nthreads = std::getenv("KVIKIO_NTHREADS");
   if (nthreads == nullptr) { return 1; }
   const int n = std::stoi(nthreads);
-  if (n <= 0) { throw std::invalid_argument("CUFILE_NTHREADS has to be a positive integer"); }
+  if (n <= 0) { throw std::invalid_argument("KVIKIO_NTHREADS has to be a positive integer"); }
   return std::stoi(nthreads);
 }
 /*NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)*/
@@ -51,7 +51,7 @@ inline kvikio::third_party::thread_pool& get() { return _current_default_thread_
  * pool will be paused as well.
  *
  * @param nthreads The number of threads to use. The default value can be specified by setting
- * the `CUFILE_NTHREADS` environment variable. If not set, the default value is 1.
+ * the `KVIKIO_NTHREADS` environment variable. If not set, the default value is 1.
  */
 inline void reset(unsigned int nthreads = get_num_threads_from_env())
 {

--- a/cpp/include/kvikio/thread_pool/default.hpp
+++ b/cpp/include/kvikio/thread_pool/default.hpp
@@ -63,6 +63,6 @@ inline void reset(unsigned int nthreads = get_num_threads_from_env())
  *
  * @return The number of threads in the current default thread pool.
  */
-inline unsigned int nthreads() { return _current_default_thread_pool.get_thread_count(); }
+inline unsigned int nthreads() noexcept { return _current_default_thread_pool.get_thread_count(); }
 
 }  // namespace kvikio::default_thread_pool

--- a/python/kvikio/_lib/kvikio_cxx_api.pxd
+++ b/python/kvikio/_lib/kvikio_cxx_api.pxd
@@ -45,6 +45,10 @@ cdef extern from "<kvikio/buffer.hpp>" namespace "kvikio" nogil:
     void memory_deregister(const void* devPtr) except +
 
 
+cdef extern from "<kvikio/config.hpp>" namespace "kvikio::config" nogil:
+    int get_global_compat_mode() except +
+
+
 cdef extern from "<kvikio/thread_pool/default.hpp>" namespace "kvikio::default_thread_pool" nogil:
     void reset(unsigned int nthreads) except +
     unsigned int nthreads()

--- a/python/kvikio/_lib/kvikio_cxx_api.pxd
+++ b/python/kvikio/_lib/kvikio_cxx_api.pxd
@@ -46,7 +46,7 @@ cdef extern from "<kvikio/buffer.hpp>" namespace "kvikio" nogil:
 
 
 cdef extern from "<kvikio/thread_pool/default.hpp>" namespace "kvikio::default_thread_pool" nogil:
-    void reset(unsigned int nthreads)
+    void reset(unsigned int nthreads) except +
     unsigned int nthreads()
 
 

--- a/python/kvikio/_lib/libkvikio.pyx
+++ b/python/kvikio/_lib/libkvikio.pyx
@@ -48,6 +48,9 @@ def memory_deregister(buf) -> None:
     cdef Array arr = buf
     kvikio_cxx_api.memory_deregister(<void*>arr.ptr)
 
+def get_global_compat_mode() -> int:
+    return kvikio_cxx_api.get_global_compat_mode()
+
 def thread_pool_reset_num_threads(nthread: int) -> None:
     kvikio_cxx_api.reset(nthread)
 

--- a/python/kvikio/config.py
+++ b/python/kvikio/config.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+
+
+from ._lib import libkvikio  # type: ignore
+
+
+def get_global_compat_mode() -> int:
+    """ Check if KvikIO is running in compatibility mode.
+
+    Return
+    ------
+    bool
+        Whether KvikIO is running in compatibility mode or not.
+    """
+    return libkvikio.get_global_compat_mode()


### PR DESCRIPTION
This PR introduce a compatibility mode that goes beyond the [Compatibility Mode](https://docs.nvidia.com/gpudirect-storage/api-reference-guide/topics/cufile-compatibility.html#cufile-compatibility-mode) already in cuFile. Enable this mode by setting the environment variable `KVIKIO_COMPAT_MODE=true`.

For now, this mode is very inefficient. 
