### PR TITLE
Specify `--croot` and other build args for kvikio build

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -78,7 +78,6 @@ fi
 # gpuci_logger "Build conda pkg for libkvikio"
 # gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/libkvikio --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
 
-
 gpuci_logger "Build conda pkg for kvikio"
 gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/kvikio --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
 

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -67,11 +67,20 @@ gpuci_mamba_retry install -c conda-forge boa
 # BUILD - Conda package builds
 ################################################################################
 
+if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
+  CONDA_BUILD_ARGS=""
+  CONDA_CHANNEL=""
+else
+  CONDA_BUILD_ARGS="--dirty --no-remove-work-dir"
+  CONDA_CHANNEL="-c $WORKSPACE/ci/artifacts/cudf/cpu/.conda-bld/"
+fi
+
 # gpuci_logger "Build conda pkg for libkvikio"
-# gpuci_conda_retry mambabuild conda/recipes/libkvikio
+# gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/libkvikio --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
+
 
 gpuci_logger "Build conda pkg for kvikio"
-gpuci_conda_retry mambabuild conda/recipes/kvikio
+gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/kvikio --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
 
 ################################################################################
 # UPLOAD - Conda packages


### PR DESCRIPTION
Looks like the nightly uploads are now failing because we forgot to set the proper `--croot` for the kvikIO builds so they are not getting picked up by the upload script - this should resolve that