### PR TITLE
Don't use `CONDA_CHANNEL` for package builds

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -69,17 +69,15 @@ gpuci_mamba_retry install -c conda-forge boa
 
 if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
   CONDA_BUILD_ARGS=""
-  CONDA_CHANNEL=""
 else
   CONDA_BUILD_ARGS="--dirty --no-remove-work-dir"
-  CONDA_CHANNEL="-c $WORKSPACE/ci/artifacts/cudf/cpu/.conda-bld/"
 fi
 
 # gpuci_logger "Build conda pkg for libkvikio"
-# gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/libkvikio --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
+# gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/libkvikio --python=$PYTHON $CONDA_BUILD_ARGS
 
 gpuci_logger "Build conda pkg for kvikio"
-gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/kvikio --python=$PYTHON $CONDA_BUILD_ARGS $CONDA_CHANNEL
+gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/kvikio --python=$PYTHON $CONDA_BUILD_ARGS
 
 ################################################################################
 # UPLOAD - Conda packages

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -14,9 +14,6 @@ export GPUCI_RETRY_SLEEP=30
 # Set default label options if they are not defined elsewhere
 export LABEL_OPTION=${LABEL_OPTION:-"--label main"}
 
-# Setup conda build dir
-export CONDA_BLD_DIR="$WORKSPACE/.conda-bld"
-
 # Skip uploads unless BUILD_MODE == "branch"
 if [ "${BUILD_MODE}" != "branch" ]; then
   echo "Skipping upload"

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -14,6 +14,9 @@ export GPUCI_RETRY_SLEEP=30
 # Set default label options if they are not defined elsewhere
 export LABEL_OPTION=${LABEL_OPTION:-"--label main"}
 
+# Setup conda build dir
+export CONDA_BLD_DIR="$WORKSPACE/.conda-bld"
+
 # Skip uploads unless BUILD_MODE == "branch"
 if [ "${BUILD_MODE}" != "branch" ]; then
   echo "Skipping upload"
@@ -32,7 +35,7 @@ fi
 
 gpuci_logger "Get conda file output locations"
 # export LIBKVIKIO_FILE=`conda build --no-build-id --croot "$WORKSPACE/.conda-bld" conda/recipes/libkvikio --output`
-export KVIKIO_FILE=`conda build --no-build-id --croot "$WORKSPACE/.conda-bld" conda/recipes/kvikio --output`
+export KVIKIO_FILE=`conda build --no-build-id --croot $CONDA_BUILD_DIR conda/recipes/kvikio --output`
 
 ################################################################################
 # UPLOAD - Conda packages


### PR DESCRIPTION
We aren't able to use `CONDA_CHANNEL` for kvikIO builds yet, so removed that variable from the builds scripts.