### PR TITLE
Fix conda build output command in upload script

### DIFF
--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -32,7 +32,7 @@ fi
 
 gpuci_logger "Get conda file output locations"
 # export LIBKVIKIO_FILE=`conda build --no-build-id --croot "$WORKSPACE/.conda-bld" conda/recipes/libkvikio --output`
-export KVIKIO_FILE=`conda build --no-build-id --croot $CONDA_BUILD_DIR conda/recipes/kvikio --output`
+export KVIKIO_FILE=$(conda build --no-build-id --croot "${CONDA_BUILD_DIR}" conda/recipes/kvikio --python=$PYTHON --output)
 
 ################################################################################
 # UPLOAD - Conda packages


### PR DESCRIPTION
Think there was a syntax error in the `conda build ... --output` command being used to locate the packages to upload - now lifting the command used by cuDF so this should work.

Also added the `--python` option to it so we can locate the different build variants of kvikIO.