### PR TITLE
Use correct conda build dir for uploads

### DIFF
--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -32,7 +32,7 @@ fi
 
 gpuci_logger "Get conda file output locations"
 # export LIBKVIKIO_FILE=`conda build --no-build-id --croot "$WORKSPACE/.conda-bld" conda/recipes/libkvikio --output`
-export KVIKIO_FILE=$(conda build --no-build-id --croot "${CONDA_BUILD_DIR}" conda/recipes/kvikio --python=$PYTHON --output)
+export KVIKIO_FILE=$(conda build --no-build-id --croot "${CONDA_BLD_DIR}" conda/recipes/kvikio --python=$PYTHON --output)
 
 ################################################################################
 # UPLOAD - Conda packages


### PR DESCRIPTION
Accidentally used `CONDA_BUILD_DIR` instead of `CONDA_BLD_DIR` for the upload script