### PR TITLE
test: use a dedicated process to run commands

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,47 @@
+import multiprocessing as mp
+import subprocess
+from typing import Iterable
+
+import pytest
+
+mp = mp.get_context("spawn")  # type: ignore
+
+
+def command_server(conn):
+    """Server to run commands given through `conn`"""
+    while True:
+        # Get the next command to run
+        cmd, cwd, verbose = conn.recv()
+        # Run command
+        res: subprocess.CompletedProcess = subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd
+        )  # type: ignore
+        if verbose:
+            print(f"{cwd}$ " + " ".join(res.args))
+            print(res.stdout.decode(), end="")
+        # Send return code back to client
+        conn.send(res.returncode)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def run_cmd():
+    """Provide a `run_cmd` function to run commands in a separate process
+
+    Use `run_cmd(cmd, cwd, verbose)` to run a command.
+
+    Notice, the server that runs the commands are spawned before CUDA initialization.
+    """
+
+    # Start the command server before the very first test
+    client_conn, server_conn = mp.Pipe()
+    p = mp.Process(target=command_server, args=(server_conn,),)
+    p.start()
+
+    def run_cmd(cmd: Iterable[str], cwd, verbose=True):
+        client_conn.send((cmd, cwd, verbose))
+        return client_conn.recv()
+
+    yield run_cmd
+
+    # Kill the command server after the last test
+    p.kill()

--- a/python/tests/test_benchmarks.py
+++ b/python/tests/test_benchmarks.py
@@ -3,26 +3,12 @@
 
 import os
 import os.path
-import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable
 
 import pytest
 
 benchmarks_path = Path(os.path.realpath(__file__)).parent / ".." / "benchmarks"
-
-
-def run_cmd(cmd: Iterable[str], cwd=benchmarks_path, verbose=True):
-    """Help function to run command"""
-
-    res: subprocess.CompletedProcess = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd
-    )  # type: ignore
-    if verbose:
-        print(f"{cwd}$ " + " ".join(res.args))
-        print(res.stdout.decode(), end="")
-    return res.returncode
 
 
 @pytest.mark.parametrize(
@@ -37,7 +23,7 @@ def run_cmd(cmd: Iterable[str], cwd=benchmarks_path, verbose=True):
         "zarr-posix",
     ],
 )
-def test_single_node_io(tmp_path, api):
+def test_single_node_io(run_cmd, tmp_path, api):
     """Test benchmarks/single-node-io.py"""
 
     if "zarr" in api:
@@ -50,7 +36,7 @@ def test_single_node_io(tmp_path, api):
         )
 
     retcode = run_cmd(
-        [
+        cmd=[
             sys.executable or "python",
             "single-node-io.py",
             "-n",
@@ -59,6 +45,7 @@ def test_single_node_io(tmp_path, api):
             str(tmp_path),
             "--api",
             api,
-        ]
+        ],
+        cwd=benchmarks_path,
     )
     assert retcode == 0


### PR DESCRIPTION
For testing, use a dedicated process to run commands to avoid corrupting CUDA