### PR TITLE
Replace setuptools with scikit-build in the Python build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.*~
 build
+python/_skbuild
 *.so
 dask-worker-space
 __pycache__

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -28,8 +28,8 @@ requirements:
     - setuptools
     - cython >=0.29,<0.30
     - cudatoolkit {{ cuda_version }}.*
-    - cmake>=3.20.1
-    - scikit-build>=0.13.1
+    - cmake >=3.20.1
+    - scikit-build >=0.13.1
     - libkvikio {{ version }}
   run:
     - cupy

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -23,12 +23,14 @@ build:
     - CUDAHOSTCXX
 
 requirements:
+  build:
+    - cmake >=3.20.1
+    - ninja
   host:
     - python
     - setuptools
     - cython >=0.29,<0.30
     - cudatoolkit {{ cuda_version }}.*
-    - cmake >=3.20.1
     - scikit-build >=0.13.1
     - libkvikio {{ version }}
   run:

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -28,6 +28,8 @@ requirements:
     - setuptools
     - cython >=0.29,<0.30
     - cudatoolkit {{ cuda_version }}.*
+    - cmake>=3.20.1
+    - scikit-build>=0.13.1
     # - libkvikio {{ version }}
   run:
     - cupy

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -32,6 +32,10 @@ option(FIND_KVIKIO_CPP "Search for existing KVIKIO C++ installations before defa
 find_package(PythonExtensions REQUIRED)
 find_package(Cython REQUIRED)
 
+# TODO: Should we symlink FindcuFile.cmake into python/cmake?
+# find cuFile
+include(../cpp/cmake/Modules/FindcuFile.cmake)
+
 # Ignore unused variable warning.
 set(ignored_variable "${SKBUILD}")
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,53 @@
+# =============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+
+set(kvikio_version 22.04.00)
+
+project(
+  kvikio-python
+  VERSION ${kvikio_version}
+  LANGUAGES # TODO: Building Python extension modules via the python_extension_module requires the C
+            # language to be enabled here. The test project that is built in scikit-build to verify
+            # various linking options for the python library is hardcoded to build with C, so until
+            # that is fixed we need to keep C.
+            C
+            CXX)
+
+option(FIND_KVIKIO_CPP "Search for existing KVIKIO C++ installations before defaulting to local files"
+       OFF)
+
+find_package(PythonExtensions REQUIRED)
+find_package(Cython REQUIRED)
+
+# Ignore unused variable warning.
+set(ignored_variable "${SKBUILD}")
+
+# If the user requested it we attempt to find RMM. TODO: Should we allow the user to specify a path
+# instead of just searching? This version assumes that the installation has been appropriately
+# configured for CMake discovery.
+if(FIND_KVIKIO_CPP)
+    find_package(KVIKIO ${kvikio_version})
+else()
+    set(KVIKIO_FOUND OFF)
+endif()
+
+if(NOT KVIKIO_FOUND)
+  add_subdirectory(../cpp kvikio-cpp)
+endif()
+
+add_subdirectory(cmake)
+add_subdirectory(kvikio/_lib)
+

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -35,11 +35,8 @@ find_package(Cython REQUIRED)
 # Ignore unused variable warning.
 set(ignored_variable "${SKBUILD}")
 
-# If the user requested it we attempt to find RMM. TODO: Should we allow the user to specify a path
-# instead of just searching? This version assumes that the installation has been appropriately
-# configured for CMake discovery.
 if(FIND_KVIKIO_CPP)
-    find_package(KVIKIO ${kvikio_version})
+    find_package(KvikIO ${kvikio_version})
 else()
     set(KVIKIO_FOUND OFF)
 endif()

--- a/python/cmake/CMakeLists.txt
+++ b/python/cmake/CMakeLists.txt
@@ -1,0 +1,15 @@
+# =============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+include(kvikio_python_helpers.cmake)

--- a/python/cmake/kvikio_python_helpers.cmake
+++ b/python/cmake/kvikio_python_helpers.cmake
@@ -41,7 +41,7 @@ function(add_cython_modules cython_modules)
         PROPERTIES PREFIX ""
                    CXX_STANDARD 17
     )
-    target_link_libraries(${cython_module} kvikio::kvikio)
+    target_link_libraries(${cython_module} kvikio)
 
     # Compute the install directory relative to the source and rely on installs being relative to
     # the CMAKE_PREFIX_PATH for e.g. editable installs.

--- a/python/cmake/kvikio_python_helpers.cmake
+++ b/python/cmake/kvikio_python_helpers.cmake
@@ -36,7 +36,11 @@ function(add_cython_modules cython_modules)
     python_extension_module(${cython_module})
 
     # To avoid libraries being prefixed with "lib".
-    set_target_properties(${cython_module} PROPERTIES PREFIX "")
+    set_target_properties(
+        ${cython_module}
+        PROPERTIES PREFIX ""
+                   CXX_STANDARD 17
+    )
     target_link_libraries(${cython_module} kvikio::kvikio)
 
     # Compute the install directory relative to the source and rely on installs being relative to

--- a/python/cmake/kvikio_python_helpers.cmake
+++ b/python/cmake/kvikio_python_helpers.cmake
@@ -41,7 +41,10 @@ function(add_cython_modules cython_modules)
         PROPERTIES PREFIX ""
                    CXX_STANDARD 17
     )
+    # Link to the C++ library.
     target_link_libraries(${cython_module} kvikio)
+    # Treat warnings as errors when compiling.
+	target_compile_options(${cython_module} PRIVATE -Werror)
 
     # Compute the install directory relative to the source and rely on installs being relative to
     # the CMAKE_PREFIX_PATH for e.g. editable installs.

--- a/python/cmake/kvikio_python_helpers.cmake
+++ b/python/cmake/kvikio_python_helpers.cmake
@@ -1,0 +1,49 @@
+# =============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+#[=======================================================================[.rst:
+add_cython_modules
+------------------
+
+Generate C(++) from Cython and create Python modules.
+
+.. code-block:: cmake
+
+  add_cython_modules(<ModuleName...>)
+
+Creates a Cython target for a module, then adds a corresponding Python
+extension module.
+
+``ModuleName``
+  The list of modules to build.
+
+#]=======================================================================]
+function(add_cython_modules cython_modules)
+  foreach(cython_module ${cython_modules})
+    add_cython_target(${cython_module} CXX PY3)
+    add_library(${cython_module} MODULE ${cython_module})
+    python_extension_module(${cython_module})
+
+    # To avoid libraries being prefixed with "lib".
+    set_target_properties(${cython_module} PROPERTIES PREFIX "")
+    target_link_libraries(${cython_module} kvikio::kvikio)
+
+    # Compute the install directory relative to the source and rely on installs being relative to
+    # the CMAKE_PREFIX_PATH for e.g. editable installs.
+    cmake_path(RELATIVE_PATH CMAKE_CURRENT_SOURCE_DIR BASE_DIRECTORY ${kvikio-python_SOURCE_DIR}
+               OUTPUT_VARIABLE install_dst)
+    install(TARGETS ${cython_module} DESTINATION ${install_dst})
+  endforeach(cython_module ${cython_sources})
+endfunction()
+

--- a/python/kvikio/_lib/CMakeLists.txt
+++ b/python/kvikio/_lib/CMakeLists.txt
@@ -1,0 +1,19 @@
+# =============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+# Set the list of Cython files to build
+set(cython_modules arr libkvikio)
+
+# Build all of the Cython targets
+add_cython_modules("${cython_modules}")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,6 +7,9 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29,<0.30",
+    "scikit-build>=0.13.1",
+    "cmake>=3.20.1",
+    "ninja",
 ]
 
 [tool.black]

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,6 +35,5 @@ setup(
         for key in find_packages(include=["kvikio._lib"])
     },
     cmdclass=versioneer.get_cmdclass(),
-    install_requires=["Cython>=0.29,<0.30"],
     zip_safe=False,
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,6 @@ from skbuild import setup
 
 import versioneer
 
-
 setup(
     name="kvikio",
     version=versioneer.get_version(),

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,154 +1,65 @@
 # Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
-import glob
-import os
-import os.path
-import shutil
-import sysconfig
-
-# Must import in this order:
-#   setuptools -> Cython.Distutils.build_ext -> setuptools.command.build_ext
-# Otherwise, setuptools.command.build_ext ends up inheriting from
-# Cython.Distutils.old_build_ext which we do not want
-import setuptools
-
-try:
-    from Cython.Distutils.build_ext import new_build_ext as _build_ext
-except ImportError:
-    from setuptools.command.build_ext import build_ext as _build_ext
-
-import distutils.util
-from distutils.sysconfig import get_python_lib
-
-import Cython.Compiler.Options
-import setuptools.command.build_ext
-from setuptools import find_packages, setup
-from setuptools.extension import Extension
+from setuptools import find_packages
+from skbuild import setup
 
 import versioneer
 
 # Set `DEBUG_BUILD=true` to enable debug build
-DEBUG_BUILD = distutils.util.strtobool(os.environ.get("DEBUG_BUILD", "false"))
+# DEBUG_BUILD = distutils.util.strtobool(os.environ.get("DEBUG_BUILD", "false"))
 
 # Turn all warnings into errors.
-Cython.Compiler.Options.warning_errors = True
+# Cython.Compiler.Options.warning_errors = True
 
 # Abort the compilation on the first error
-Cython.Compiler.Options.fast_fail = True
+# Cython.Compiler.Options.fast_fail = True
 
-install_requires = ["cython"]
-this_setup_scrip_dir = os.path.dirname(os.path.realpath(__file__))
+# install_requires = ["cython"]
+# this_setup_scrip_dir = os.path.dirname(os.path.realpath(__file__))
 
 # Throughout the script, we will populate `include_dirs`,
 # `library_dirs` and `depends`.
-include_dirs = [os.path.dirname(sysconfig.get_path("include"))]
-library_dirs = [get_python_lib()]
-extra_objects = []
-depends = []  # Files to trigger rebuild when modified
+# include_dirs = [os.path.dirname(sysconfig.get_path("include"))]
+# library_dirs = [get_python_lib()]
+# extra_objects = []
+# depends = []  # Files to trigger rebuild when modified
 
-# Find and add CUDA include and binary paths
-CUDA_HOME = os.environ.get("CUDA_HOME", False)
-if not CUDA_HOME:
-    path_to_cuda_gdb = shutil.which("cuda-gdb")
-    if path_to_cuda_gdb is None:
-        raise OSError(
-            "Could not locate CUDA. "
-            "Please set the environment variable "
-            "CUDA_HOME to the path to the CUDA installation "
-            "and try again."
-        )
-    CUDA_HOME = os.path.dirname(os.path.dirname(path_to_cuda_gdb))
-if not os.path.isdir(CUDA_HOME):
-    raise OSError(f"Invalid CUDA_HOME: directory does not exist: {CUDA_HOME}")
-include_dirs.append(os.path.join(CUDA_HOME, "include"))
-library_dirs.append(os.path.join(CUDA_HOME, "lib64"))
+# # Find and add CUDA include and binary paths
+# CUDA_HOME = os.environ.get("CUDA_HOME", False)
+# if not CUDA_HOME:
+#     path_to_cuda_gdb = shutil.which("cuda-gdb")
+#     if path_to_cuda_gdb is None:
+#         raise OSError(
+#             "Could not locate CUDA. "
+#             "Please set the environment variable "
+#             "CUDA_HOME to the path to the CUDA installation "
+#             "and try again."
+#         )
+#     CUDA_HOME = os.path.dirname(os.path.dirname(path_to_cuda_gdb))
+# if not os.path.isdir(CUDA_HOME):
+#     raise OSError(f"Invalid CUDA_HOME: directory does not exist: {CUDA_HOME}")
+# include_dirs.append(os.path.join(CUDA_HOME, "include"))
+# library_dirs.append(os.path.join(CUDA_HOME, "lib64"))
 
-# Use CuFile location outside of CUDA_HOME
-if "CUFILE_HOME" in os.environ:
-    CUFILE_HOME = os.environ["CUFILE_HOME"]
-    if not os.path.isdir(CUDA_HOME):
-        raise OSError(f"Invalid CUFILE_HOME: directory does not exist: {CUFILE_HOME}")
-    include_dirs.append(os.path.join(CUFILE_HOME, "include"))
-    if os.path.isdir(os.path.join(CUFILE_HOME, "lib64")):
-        library_dirs.append(os.path.join(CUFILE_HOME, "lib64"))
-    else:
-        library_dirs.append(os.path.join(CUFILE_HOME, "lib"))
+# # Use CuFile location outside of CUDA_HOME
+# if "CUFILE_HOME" in os.environ:
+#     CUFILE_HOME = os.environ["CUFILE_HOME"]
+#     if not os.path.isdir(CUDA_HOME):
+#         raise OSError(f"Invalid CUFILE_HOME: directory does not exist: {CUFILE_HOME}")
+#     include_dirs.append(os.path.join(CUFILE_HOME, "include"))
+#     if os.path.isdir(os.path.join(CUFILE_HOME, "lib64")):
+#         library_dirs.append(os.path.join(CUFILE_HOME, "lib64"))
+#     else:
+#         library_dirs.append(os.path.join(CUFILE_HOME, "lib"))
+#
+# # Add kvikio headers from the source tree (if available)
+# kvikio_include_dir = os.path.abspath(f"{this_setup_scrip_dir}/../cpp/include")
+# if os.path.isdir(kvikio_include_dir):
+#     include_dirs = [kvikio_include_dir] + include_dirs
+#     depends.extend(glob.glob(f"{kvikio_include_dir}/kvikio/*"))
+#     depends.extend(f"{this_setup_scrip_dir}/../cpp/CMakeLists.txt")
 
-# Add kvikio headers from the source tree (if available)
-kvikio_include_dir = os.path.abspath(f"{this_setup_scrip_dir}/../cpp/include")
-if os.path.isdir(kvikio_include_dir):
-    include_dirs = [kvikio_include_dir] + include_dirs
-    depends.extend(glob.glob(f"{kvikio_include_dir}/kvikio/*"))
-    depends.extend(f"{this_setup_scrip_dir}/../cpp/CMakeLists.txt")
-
-extensions = [
-    Extension(
-        "kvikio._lib.libkvikio",
-        sources=["kvikio/_lib/libkvikio.pyx"],
-        include_dirs=include_dirs,
-        library_dirs=library_dirs,
-        libraries=["dl", "cuda"],
-        language="c++",
-        extra_compile_args=["-std=c++17"],
-        depends=depends,
-    ),
-    Extension(
-        "kvikio._lib.arr",
-        sources=["kvikio/_lib/arr.pyx"],
-        language="c++",
-        extra_compile_args=["-std=c++17"],
-        depends=depends,
-    ),
-]
-
-
-def remove_flags(compiler, *flags):
-    for flag in flags:
-        try:
-            compiler.compiler_so = list(filter((flag).__ne__, compiler.compiler_so))
-        except Exception:
-            pass
-
-
-class build_ext(_build_ext):
-    def build_extensions(self):
-        # No '-Wstrict-prototypes' warning
-        remove_flags(self.compiler, "-Wstrict-prototypes")
-        if not DEBUG_BUILD:
-            # Full optimization
-            self.compiler.compiler_so.append("-O3")
-        if not DEBUG_BUILD:
-            # No debug symbols
-            remove_flags(self.compiler, "-g", "-G", "-O1", "-O2")
-        super().build_extensions()
-
-    def finalize_options(self):
-        if self.distribution.ext_modules:
-            # Delay import this to allow for Cython-less installs
-            from Cython.Build.Dependencies import cythonize
-
-            nthreads = getattr(self, "parallel", None)  # -j option in Py3.5+
-            nthreads = int(nthreads) if nthreads else None
-            self.distribution.ext_modules = cythonize(
-                self.distribution.ext_modules,
-                nthreads=nthreads,
-                force=self.force,
-                gdb_debug=False,
-                compiler_directives=dict(
-                    profile=False,
-                    language_level=3,
-                    embedsignature=True,
-                    binding=(not DEBUG_BUILD),
-                ),
-            )
-        # Skip calling super() and jump straight to setuptools
-        setuptools.command.build_ext.build_ext.finalize_options(self)
-
-
-cmdclass = dict()
-cmdclass.update(versioneer.get_cmdclass())
-cmdclass["build_ext"] = build_ext
 
 setup(
     name="kvikio",
@@ -168,12 +79,18 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     # Include the separately-compiled shared library
-    setup_requires=["Cython>=0.29,<0.30"],
     extras_require={"test": ["pytest", "pytest-xdist"]},
-    ext_modules=extensions,
     packages=find_packages(exclude=["tests*"]),
-    package_data={"": ["*.pyi"]},
-    cmdclass=cmdclass,
-    install_requires=install_requires,
+    package_data={
+        # Note: A dict comprehension with an explicit copy is necessary (rather
+        # than something simpler like a dict.fromkeys) because otherwise every
+        # package will refer to the same list and skbuild modifies it in place.
+        key: ["*.pyi", "*.pxd"]
+        for key in find_packages(
+            include=["kvikio._lib"]
+        )
+    },
+    cmdclass=versioneer.get_cmdclass(),
+    install_requires=["Cython>=0.29,<0.30"],
     zip_safe=False,
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,60 +6,6 @@ from skbuild import setup
 
 import versioneer
 
-# Set `DEBUG_BUILD=true` to enable debug build
-# DEBUG_BUILD = distutils.util.strtobool(os.environ.get("DEBUG_BUILD", "false"))
-
-# Turn all warnings into errors.
-# Cython.Compiler.Options.warning_errors = True
-
-# Abort the compilation on the first error
-# Cython.Compiler.Options.fast_fail = True
-
-# install_requires = ["cython"]
-# this_setup_scrip_dir = os.path.dirname(os.path.realpath(__file__))
-
-# Throughout the script, we will populate `include_dirs`,
-# `library_dirs` and `depends`.
-# include_dirs = [os.path.dirname(sysconfig.get_path("include"))]
-# library_dirs = [get_python_lib()]
-# extra_objects = []
-# depends = []  # Files to trigger rebuild when modified
-
-# # Find and add CUDA include and binary paths
-# CUDA_HOME = os.environ.get("CUDA_HOME", False)
-# if not CUDA_HOME:
-#     path_to_cuda_gdb = shutil.which("cuda-gdb")
-#     if path_to_cuda_gdb is None:
-#         raise OSError(
-#             "Could not locate CUDA. "
-#             "Please set the environment variable "
-#             "CUDA_HOME to the path to the CUDA installation "
-#             "and try again."
-#         )
-#     CUDA_HOME = os.path.dirname(os.path.dirname(path_to_cuda_gdb))
-# if not os.path.isdir(CUDA_HOME):
-#     raise OSError(f"Invalid CUDA_HOME: directory does not exist: {CUDA_HOME}")
-# include_dirs.append(os.path.join(CUDA_HOME, "include"))
-# library_dirs.append(os.path.join(CUDA_HOME, "lib64"))
-
-# # Use CuFile location outside of CUDA_HOME
-# if "CUFILE_HOME" in os.environ:
-#     CUFILE_HOME = os.environ["CUFILE_HOME"]
-#     if not os.path.isdir(CUDA_HOME):
-#         raise OSError(f"Invalid CUFILE_HOME: directory does not exist: {CUFILE_HOME}")
-#     include_dirs.append(os.path.join(CUFILE_HOME, "include"))
-#     if os.path.isdir(os.path.join(CUFILE_HOME, "lib64")):
-#         library_dirs.append(os.path.join(CUFILE_HOME, "lib64"))
-#     else:
-#         library_dirs.append(os.path.join(CUFILE_HOME, "lib"))
-#
-# # Add kvikio headers from the source tree (if available)
-# kvikio_include_dir = os.path.abspath(f"{this_setup_scrip_dir}/../cpp/include")
-# if os.path.isdir(kvikio_include_dir):
-#     include_dirs = [kvikio_include_dir] + include_dirs
-#     depends.extend(glob.glob(f"{kvikio_include_dir}/kvikio/*"))
-#     depends.extend(f"{this_setup_scrip_dir}/../cpp/CMakeLists.txt")
-
 
 setup(
     name="kvikio",

--- a/python/setup.py
+++ b/python/setup.py
@@ -86,9 +86,7 @@ setup(
         # than something simpler like a dict.fromkeys) because otherwise every
         # package will refer to the same list and skbuild modifies it in place.
         key: ["*.pyi", "*.pxd"]
-        for key in find_packages(
-            include=["kvikio._lib"]
-        )
+        for key in find_packages(include=["kvikio._lib"])
     },
     cmdclass=versioneer.get_cmdclass(),
     install_requires=["Cython>=0.29,<0.30"],


### PR DESCRIPTION
This PR rewrites the Python build system to use scikit-build, enabling easier interfacing with CMake and therefore integration with C++ builds. This change should help facilitate more complicated Python/C++ build interactions like what we might need for #24.