### PR TITLE
Auto detect running inside docker

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -66,9 +66,6 @@ conda list --show-channel-urls
 
 cd "$WORKSPACE/python"
 
-# For now, we have to run KvikIO in compatibility mode
-export KVIKIO_COMPAT_MODE=true
-
 gpuci_logger "Build kvikio from source"
 python -m pip install .
 

--- a/cpp/include/kvikio/config.hpp
+++ b/cpp/include/kvikio/config.hpp
@@ -63,8 +63,11 @@ inline std::pair<bool, bool> _current_global_compat_mode{std::make_pair(false, f
  * reads and writes are done using POSIX.
  *
  * Set the enviornment variable `KVIKIO_COMPAT_MODE` to enable/disable compatibility mode.
- * By default, compatibility mode is enabled when `libcufile` cannot be found or when
- * running in Windows Subsystem for Linux (WSL).
+ * By default, compatibility mode is enabled:
+ *  - when `libcufile` cannot be found
+ *  - when running in Windows Subsystem for Linux (WSL)
+ *  - when `/run/udev` isn't readable, which typically happens when running inside a docker
+ *    image not launched with `--volume /run/udev:/run/udev:ro`
  *
  * @return The boolean answer
  */
@@ -77,7 +80,7 @@ inline bool get_global_compat_mode()
     // Setting `KVIKIO_COMPAT_MODE` take precedence
     return static_cast<bool>(env);
   }
-  return !is_cufile_library_available() || is_running_in_wsl();
+  return !is_cufile_library_available() || is_running_in_wsl() || !run_udev_readable();
 }
 
 }  // namespace kvikio::config

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -19,6 +19,7 @@
 #include <sys/utsname.h>
 #include <chrono>
 #include <cstring>
+#include <filesystem>
 #include <future>
 #include <iostream>
 #include <tuple>
@@ -160,6 +161,24 @@ void get_symbol(T& handle, void* lib, const char* name)
     return name.find("icrosoft") != std::string::npos;
   }
   return false;
+}
+
+/**
+ * @brief Check if `/run/udev` is readable
+ *
+ * cuFile files with `internal error` when `/run/udev` isn't readable.
+ * This typically happens when running inside a docker image not launched
+ * with `--volume /run/udev:/run/udev:ro`.
+ *
+ * @return The boolean answer
+ */
+[[nodiscard]] inline bool run_udev_readable()
+{
+  try {
+    return std::filesystem::is_directory("/run/udev");
+  } catch (const std::filesystem::filesystem_error& e) {
+    return false;
+  }
 }
 
 }  // namespace kvikio


### PR DESCRIPTION
Automatically enable KvikIO compatibility mode when `/run/udev` isn't readable. This typically happens when running inside a docker image not launched with `--volume /run/udev:/run/udev:ro`.

Closes  #33