### PR TITLE
Install `kvikio` before building docs

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -28,7 +28,7 @@ gpuci_logger "Activate conda env"
 conda activate rapids
 
 gpuci_logger "Install kvikIO"
-gpuci_mamba_rety install -y -c rapidsai-nightly kvikio
+gpuci_conda_rety install -y -c rapidsai-nightly kvikio
 
 gpuci_logger "Check versions"
 python --version

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -27,6 +27,9 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
+gpuci_logger "Install kvikIO"
+gpuci_mamba_rety install -y -c rapidsai-nightly kvikio
+
 gpuci_logger "Check versions"
 python --version
 $CC --version


### PR DESCRIPTION
Hopefully last fix to get docs working 🙂 installs kvikIO before building docs so that API pages are rendered properly

cc @ajschmidt8 