### PR TITLE
Updates to Python build

### DIFF
--- a/conda/recipes/kvikio/build.sh
+++ b/conda/recipes/kvikio/build.sh
@@ -1,5 +1,0 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
-
-# This assumes the script is executed from the root of the repo directory
-cd python
-python -m pip install .

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -21,6 +21,9 @@ build:
     - CC
     - CXX
     - CUDAHOSTCXX
+  script:
+    - cd python
+    - python -m pip install .
 
 requirements:
   build:

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -23,7 +23,7 @@ build:
     - CUDAHOSTCXX
   script:
     - cd python
-    - python -m pip install .
+    - python -m pip install . -vv
 
 requirements:
   build:

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -29,6 +29,7 @@ requirements:
   host:
     - python
     - setuptools
+    - pip
     - cython >=0.29,<0.30
     - cudatoolkit {{ cuda_version }}.*
     - scikit-build >=0.13.1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,6 @@
 # See file LICENSE for terms.
 
 [build-system]
-
 requires = [
     "wheel",
     "setuptools",
@@ -11,6 +10,7 @@ requires = [
     "cmake>=3.20.1",
     "ninja",
 ]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 # See file LICENSE for terms.
 
 [build-system]
-
+build-backend = "setuptools.build_meta"
 requires = [
     "wheel",
     "setuptools",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 # See file LICENSE for terms.
 
 [build-system]
-build-backend = "setuptools.build_meta"
+
 requires = [
     "wheel",
     "setuptools",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,6 @@ requires = [
     "cmake>=3.20.1",
     "ninja",
 ]
-build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
* Require `pip` in `host` (as it is used in the build)
* Inline the build in `meta.yaml`'s `script` (dropping `build.sh`)
* Increase `pip` verbosity (to aid in detecting build issues)
* ~~Specify `build-backend` (per [this example]( https://scikit-build.readthedocs.io/en/latest/usage.html#example-of-setup-py-cmakelists-txt-and-pyproject-toml ))~~ (this causes [a build error with `pip` on CI]( https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/kvikio/job/prb/job/kvikio-cpu-cuda-build/CUDA=11.5/87/console ) so skipped for now)