### PR TITLE
Fallback to Compat mode when `cufile.h` isn't found

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -27,6 +27,9 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
+gpuci_logger "Install kvikIO"
+gpuci_conda_retry install -y -c rapidsai-nightly kvikio
+
 gpuci_logger "Check versions"
 python --version
 $CC --version

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -53,10 +53,13 @@ rapids_find_package(
 )
 
 rapids_find_package(
-  cuFile REQUIRED
+  cuFile
   BUILD_EXPORT_SET kvikio-exports
   INSTALL_EXPORT_SET kvikio-exports
 )
+if(NOT cuFile_FOUND)
+  message(WARNING "Building KvikIO without cuFile.h")
+endif()
 
 # library targets
 add_library(kvikio INTERFACE)
@@ -69,7 +72,9 @@ target_include_directories(
 
 target_link_libraries(kvikio INTERFACE Threads::Threads)
 target_link_libraries(kvikio INTERFACE cuda)
-target_link_libraries(kvikio INTERFACE cufile::cuFile_interface)
+if(cuFile_FOUND)
+  target_link_libraries(kvikio INTERFACE cufile::cuFile_interface)
+endif()
 target_link_libraries(kvikio INTERFACE dl)
 target_compile_features(kvikio INTERFACE cxx_std_17)
 

--- a/cpp/include/kvikio/buffer.hpp
+++ b/cpp/include/kvikio/buffer.hpp
@@ -23,6 +23,7 @@
 #include <kvikio/config.hpp>
 #include <kvikio/error.hpp>
 #include <kvikio/shim/cufile.hpp>
+#include <kvikio/shim/cufile_h_wrapper.hpp>
 #include <kvikio/utils.hpp>
 
 namespace kvikio {
@@ -49,6 +50,7 @@ inline void buffer_register(const void* devPtr_base,
                             const std::vector<int>& errors_to_ignore = std::vector<int>())
 {
   if (config::get_global_compat_mode()) { return; }
+#ifdef KVIKIO_CUFILE_EXIST
   CUfileError_t status = cuFileAPI::instance()->BufRegister(devPtr_base, size, flags);
   if (status.err != CU_FILE_SUCCESS) {
     // Check if `status.err` is in `errors_to_ignore`
@@ -57,6 +59,7 @@ inline void buffer_register(const void* devPtr_base,
       CUFILE_TRY(status);
     }
   }
+#endif
 }
 
 /**
@@ -67,7 +70,9 @@ inline void buffer_register(const void* devPtr_base,
 inline void buffer_deregister(const void* devPtr_base)
 {
   if (config::get_global_compat_mode()) { return; }
+#ifdef KVIKIO_CUFILE_EXIST
   CUFILE_TRY(cuFileAPI::instance()->BufDeregister(devPtr_base));
+#endif
 }
 
 /**

--- a/cpp/include/kvikio/driver.hpp
+++ b/cpp/include/kvikio/driver.hpp
@@ -20,9 +20,9 @@
 
 #include <kvikio/error.hpp>
 #include <kvikio/shim/cufile.hpp>
+#include <kvikio/shim/cufile_h_wrapper.hpp>
 
 namespace kvikio {
-
 namespace detail {
 
 [[nodiscard]] bool get_driver_flag(unsigned int prop, unsigned int flag) noexcept
@@ -38,8 +38,10 @@ void set_driver_flag(unsigned int& prop, unsigned int flag, bool val) noexcept
     prop &= ~(1U << flag);
   }
 }
-
 }  // namespace detail
+
+#ifdef KVIKIO_CUFILE_EXIST
+
 class DriverInitializer {
   // Optional, if not used cuFiles opens the driver automatically
  public:
@@ -174,5 +176,81 @@ class DriverProperties {
     _props.max_device_pinned_mem_size = size_in_kb;
   }
 };
+
+#else
+struct DriverInitializer {
+};
+
+struct DriverProperties {
+  DriverProperties() = default;
+
+  static bool is_gds_availabe() { return false; }
+
+  [[nodiscard]] static unsigned int get_nvfs_major_version()
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  [[nodiscard]] static unsigned int get_nvfs_minor_version()
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  [[nodiscard]] static bool get_nvfs_allow_compat_mode()
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  [[nodiscard]] static bool get_nvfs_poll_mode()
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  [[nodiscard]] static std::size_t get_nvfs_poll_thresh_size()
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  static void set_nvfs_poll_mode(bool enable)
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  static void set_nvfs_poll_thresh_size(std::size_t size_in_kb)
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  [[nodiscard]] static std::vector<CUfileDriverControlFlags> get_nvfs_statusflags()
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  [[nodiscard]] static std::size_t get_max_device_cache_size()
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  static void set_max_device_cache_size(std::size_t size_in_kb)
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  [[nodiscard]] static std::size_t get_per_buffer_cache_size()
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  [[nodiscard]] static std::size_t get_max_pinned_memory_size()
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+
+  static void set_max_pinned_memory_size(std::size_t size_in_kb)
+  {
+    throw CUfileException("KvikIO not compiled with cuFile.h");
+  }
+};
+#endif
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/error.hpp
+++ b/cpp/include/kvikio/error.hpp
@@ -20,7 +20,7 @@
 
 #include <cuda.h>
 
-#include <cufile.h>
+#include <kvikio/shim/cufile_h_wrapper.hpp>
 
 namespace kvikio {
 
@@ -31,6 +31,7 @@ struct CUfileException : public std::runtime_error {
 #define KVIKIO_STRINGIFY_DETAIL(x) #x
 #define KVIKIO_STRINGIFY(x)        KVIKIO_STRINGIFY_DETAIL(x)
 
+#ifdef KVIKIO_CUFILE_EXIST
 #ifndef CUFILE_TRY
 #define CUFILE_TRY(...)                                         \
   GET_CUFILE_TRY_MACRO(__VA_ARGS__, CUFILE_TRY_2, CUFILE_TRY_1) \
@@ -62,6 +63,7 @@ struct CUfileException : public std::runtime_error {
     }                                                                                             \
   } while (0)
 #define CUFILE_TRY_1(_call) CUFILE_TRY_2(_call, CUfileException)
+#endif
 #endif
 
 #ifndef CUDA_DRIVER_TRY

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -15,11 +15,12 @@
  */
 #pragma once
 #include <kvikio/error.hpp>
+#include <kvikio/shim/cufile_h_wrapper.hpp>
 #include <kvikio/utils.hpp>
 
-#include <cufile.h>
-
 namespace kvikio {
+
+#ifdef KVIKIO_CUFILE_EXIST
 
 /**
  * @brief Shim layer of the cuFile C-API
@@ -67,11 +68,14 @@ class cuFileAPI {
   }
 };
 
+#endif
+
 /**
  * @brief Check whether the cuFile library is available
  *
  * @return The boolean answer
  */
+#ifdef KVIKIO_CUFILE_EXIST
 inline bool is_cufile_library_available()
 {
   try {
@@ -81,5 +85,8 @@ inline bool is_cufile_library_available()
   }
   return true;
 }
+#else
+constexpr bool is_cufile_library_available() { return false; }
+#endif
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
@@ -15,6 +15,13 @@
  */
 #pragma once
 
+/**
+ * In order to support compilation when `cufile.h` isn't available, we
+ * wrap all use of cufile in a `#ifdef KVIKIO_CUFILE_EXIST` guard.
+ *
+ * The motivation here is to make KvikIO work in all circumstances so
+ * that libraries doesn't have to implement there own fallback solutions.
+ */
 #ifndef KVIKIO_DISABLE_CUFILE
 #if __has_include(<cufile.h>)
 #include <cufile.h>
@@ -23,12 +30,9 @@
 #endif
 
 #ifndef KVIKIO_CUFILE_EXIST
-
 using CUfileDriverControlFlags_t = enum CUfileDriverControlFlags {
   CU_FILE_USE_POLL_MODE     = 0, /*!< use POLL mode. properties.use_poll_mode*/
   CU_FILE_ALLOW_COMPAT_MODE = 1  /*!< allow COMPATIBILITY mode. properties.allow_compat_mode*/
 };
-
 using CUfileHandle_t = void*;
-
 #endif

--- a/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#ifndef KVIKIO_DISABLE_CUFILE
+#if __has_include(<cufile.h>)
+#include <cufile.h>
+#define KVIKIO_CUFILE_EXIST
+#endif
+#endif
+
+#ifndef KVIKIO_CUFILE_EXIST
+
+using CUfileDriverControlFlags_t = enum CUfileDriverControlFlags {
+  CU_FILE_USE_POLL_MODE     = 0, /*!< use POLL mode. properties.use_poll_mode*/
+  CU_FILE_ALLOW_COMPAT_MODE = 1  /*!< allow COMPATIBILITY mode. properties.allow_compat_mode*/
+};
+
+using CUfileHandle_t = void*;
+
+#endif

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <dlfcn.h>
+#include <sys/types.h>
 #include <sys/utsname.h>
 #include <chrono>
 #include <cstring>
@@ -26,7 +27,6 @@
 
 #include <cuda.h>
 
-#include <cufile.h>
 #include <kvikio/error.hpp>
 
 namespace kvikio {


### PR DESCRIPTION
Use `__has_include(<cufile.h>)` to fallback to compat mode.

The motivation here is to make KvikIO work in all circumstances so that libraries doesn't have to implement there own fallback solutions.