### PR TITLE
Implement task size for parallel IO operations

### DIFF
--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -54,7 +54,7 @@ bool getenv_or(std::string_view env_var_name, bool default_val)
   try {
     // Try parsing `env_var_name` as a integer
     return static_cast<bool>(std::stoi(env_val));
-  } catch (std::invalid_argument) {
+  } catch (const std::invalid_argument&) {
   }
   // Convert to lowercase
   std::string str{env_val};

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -324,8 +324,8 @@ class FileHandle {
   /**
    * @brief Reads specified bytes from the file into the device memory in parallel.
    *
-   * This API is a parallel async version of `.read()` that create `ntasks` tasks
-   * for the thread pool to execute.
+   * This API is a parallel async version of `.read()` that partition the operation
+   * into tasks of size `task_size` for execution in the default thread pool.
    *
    * @note `pread` use the base address of the allocation `devPtr` is part of. This means
    * that when registering buffers, use the base address of the allocation. This is what
@@ -334,13 +334,13 @@ class FileHandle {
    * @param devPtr Address to device memory.
    * @param size Size in bytes to read.
    * @param file_offset Offset in the file to read from.
-   * @param ntasks Number of tasks to use.
+   * @param task_size Size of each task in bytes.
    * @return Future that on completion returns the size of bytes that were successfully read.
    */
   std::future<std::size_t> pread(void* devPtr,
                                  std::size_t size,
                                  std::size_t file_offset = 0,
-                                 std::size_t ntasks      = defaults::thread_pool_nthreads())
+                                 std::size_t task_size   = defaults::task_size())
   {
     // Lambda that calls this->read()
     auto op = [this](void* devPtr_base,
@@ -349,14 +349,14 @@ class FileHandle {
                      std::size_t devPtr_offset) -> std::size_t {
       return read(devPtr_base, size, file_offset, devPtr_offset);
     };
-    return parallel_io(op, devPtr, size, file_offset, ntasks);
+    return parallel_io(op, devPtr, size, file_offset, task_size);
   }
 
   /**
    * @brief Writes specified bytes from the device memory into the file in parallel.
    *
-   * This API is a parallel async version of `.write()` that create `ntasks` tasks
-   * for the thread pool to execute.
+   * This API is a parallel async version of `.write()` that partition the operation
+   * into tasks of size `task_size` for execution in the default thread pool.
    *
    * @note `pwrite` use the base address of the allocation `devPtr` is part of. This means
    * that when registering buffers, use the base address of the allocation. This is what
@@ -365,13 +365,13 @@ class FileHandle {
    * @param devPtr Address to device memory.
    * @param size Size in bytes to write.
    * @param file_offset Offset in the file to write from.
-   * @param ntasks Number of tasks to use.
+   * @param task_size Size of each task in bytes.
    * @return Future that on completion returns the size of bytes that were successfully written.
    */
   std::future<std::size_t> pwrite(const void* devPtr,
                                   std::size_t size,
                                   std::size_t file_offset = 0,
-                                  std::size_t ntasks      = defaults::thread_pool_nthreads())
+                                  std::size_t task_size   = defaults::task_size())
   {
     // Lambda that calls this->write()
     auto op = [this](const void* devPtr_base,
@@ -380,7 +380,7 @@ class FileHandle {
                      std::size_t devPtr_offset) -> std::size_t {
       return write(devPtr_base, size, file_offset, devPtr_offset);
     };
-    return parallel_io(op, devPtr, size, file_offset, ntasks);
+    return parallel_io(op, devPtr, size, file_offset, task_size);
   }
 };
 

--- a/cpp/include/kvikio/parallel_operation.hpp
+++ b/cpp/include/kvikio/parallel_operation.hpp
@@ -73,6 +73,7 @@ std::future<std::size_t> parallel_io(
         devPtr_offset += unaligned_range;
         size -= unaligned_range;
       }
+      assert(file_offset % page_size == 0);  // `file_offset` is now aligned
     }
     // 2) Submit tasks for the aligned range from the first page boundary to the last page boundary
     {
@@ -82,6 +83,7 @@ std::future<std::size_t> parallel_io(
           defaults::thread_pool().submit(task, devPtr_base, task_size, file_offset, devPtr_offset));
         file_offset += task_size;
         devPtr_offset += task_size;
+        assert(size >= task_size);  // This is true because we do `size / task_size` iterations
         size -= task_size;
       }
     }

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -82,7 +82,7 @@ inline bool is_cufile_library_available()
 {
   try {
     cuFileAPI::instance();
-  } catch (const CUfileException& e) {
+  } catch (const CUfileException&) {
     return false;
   }
   return true;

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -179,7 +179,7 @@ void get_symbol(T& handle, void* lib, const char* name)
 {
   try {
     return std::filesystem::is_directory("/run/udev");
-  } catch (const std::filesystem::filesystem_error& e) {
+  } catch (const std::filesystem::filesystem_error&) {
     return false;
   }
 }

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -31,6 +31,9 @@
 
 namespace kvikio {
 
+// cuFile defines a page size to 4 KiB
+inline constexpr std::size_t page_size = 4096;
+
 [[nodiscard]] inline off_t convert_size2off(std::size_t x)
 {
   if (x >= std::numeric_limits<off_t>::max()) {
@@ -41,7 +44,7 @@ namespace kvikio {
 
 [[nodiscard]] inline CUdeviceptr convert_void2deviceptr(const void* devPtr)
 {
-  /*NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)*/
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   return reinterpret_cast<CUdeviceptr>(devPtr);
 }
 
@@ -96,7 +99,7 @@ inline std::tuple<void*, std::size_t, std::size_t> get_alloc_info(const void* de
   PushAndPopContext context(_ctx);
   CUDA_DRIVER_TRY(cuMemGetAddressRange(&base_ptr, &base_size, dev));
   std::size_t offset = dev - base_ptr;
-  /*NOLINTNEXTLINE(performance-no-int-to-ptr, cppcoreguidelines-pro-type-reinterpret-cast)*/
+  // NOLINTNEXTLINE(performance-no-int-to-ptr, cppcoreguidelines-pro-type-reinterpret-cast)
   return std::make_tuple(reinterpret_cast<void*>(base_ptr), base_size, offset);
 }
 
@@ -135,7 +138,7 @@ template <typename T>
 void get_symbol(T& handle, void* lib, const char* name)
 {
   ::dlerror();  // Clear old errors
-  /*NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)*/
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   handle          = reinterpret_cast<T>(::dlsym(lib, name));
   const char* err = ::dlerror();
   if (err != nullptr) {

--- a/python/benchmarks/single-node-io.py
+++ b/python/benchmarks/single-node-io.py
@@ -66,7 +66,7 @@ def run_cufile_multiple_files_multiple_arrays(args):
     # Write
     files = [kvikio.CuFile(file_path % i, flags="w") for i in range(args.nthreads)]
     t0 = clock()
-    futures = [f.pwrite(a, ntasks=1) for f, a in zip(files, arrays)]
+    futures = [f.pwrite(a, task_size=a.nbytes) for f, a in zip(files, arrays)]
     res = sum(f.get() for f in futures)
     del files
     write_time = clock() - t0
@@ -75,7 +75,7 @@ def run_cufile_multiple_files_multiple_arrays(args):
     # Read
     files = [kvikio.CuFile(file_path % i, flags="r") for i in range(args.nthreads)]
     t0 = clock()
-    futures = [f.pread(a, ntasks=1) for f, a in zip(files, arrays)]
+    futures = [f.pread(a, task_size=a.nbytes) for f, a in zip(files, arrays)]
     res = sum(f.get() for f in futures)
     del files
     read_time = clock() - t0
@@ -143,7 +143,8 @@ def run_cufile_multiple_arrays(args):
     f = kvikio.CuFile(file_path, flags="w")
     t0 = clock()
     futures = [
-        f.pwrite(a, ntasks=1, file_offset=i * chunksize) for i, a in enumerate(arrays)
+        f.pwrite(a, task_size=a.nbytes, file_offset=i * chunksize)
+        for i, a in enumerate(arrays)
     ]
     res = sum(f.get() for f in futures)
     f.close()
@@ -153,7 +154,7 @@ def run_cufile_multiple_arrays(args):
     # Read
     f = kvikio.CuFile(file_path, flags="r")
     t0 = clock()
-    futures = [f.pread(a, ntasks=1) for a in arrays]
+    futures = [f.pread(a, task_size=a.nbytes) for a in arrays]
     res = sum(f.get() for f in futures)
     f.close()
     read_time = clock() - t0

--- a/python/kvikio/_lib/kvikio_cxx_api.pxd
+++ b/python/kvikio/_lib/kvikio_cxx_api.pxd
@@ -47,10 +47,11 @@ cdef extern from "<kvikio/buffer.hpp>" namespace "kvikio" nogil:
 
 cdef extern from "<kvikio/defaults.hpp>" namespace "kvikio::defaults" nogil:
     bool compat_mode() except +
-    void compat_mode_reset(bool enable)
-    unsigned int thread_pool_nthreads()
+    void compat_mode_reset(bool enable) except +
+    unsigned int thread_pool_nthreads() except +
     void thread_pool_nthreads_reset(unsigned int nthreads) except +
-
+    size_t task_size() except +
+    void task_size_reset(size_t nbytes) except +
 
 cdef extern from "<kvikio/file_handle.hpp>" namespace "kvikio" nogil:
     cdef cppclass FileHandle:
@@ -73,13 +74,13 @@ cdef extern from "<kvikio/file_handle.hpp>" namespace "kvikio" nogil:
             void* devPtr,
             size_t size,
             size_t file_offset,
-            size_t ntasks
+            size_t task_size
         ) except +
         future[size_t] pwrite(
             void* devPtr,
             size_t size,
             size_t file_offset,
-            size_t ntasks
+            size_t task_size
         ) except +
         size_t read(
             void* devPtr_base,

--- a/python/kvikio/_lib/libkvikio.pyx
+++ b/python/kvikio/_lib/libkvikio.pyx
@@ -67,6 +67,14 @@ def thread_pool_nthreads_reset(nthreads: int) -> None:
     kvikio_cxx_api.thread_pool_nthreads_reset(nthreads)
 
 
+def task_size() -> int:
+    return kvikio_cxx_api.task_size()
+
+
+def task_size_reset(nthreads: int) -> None:
+    kvikio_cxx_api.task_size_reset(nthreads)
+
+
 cdef pair[uintptr_t, size_t] _parse_buffer(buf, size):
     """Parse `buf` and `size` argument and return a pointer and nbytes"""
     if not isinstance(buf, Array):
@@ -110,25 +118,25 @@ cdef class CuFile:
     def open_flags(self) -> int:
         return self._handle.fd_open_flags()
 
-    def pread(self, buf, size: int, file_offset: int, ntasks) -> IOFuture:
+    def pread(self, buf, size: int, file_offset: int, task_size) -> IOFuture:
         cdef pair[uintptr_t, size_t] info = _parse_buffer(buf, size)
         return _wrap_io_future(
             self._handle.pread(
                 <void*>info.first,
                 info.second,
                 file_offset,
-                ntasks if ntasks else kvikio_cxx_api.thread_pool_nthreads()
+                task_size if task_size else kvikio_cxx_api.task_size()
             )
         )
 
-    def pwrite(self, buf, size: int, file_offset: int, ntasks) -> IOFuture:
+    def pwrite(self, buf, size: int, file_offset: int, task_size) -> IOFuture:
         cdef pair[uintptr_t, size_t] info = _parse_buffer(buf, size)
         return _wrap_io_future(
             self._handle.pwrite(
                 <void*>info.first,
                 info.second,
                 file_offset,
-                ntasks if ntasks else kvikio_cxx_api.thread_pool_nthreads()
+                task_size if task_size else kvikio_cxx_api.task_size()
             )
         )
 

--- a/python/kvikio/cufile.py
+++ b/python/kvikio/cufile.py
@@ -87,7 +87,7 @@ class CuFile:
         self.close()
 
     def pread(
-        self, buf, size: int = None, file_offset: int = 0, ntasks=None
+        self, buf, size: int = None, file_offset: int = 0, task_size=None
     ) -> IOFuture:
         """Reads specified bytes from the file into the device memory in parallel
 
@@ -97,7 +97,8 @@ class CuFile:
         match the performance of aligned reads.
 
         `pread` is non-blocking and returns a `IOFuture` that can be waited upon. It
-        creates `ntasks` for the KvikIO thread pool to execute.
+        partitions the operation into tasks of size `task_size` for execution in the
+        default thread pool.
 
         Parameters
         ----------
@@ -107,8 +108,8 @@ class CuFile:
             Size in bytes to read.
         file_offset: int, optional
             Offset in the file to read from.
-        ntasks: int, default=kvikio.defaults.get_num_threads()
-            Number of tasks to use.
+        task_size: int, default=kvikio.defaults.task_size()
+            Size of each task in bytes.
 
         Returns
         ------
@@ -116,10 +117,10 @@ class CuFile:
             Future that on completion returns the size of bytes that were successfully
             read.
         """
-        return IOFuture(self._handle.pread(buf, size, file_offset, ntasks))
+        return IOFuture(self._handle.pread(buf, size, file_offset, task_size))
 
     def pwrite(
-        self, buf, size: int = None, file_offset: int = 0, ntasks=None
+        self, buf, size: int = None, file_offset: int = 0, task_size=None
     ) -> IOFuture:
         """Writes specified bytes from the device memory into the file in parallel
 
@@ -129,7 +130,9 @@ class CuFile:
         with aligned writes.
 
         `pwrite` is non-blocking and returns a `IOFuture` that can be waited upon. It
-        creates `ntasks` for the KvikIO thread pool to execute.
+        partitions the operation into tasks of size `task_size` for execution in the
+        default thread pool.
+
 
         Parameters
         ----------
@@ -139,8 +142,8 @@ class CuFile:
             Size in bytes to read.
         file_offset: int, optional
             Offset in the file to write from.
-        ntasks: int, default=kvikio.defaults.get_num_threads()
-            Number of tasks to use.
+        task_size: int, default=kvikio.defaults.task_size()
+            Size of each task in bytes.
 
         Returns
         ------
@@ -148,9 +151,9 @@ class CuFile:
             Future that on completion returns the size of bytes that were successfully
             written.
         """
-        return IOFuture(self._handle.pwrite(buf, size, file_offset, ntasks))
+        return IOFuture(self._handle.pwrite(buf, size, file_offset, task_size))
 
-    def read(self, buf, size: int = None, file_offset: int = 0, ntasks=None) -> int:
+    def read(self, buf, size: int = None, file_offset: int = 0, task_size=None) -> int:
         """Reads specified bytes from the file into the device memory in parallel
 
         This is a blocking version of `.pread`.
@@ -163,17 +166,17 @@ class CuFile:
             Size in bytes to read.
         file_offset: int, optional
             Offset in the file to read from.
-        ntasks: int, default=kvikio.defaults.get_num_threads()
-            Number of tasks to use.
+        task_size: int, default=kvikio.defaults.task_size()
+            Size of each task in bytes.
 
         Returns
         ------
         int
             The size of bytes that were successfully read.
         """
-        return self.pread(buf, size, file_offset, ntasks).get()
+        return self.pread(buf, size, file_offset, task_size).get()
 
-    def write(self, buf, size: int = None, file_offset: int = 0, ntasks=None) -> int:
+    def write(self, buf, size: int = None, file_offset: int = 0, task_size=None) -> int:
         """Writes specified bytes from the device memory into the file in parallel
 
         This is a blocking version of `.pwrite`.
@@ -186,15 +189,15 @@ class CuFile:
             Size in bytes to read.
         file_offset: int, optional
             Offset in the file to write from.
-        ntasks: int, default=kvikio.defaults.get_num_threads()
-            Number of tasks to use.
+        task_size: int, default=kvikio.defaults.task_size()
+            Size of each task in bytes.
 
         Returns
         ------
         int
             The size of bytes that were successfully written.
         """
-        return self.pwrite(buf, size, file_offset, ntasks).get()
+        return self.pwrite(buf, size, file_offset, task_size).get()
 
     def raw_read(
         self, buf, size: int = None, file_offset: int = 0, dev_offset: int = 0

--- a/python/kvikio/defaults.py
+++ b/python/kvikio/defaults.py
@@ -108,3 +108,46 @@ def set_num_threads(nthreads: int):
         yield
     finally:
         reset_num_threads(old_value)
+
+
+def task_size() -> int:
+    """ Get the default task size used for parallel IO operations.
+
+    Set the default value using `task_size_reset()` or by setting
+    the `KVIKIO_TASK_SIZE` environment variable. If not set,
+    the default value is 16 MiB.
+
+    Return
+    ------
+    nthreads: int
+        The number of threads in the current thread pool.
+    """
+    return libkvikio.task_size()
+
+
+def reset_task_size(nbytes: int) -> None:
+    """ Reset the default task size used for parallel IO operations.
+
+    Parameters
+    ----------
+    nbytes : int
+        The number of threads to use.
+    """
+    libkvikio.task_size_reset(nbytes)
+
+
+@contextlib.contextmanager
+def set_task_size(nbytes: int):
+    """ Context for resetting the task size used for parallel IO operations.
+
+    Parameters
+    ----------
+    nbytes : int
+        The number of threads to use.
+    """
+    old_value = task_size()
+    try:
+        reset_task_size(nbytes)
+        yield
+    finally:
+        reset_task_size(old_value)

--- a/python/tests/test_basic_io.py
+++ b/python/tests/test_basic_io.py
@@ -103,16 +103,19 @@ def test_write_to_files_in_chunks(tmp_path):
 
 
 @pytest.mark.parametrize("nthreads", [1, 3, 16])
-@pytest.mark.parametrize("tasksize", [7, 13, 199, 1024])
-@pytest.mark.parametrize("start,end", [(0, 2000), (1, 1950), (20, 30), (1024, 1500)])
+@pytest.mark.parametrize("tasksize", [1000, int(1.5 * 4096), int(2.3 * 4096)])
+@pytest.mark.parametrize(
+    "start,end",
+    [(0, 10 * 4096), (1, int(1.3 * 4096)), (int(2.1 * 4096), int(5.6 * 4096))],
+)
 def test_read_write_slices(tmp_path, nthreads, tasksize, start, end):
     """Read and write different slices"""
 
     with kvikio.defaults.set_num_threads(nthreads):
         with kvikio.defaults.set_task_size(tasksize):
             filename = tmp_path / "test-file"
-            a = cupy.arange(2000)
-            b = cupy.arange(2000)
+            a = cupy.arange(10 * 4096)  # 10 page-sizes
+            b = a.copy()
             a[start:end] = 42
             with kvikio.CuFile(filename, "w") as f:
                 assert f.write(a[start:end]) == a[start:end].nbytes

--- a/python/tests/test_basic_io.py
+++ b/python/tests/test_basic_io.py
@@ -27,37 +27,51 @@ def check_bit_flags(
 
 @pytest.mark.parametrize("size", [1, 10, 100, 1000, 1024, 4096, 4096 * 10])
 @pytest.mark.parametrize("nthreads", [1, 3, 4, 16])
-def test_read_write(tmp_path, size, nthreads):
+@pytest.mark.parametrize("tasksize", [199, 1024])
+def test_read_write(tmp_path, size, nthreads, tasksize):
     """Test basic read/write"""
     filename = tmp_path / "test-file"
 
     with kvikio.defaults.set_num_threads(nthreads):
-        assert kvikio.defaults.get_num_threads() == nthreads
+        with kvikio.defaults.set_task_size(tasksize):
+            # Write file
+            a = cupy.arange(size)
+            f = kvikio.CuFile(filename, "w")
+            assert not f.closed
+            assert check_bit_flags(f.open_flags(), os.O_WRONLY)
+            assert f.write(a) == a.nbytes
 
-        # Write file
-        a = cupy.arange(size)
-        f = kvikio.CuFile(filename, "w")
+            # Try to read file opened in write-only mode
+            with pytest.raises(RuntimeError, match="unsupported file open flags"):
+                f.read(a)
+
+            # Close file
+            f.close()
+            assert f.closed
+
+            # Read file into a new array and compare
+            b = cupy.empty_like(a)
+            f = kvikio.CuFile(filename, "r")
+            assert check_bit_flags(f.open_flags(), os.O_RDONLY)
+            assert f.read(b) == b.nbytes
+            assert all(a == b)
+
+
+def test_file_handle_context(tmp_path):
+    """Open a CuFile in a context"""
+    filename = tmp_path / "test-file"
+    a = cupy.arange(200)
+    b = cupy.empty_like(a)
+    with kvikio.CuFile(filename, "w+") as f:
         assert not f.closed
-        assert check_bit_flags(f.open_flags(), os.O_WRONLY)
+        assert check_bit_flags(f.open_flags(), os.O_RDWR)
         assert f.write(a) == a.nbytes
-
-        # Try to read file opened in write-only mode
-        with pytest.raises(RuntimeError, match="unsupported file open flags"):
-            f.read(a)
-
-        # Close file
-        f.close()
-        assert f.closed
-
-        # Read file into a new array and compare
-        b = cupy.empty_like(a)
-        f = kvikio.CuFile(filename, "r")
-        assert check_bit_flags(f.open_flags(), os.O_RDONLY)
         assert f.read(b) == b.nbytes
         assert all(a == b)
+    assert f.closed
 
 
-def test_write_in_offsets(tmp_path):
+def test_write_to_files_in_chunks(tmp_path):
     """Write to files in chunks"""
     filename = tmp_path / "test-file"
 
@@ -88,18 +102,23 @@ def test_write_in_offsets(tmp_path):
     assert all(a == b)
 
 
-def test_file_handle_context(tmp_path):
-    """Open a CuFile in a context"""
-    filename = tmp_path / "test-file"
-    a = cupy.arange(200)
-    b = cupy.empty_like(a)
-    with kvikio.CuFile(filename, "w+") as f:
-        assert not f.closed
-        assert check_bit_flags(f.open_flags(), os.O_RDWR)
-        assert f.write(a) == a.nbytes
-        assert f.read(b) == b.nbytes
-        assert all(a == b)
-    assert f.closed
+@pytest.mark.parametrize("nthreads", [1, 3, 16])
+@pytest.mark.parametrize("tasksize", [7, 13, 199, 1024])
+@pytest.mark.parametrize("start,end", [(0, 2000), (1, 1950), (20, 30), (1024, 1500)])
+def test_read_write_slices(tmp_path, nthreads, tasksize, start, end):
+    """Read and write different slices"""
+
+    with kvikio.defaults.set_num_threads(nthreads):
+        with kvikio.defaults.set_task_size(tasksize):
+            filename = tmp_path / "test-file"
+            a = cupy.arange(2000)
+            b = cupy.arange(2000)
+            a[start:end] = 42
+            with kvikio.CuFile(filename, "w") as f:
+                assert f.write(a[start:end]) == a[start:end].nbytes
+            with kvikio.CuFile(filename, "r") as f:
+                assert f.read(b[start:end]) == b[start:end].nbytes
+            assert all(a == b)
 
 
 @pytest.mark.skipif(

--- a/python/tests/test_defaults.py
+++ b/python/tests/test_defaults.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+
+
+import pytest
+
+import kvikio.defaults
+
+
+@pytest.mark.skipif(
+    kvikio.defaults.compat_mode(),
+    reason="cannot test `compat_mode` when already running in compatibility mode",
+)
+def test_compat_mode():
+    """Test changing `compat_mode`"""
+
+    before = kvikio.defaults.compat_mode()
+    with kvikio.defaults.set_compat_mode(True):
+        assert kvikio.defaults.compat_mode()
+        kvikio.defaults.compat_mode_reset(False)
+        assert not kvikio.defaults.compat_mode()
+    assert before == kvikio.defaults.compat_mode()
+
+
+def test_num_threads():
+    """Test changing `num_threads`"""
+
+    before = kvikio.defaults.get_num_threads()
+    with kvikio.defaults.set_num_threads(3):
+        assert kvikio.defaults.get_num_threads() == 3
+        kvikio.defaults.reset_num_threads(4)
+        assert kvikio.defaults.get_num_threads() == 4
+    assert before == kvikio.defaults.get_num_threads()
+
+
+def test_task_size():
+    """Test changing `task_size`"""
+
+    before = kvikio.defaults.task_size()
+    with kvikio.defaults.set_task_size(3):
+        assert kvikio.defaults.task_size() == 3
+        kvikio.defaults.reset_task_size(4)
+        assert kvikio.defaults.task_size() == 4
+    assert before == kvikio.defaults.task_size()


### PR DESCRIPTION
Partitions parallel IO operations into tasks of size `KVIKIO_TASK_SIZE` for execution in the default thread pool.