### PR TITLE
compat_mode per `FileHandle`

### DIFF
--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -104,7 +104,7 @@ class defaults {
     }
     // Determine the default value of `task_size`
     {
-      const ssize_t env = getenv_or("KVIKIO_TASK_SIZE", 16 * 1024 * 1024);
+      const ssize_t env = getenv_or("KVIKIO_TASK_SIZE", 4 * 1024 * 1024);
       if (env <= 0) {
         throw std::invalid_argument("KVIKIO_TASK_SIZE has to be a positive integer");
       }

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -80,7 +80,7 @@ bool getenv_or(std::string_view env_var_name, bool default_val)
 class defaults {
  private:
   kvikio::third_party::thread_pool _thread_pool{get_num_threads_from_env()};
-  bool _combat_mode;
+  bool _compat_mode;
   std::size_t _task_size;
 
   static unsigned int get_num_threads_from_env()
@@ -96,10 +96,10 @@ class defaults {
     {
       if (std::getenv("KVIKIO_COMPAT_MODE") != nullptr) {
         // Setting `KVIKIO_COMPAT_MODE` take precedence
-        _combat_mode = getenv_or("KVIKIO_COMPAT_MODE", false);
+        _compat_mode = getenv_or("KVIKIO_COMPAT_MODE", false);
       } else {
         // If `KVIKIO_COMPAT_MODE` isn't set, we infer based on runtime environment
-        _combat_mode = !is_cufile_available();
+        _compat_mode = !is_cufile_available();
       }
     }
     // Determine the default value of `task_size`
@@ -137,7 +137,7 @@ class defaults {
    *
    * @return The boolean answer
    */
-  [[nodiscard]] static bool compat_mode() { return instance()->_combat_mode; }
+  [[nodiscard]] static bool compat_mode() { return instance()->_compat_mode; }
 
   /**
    * @brief Reset the value of `kvikio::defaults::compat_mode()`
@@ -147,7 +147,7 @@ class defaults {
    *
    * @param enable Whether to enable compatibility mode or not.
    */
-  static void compat_mode_reset(bool enable) { instance()->_combat_mode = enable; }
+  static void compat_mode_reset(bool enable) { instance()->_compat_mode = enable; }
 
   /**
    * @brief Get the default thread pool.

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -141,6 +141,11 @@ class defaults {
 
   /**
    * @brief Reset the value of `kvikio::defaults::compat_mode()`
+   *
+   * Changing compatibility mode, effects all new FileHandles that doesn't sets the
+   * `compat_mode` argument explicitly but it never effect existing FileHandles.
+   *
+   * @param enable Whether to enable compatibility mode or not.
    */
   static void compat_mode_reset(bool enable) { instance()->_combat_mode = enable; }
 

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -240,6 +240,7 @@ class FileHandle {
    */
   [[nodiscard]] inline std::size_t nbytes() const
   {
+    if (closed()) { return 0; }
     if (_nbytes == 0) { _nbytes = get_file_size(_fd_direct_on); }
     return _nbytes;
   }

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -218,14 +218,22 @@ class FileHandle {
   }
 
   /**
-   * @brief Get one of the file descripters
+   * @brief Get one of the file descriptors
+   *
+   * Notice, `FileHandle` maintains two file descriptors - one opened with the
+   * `O_DIRECT` flag and one without. This function returns one of them but
+   * it is unspecified with one.
    *
    * @return File descripter
    */
   [[nodiscard]] int fd() const noexcept { return _fd_direct_off; }
 
   /**
-   * @brief Get the flags of one of the file descripters (see open(2))
+   * @brief Get the flags of one of the file descriptors (see open(2))
+   *
+   * Notice, `FileHandle` maintains two file descriptors - one opened with the
+   * `O_DIRECT` flag and one without. This function returns the flags of one of
+   * them but it is unspecified with one.
    *
    * @return File descripter
    */

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -218,7 +218,7 @@ class FileHandle {
   }
 
   /**
-   * @brief Get the file descripter of one of the open files
+   * @brief Get one of the file descripters
    *
    * @return File descripter
    */

--- a/cpp/include/kvikio/parallel_operation.hpp
+++ b/cpp/include/kvikio/parallel_operation.hpp
@@ -66,14 +66,12 @@ std::future<std::size_t> parallel_io(
   tasks.reserve(size / task_size + 2);
 
   // 1) Submit `task_size` sized tasks
-  {
-    while (size >= task_size) {
-      tasks.push_back(
-        defaults::thread_pool().submit(task, devPtr_base, task_size, file_offset, devPtr_offset));
-      file_offset += task_size;
-      devPtr_offset += task_size;
-      size -= task_size;
-    }
+  while (size >= task_size) {
+    tasks.push_back(
+      defaults::thread_pool().submit(task, devPtr_base, task_size, file_offset, devPtr_offset));
+    file_offset += task_size;
+    devPtr_offset += task_size;
+    size -= task_size;
   }
   // 2) Submit a task for the remainder
   if (size > 0) {

--- a/cpp/include/kvikio/parallel_operation.hpp
+++ b/cpp/include/kvikio/parallel_operation.hpp
@@ -58,7 +58,7 @@ std::future<std::size_t> parallel_io(
 
   // Single-task guard
   if (task_size >= size || page_size >= size) {
-    return std::async(std::launch::deferred, task, devPtr_base, size, file_offset, devPtr_offset);
+    return defaults::thread_pool().submit(task, devPtr_base, size, file_offset, devPtr_offset);
   }
 
   // We know an upper bound of the total number of tasks

--- a/cpp/include/kvikio/parallel_operation.hpp
+++ b/cpp/include/kvikio/parallel_operation.hpp
@@ -56,42 +56,42 @@ std::future<std::size_t> parallel_io(
     return op(devPtr_base, size, file_offset, devPtr_offset);
   };
 
+  // Single-task guard
+  if (task_size >= size || page_size >= size) {
+    return std::async(std::launch::deferred, task, devPtr_base, size, file_offset, devPtr_offset);
+  }
+
+  // We know an upper bound of the total number of tasks
   std::vector<std::future<std::size_t>> tasks;
-  if (task_size >= size || page_size >= size) {  // Single-task guard
+  tasks.reserve(size / task_size + 2);
+
+  // 1) Submit a task for the unaligned range from the start to the first page boundary
+  {
+    const std::size_t unaligned_range = file_offset % page_size;
+    assert(unaligned_range < size);  // This is true because of the single-task guard above.
+    if (unaligned_range > 0) {
+      tasks.push_back(defaults::thread_pool().submit(
+        task, devPtr_base, unaligned_range, file_offset, devPtr_offset));
+      file_offset += unaligned_range;
+      devPtr_offset += unaligned_range;
+      size -= unaligned_range;
+    }
+    assert(file_offset % page_size == 0);  // `file_offset` is now aligned
+  }
+  // 2) Submit tasks for the aligned range from the first page boundary to the last page boundary
+  {
+    while (size >= task_size) {
+      tasks.push_back(
+        defaults::thread_pool().submit(task, devPtr_base, task_size, file_offset, devPtr_offset));
+      file_offset += task_size;
+      devPtr_offset += task_size;
+      size -= task_size;
+    }
+  }
+  // 3) Submit a task for the remainder range from the last page boundary to the end
+  if (size > 0) {
     tasks.push_back(
       defaults::thread_pool().submit(task, devPtr_base, size, file_offset, devPtr_offset));
-  } else {
-    // We have an upper bound of the total number of tasks
-    tasks.reserve(size / task_size + 2);
-
-    // 1) Submit a task for the unaligned range from the start to the first page boundary
-    {
-      const std::size_t unaligned_range = file_offset % page_size;
-      assert(unaligned_range < size);  // This is true because of the single-task guard above.
-      if (unaligned_range > 0) {
-        tasks.push_back(defaults::thread_pool().submit(
-          task, devPtr_base, unaligned_range, file_offset, devPtr_offset));
-        file_offset += unaligned_range;
-        devPtr_offset += unaligned_range;
-        size -= unaligned_range;
-      }
-      assert(file_offset % page_size == 0);  // `file_offset` is now aligned
-    }
-    // 2) Submit tasks for the aligned range from the first page boundary to the last page boundary
-    {
-      while (size >= task_size) {
-        tasks.push_back(
-          defaults::thread_pool().submit(task, devPtr_base, task_size, file_offset, devPtr_offset));
-        file_offset += task_size;
-        devPtr_offset += task_size;
-        size -= task_size;
-      }
-    }
-    // 3) Submit a task for the remainder range from the last page boundary to the end
-    if (size > 0) {
-      tasks.push_back(
-        defaults::thread_pool().submit(task, devPtr_base, size, file_offset, devPtr_offset));
-    }
   }
 
   // Finally, we sum the result of all tasks.

--- a/cpp/include/kvikio/parallel_operation.hpp
+++ b/cpp/include/kvikio/parallel_operation.hpp
@@ -65,7 +65,7 @@ std::future<std::size_t> parallel_io(
   std::vector<std::future<std::size_t>> tasks;
   tasks.reserve(size / task_size + 2);
 
-  // 1) Submit tasks for the aligned range from the first page boundary to the last page boundary
+  // 1) Submit `task_size` sized tasks
   {
     while (size >= task_size) {
       tasks.push_back(
@@ -75,7 +75,7 @@ std::future<std::size_t> parallel_io(
       size -= task_size;
     }
   }
-  // 2) Submit a task for the remainder range from the last page boundary to the end
+  // 2) Submit a task for the remainder
   if (size > 0) {
     tasks.push_back(
       defaults::thread_pool().submit(task, devPtr_base, size, file_offset, devPtr_offset));

--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -208,6 +208,9 @@ inline std::size_t posix_io(int fd,
 /**
  * @brief Read main memory from disk using POSIX
  *
+ * If `size` or `file_offset` isn't aligned with `page_size` then
+ * `fd` cannot have been opened with the `O_DIRECT` flag.
+ *
  * @param fd File decriptor
  * @param devPtr_base Base address of buffer in device memory.
  * @param size Size in bytes to read.
@@ -226,6 +229,9 @@ inline std::size_t posix_read(int fd,
 
 /**
  * @brief Write main memory to disk using POSIX
+ *
+ * If `size` or `file_offset` isn't aligned with `page_size` then
+ * `fd` cannot have been opened with the `O_DIRECT` flag.
  *
  * @param fd File decriptor
  * @param devPtr_base Base address of buffer in device memory.

--- a/python/tests/test_basic_io.py
+++ b/python/tests/test_basic_io.py
@@ -71,6 +71,22 @@ def test_file_handle_context(tmp_path):
     assert f.closed
 
 
+@pytest.mark.skipif(
+    kvikio.defaults.compat_mode(),
+    reason="cannot test `set_compat_mode` when already running in compatibility mode",
+)
+def test_set_compat_mode_between_io(tmp_path):
+    """Test changing `compat_mode`"""
+
+    with kvikio.defaults.set_compat_mode(False):
+        f = kvikio.CuFile(tmp_path / "test-file", "w")
+        assert not f.closed
+        assert f.open_flags() & os.O_WRONLY != 0
+        with kvikio.defaults.set_compat_mode(True):
+            a = cupy.arange(10)
+            assert f.write(a) == a.nbytes
+
+
 def test_write_to_files_in_chunks(tmp_path):
     """Write to files in chunks"""
     filename = tmp_path / "test-file"

--- a/python/tests/test_basic_io.py
+++ b/python/tests/test_basic_io.py
@@ -119,7 +119,7 @@ def test_write_to_files_in_chunks(tmp_path):
 
 
 @pytest.mark.parametrize("nthreads", [1, 3, 16])
-@pytest.mark.parametrize("tasksize", [1000, int(1.5 * 4096), int(2.3 * 4096)])
+@pytest.mark.parametrize("tasksize", [1000, 4096, int(1.5 * 4096), int(2.3 * 4096)])
 @pytest.mark.parametrize(
     "start,end",
     [(0, 10 * 4096), (1, int(1.3 * 4096)), (int(2.1 * 4096), int(5.6 * 4096))],


### PR DESCRIPTION
KvikIO's compatibility mode is now per `FileHandle` thus changing compatibility mode, effects all new `FileHandles` that doesn't sets the `compat_mode` argument explicitly but it never effect existing `FileHandles`.