### PR TITLE
rapids_export(): typo in argument

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -106,7 +106,7 @@ rapids_export(
   INSTALL kvikio
   EXPORT_SET kvikio-exports
   GLOBAL_TARGETS kvikio
-  namespace kvikio::
+  NAMESPACE kvikio::
   DOCUMENTATION doc_string
 )
 
@@ -115,7 +115,7 @@ rapids_export(
   BUILD kvikio
   EXPORT_SET kvikio-exports
   GLOBAL_TARGETS kvikio
-  namespace kvikio::
+  NAMESPACE kvikio::
   DOCUMENTATION doc_string
 )
 


### PR DESCRIPTION
lowercase "namespace" should be "NAMESPACE"

This is critical and should be merged into `branch-22.04` before release