### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -106,7 +106,7 @@ rapids_export(
   INSTALL kvikio
   EXPORT_SET kvikio-exports
   GLOBAL_TARGETS kvikio
-  namespace kvikio::
+  NAMESPACE kvikio::
   DOCUMENTATION doc_string
 )
 
@@ -115,7 +115,7 @@ rapids_export(
   BUILD kvikio
   EXPORT_SET kvikio-exports
   GLOBAL_TARGETS kvikio
-  namespace kvikio::
+  NAMESPACE kvikio::
   DOCUMENTATION doc_string
 )
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.