### PR TITLE
Embed Cython docstrings in generated files.

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -16,6 +16,10 @@ cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
 set(kvikio_version 22.06.00)
 
+set(CYTHON_FLAGS
+    "--directive binding=True,embedsignature=True,always_allow_keywords=True"
+    CACHE STRING "The directives for Cython compilation.")
+
 project(
   kvikio-python
   VERSION ${kvikio_version}


### PR DESCRIPTION
This PR embeds signatures in Cython functions and classes so that they'll be accessible for normal Python help. While docstrings are currently present as expected, we still have to provide Cython with the appropriate directives to tell it that we want signatures.