### PR TITLE
Keep the rapids-cmake version insync with calver

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -35,6 +35,9 @@ sed_runner "/project(/,/)/s/VERSION.*/VERSION ${NEXT_FULL_TAG}/" cpp/CMakeLists.
 # python update
 sed_runner 's/set(kvikio_version.*)/set(kvikio_version '${NEXT_FULL_TAG}')/g' python/CMakeLists.txt
 
+# rapids-cmake version
+sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cmake"'/g' cpp/cmake/fetch_rapids.cmake
+
 # script update
 sed_runner 's/version=.*/version="'${NEXT_SHORT_TAG}'"):/g' scripts/format-all.py
 

--- a/cpp/cmake/fetch_rapids.cmake
+++ b/cpp/cmake/fetch_rapids.cmake
@@ -11,7 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.06/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake
 )
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)


### PR DESCRIPTION
Update to rapids-cmake 22.06 and also update the release scripts so we don't have a calver dsync going forward.