### PR TITLE
Mark detail functions as inline

### DIFF
--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -46,7 +46,7 @@ T getenv_or(std::string_view env_var_name, T default_val)
 }
 
 template <>
-bool getenv_or(std::string_view env_var_name, bool default_val)
+inline bool getenv_or(std::string_view env_var_name, bool default_val)
 {
   const auto* env_val = std::getenv(env_var_name.data());
   if (env_val == nullptr) { return default_val; }

--- a/cpp/include/kvikio/driver.hpp
+++ b/cpp/include/kvikio/driver.hpp
@@ -25,12 +25,12 @@
 namespace kvikio {
 namespace detail {
 
-[[nodiscard]] bool get_driver_flag(unsigned int prop, unsigned int flag) noexcept
+[[nodiscard]] inline bool get_driver_flag(unsigned int prop, unsigned int flag) noexcept
 {
   return (prop & (1U << flag)) != 0;
 }
 
-void set_driver_flag(unsigned int& prop, unsigned int flag, bool val) noexcept
+inline void set_driver_flag(unsigned int& prop, unsigned int flag, bool val) noexcept
 {
   if (val) {
     prop |= (1U << flag);

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -91,7 +91,7 @@ inline int open_fd(const std::string& file_path,
  *
  * @return Open flags
  */
-[[nodiscard]] int open_flags(int fd)
+[[nodiscard]] inline int open_flags(int fd)
 {
   int ret = fcntl(fd, F_GETFL);  // NOLINT(cppcoreguidelines-pro-type-vararg)
   if (ret == -1) {


### PR DESCRIPTION
These function needs to be inline so that the header can be safely included in multiple files in the same TU without ODR violations.