### PR TITLE
Check stub error

### DIFF
--- a/cpp/include/kvikio/error.hpp
+++ b/cpp/include/kvikio/error.hpp
@@ -27,41 +27,6 @@ struct CUfileException : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
-#ifdef KVIKIO_CUFILE_EXIST
-#ifndef CUFILE_TRY
-#define CUFILE_TRY(...)                                         \
-  GET_CUFILE_TRY_MACRO(__VA_ARGS__, CUFILE_TRY_2, CUFILE_TRY_1) \
-  (__VA_ARGS__)
-#define GET_CUFILE_TRY_MACRO(_1, _2, NAME, ...) NAME
-#define CUFILE_TRY_2(_call, _exception_type)                                                      \
-  do {                                                                                            \
-    CUfileError_t const error = (_call);                                                          \
-    if (error.err != CU_FILE_SUCCESS) {                                                           \
-      if (error.err == CU_FILE_CUDA_DRIVER_ERROR) {                                               \
-        if (error.cu_err != CUDA_SUCCESS) {                                                       \
-          const char* err_name;                                                                   \
-          const char* err_str;                                                                    \
-          CUresult err_name_status = cudaAPI::instance().GetErrorName(error.cu_err, &err_name);   \
-          CUresult err_str_status  = cudaAPI::instance().GetErrorString(error.cu_err, &err_str);  \
-          if (err_name_status == CUDA_ERROR_INVALID_VALUE) { err_name = "unknown"; }              \
-          if (err_str_status == CUDA_ERROR_INVALID_VALUE) { err_str = "unknown"; }                \
-          /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                          \
-          throw _exception_type{std::string{"CUDA error at: "} + __FILE__ + ":" +                 \
-                                KVIKIO_STRINGIFY(__LINE__) + ": " + std::string(err_name) + "(" + \
-                                std::string(err_str) + ")"};                                      \
-        }                                                                                         \
-      } else {                                                                                    \
-        /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                            \
-        throw _exception_type{std::string{"cuFile error at: "} + __FILE__ + ":" +                 \
-                              KVIKIO_STRINGIFY(__LINE__) + ": " +                                 \
-                              cufileop_status_error(error.err)};                                  \
-      }                                                                                           \
-    }                                                                                             \
-  } while (0)
-#define CUFILE_TRY_1(_call) CUFILE_TRY_2(_call, CUfileException)
-#endif
-#endif
-
 #ifndef CUDA_DRIVER_TRY
 #define CUDA_DRIVER_TRY(...)                                                   \
   GET_CUDA_DRIVER_TRY_MACRO(__VA_ARGS__, CUDA_DRIVER_TRY_2, CUDA_DRIVER_TRY_1) \
@@ -84,6 +49,31 @@ struct CUfileException : public std::runtime_error {
     }                                                                                         \
   } while (0)
 #define CUDA_DRIVER_TRY_1(_call) CUDA_DRIVER_TRY_2(_call, CUfileException)
+#endif
+
+#ifdef KVIKIO_CUFILE_EXIST
+#ifndef CUFILE_TRY
+#define CUFILE_TRY(...)                                         \
+  GET_CUFILE_TRY_MACRO(__VA_ARGS__, CUFILE_TRY_2, CUFILE_TRY_1) \
+  (__VA_ARGS__)
+#define GET_CUFILE_TRY_MACRO(_1, _2, NAME, ...) NAME
+#define CUFILE_TRY_2(_call, _exception_type)                                      \
+  do {                                                                            \
+    CUfileError_t const error = (_call);                                          \
+    if (error.err != CU_FILE_SUCCESS) {                                           \
+      if (error.err == CU_FILE_CUDA_DRIVER_ERROR) {                               \
+        CUresult const cuda_error = error.cu_err;                                 \
+        CUDA_DRIVER_TRY(cuda_error);                                              \
+      } else {                                                                    \
+        /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                            \
+        throw _exception_type{std::string{"cuFile error at: "} + __FILE__ + ":" + \
+                              KVIKIO_STRINGIFY(__LINE__) + ": " +                 \
+                              cufileop_status_error(error.err)};                  \
+      }                                                                           \
+    }                                                                             \
+  } while (0)
+#define CUFILE_TRY_1(_call) CUFILE_TRY_2(_call, CUfileException)
+#endif
 #endif
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/error.hpp
+++ b/cpp/include/kvikio/error.hpp
@@ -32,21 +32,25 @@ struct CUfileException : public std::runtime_error {
   GET_CUDA_DRIVER_TRY_MACRO(__VA_ARGS__, CUDA_DRIVER_TRY_2, CUDA_DRIVER_TRY_1) \
   (__VA_ARGS__)
 #define GET_CUDA_DRIVER_TRY_MACRO(_1, _2, NAME, ...) NAME
-#define CUDA_DRIVER_TRY_2(_call, _exception_type)                                             \
-  do {                                                                                        \
-    CUresult const error = (_call);                                                           \
-    if (error != CUDA_SUCCESS) {                                                              \
-      const char* err_name;                                                                   \
-      const char* err_str;                                                                    \
-      CUresult err_name_status = cudaAPI::instance().GetErrorName(error, &err_name);          \
-      CUresult err_str_status  = cudaAPI::instance().GetErrorString(error, &err_str);         \
-      if (err_name_status == CUDA_ERROR_INVALID_VALUE) { err_name = "unknown"; }              \
-      if (err_str_status == CUDA_ERROR_INVALID_VALUE) { err_str = "unknown"; }                \
-      /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                          \
-      throw _exception_type{std::string{"CUDA error at: "} + __FILE__ + ":" +                 \
-                            KVIKIO_STRINGIFY(__LINE__) + ": " + std::string(err_name) + "(" + \
-                            std::string(err_str) + ")"};                                      \
-    }                                                                                         \
+#define CUDA_DRIVER_TRY_2(_call, _exception_type)                                              \
+  do {                                                                                         \
+    CUresult const error = (_call);                                                            \
+    if (error == CUDA_ERROR_STUB_LIBRARY) {                                                    \
+      throw(_exception_type){std::string{"CUDA error at: "} + __FILE__ + ":" +                 \
+                             KVIKIO_STRINGIFY(__LINE__) +                                      \
+                             ": CUDA_ERROR_STUB_LIBRARY("                                      \
+                             "The CUDA driver loaded is a stub library)"};                     \
+    } else if (error != CUDA_SUCCESS) {                                                        \
+      const char* err_name;                                                                    \
+      const char* err_str;                                                                     \
+      CUresult err_name_status = cudaAPI::instance().GetErrorName(error, &err_name);           \
+      CUresult err_str_status  = cudaAPI::instance().GetErrorString(error, &err_str);          \
+      if (err_name_status == CUDA_ERROR_INVALID_VALUE) { err_name = "unknown"; }               \
+      if (err_str_status == CUDA_ERROR_INVALID_VALUE) { err_str = "unknown"; }                 \
+      throw(_exception_type){std::string{"CUDA error at: "} + __FILE__ + ":" +                 \
+                             KVIKIO_STRINGIFY(__LINE__) + ": " + std::string(err_name) + "(" + \
+                             std::string(err_str) + ")"};                                      \
+    }                                                                                          \
   } while (0)
 #define CUDA_DRIVER_TRY_1(_call) CUDA_DRIVER_TRY_2(_call, CUfileException)
 #endif
@@ -57,20 +61,19 @@ struct CUfileException : public std::runtime_error {
   GET_CUFILE_TRY_MACRO(__VA_ARGS__, CUFILE_TRY_2, CUFILE_TRY_1) \
   (__VA_ARGS__)
 #define GET_CUFILE_TRY_MACRO(_1, _2, NAME, ...) NAME
-#define CUFILE_TRY_2(_call, _exception_type)                                      \
-  do {                                                                            \
-    CUfileError_t const error = (_call);                                          \
-    if (error.err != CU_FILE_SUCCESS) {                                           \
-      if (error.err == CU_FILE_CUDA_DRIVER_ERROR) {                               \
-        CUresult const cuda_error = error.cu_err;                                 \
-        CUDA_DRIVER_TRY(cuda_error);                                              \
-      } else {                                                                    \
-        /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                            \
-        throw _exception_type{std::string{"cuFile error at: "} + __FILE__ + ":" + \
-                              KVIKIO_STRINGIFY(__LINE__) + ": " +                 \
-                              cufileop_status_error(error.err)};                  \
-      }                                                                           \
-    }                                                                             \
+#define CUFILE_TRY_2(_call, _exception_type)                                       \
+  do {                                                                             \
+    CUfileError_t const error = (_call);                                           \
+    if (error.err != CU_FILE_SUCCESS) {                                            \
+      if (error.err == CU_FILE_CUDA_DRIVER_ERROR) {                                \
+        CUresult const cuda_error = error.cu_err;                                  \
+        CUDA_DRIVER_TRY(cuda_error);                                               \
+      } else {                                                                     \
+        throw(_exception_type){std::string{"cuFile error at: "} + __FILE__ + ":" + \
+                               KVIKIO_STRINGIFY(__LINE__) + ": " +                 \
+                               cufileop_status_error(error.err)};                  \
+      }                                                                            \
+    }                                                                              \
   } while (0)
 #define CUFILE_TRY_1(_call) CUFILE_TRY_2(_call, CUfileException)
 #endif


### PR DESCRIPTION
When using a stub, calling `cuGetErrorName()` and `cuGetErrorString()` results in segfault. In this PR we check `CUDA_ERROR_STUB_LIBRARY` explicitly. 