### PR TITLE
dlopen: use already loaded symbols if available

### DIFF
--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -45,7 +45,15 @@ class cudaAPI {
  private:
   cudaAPI()
   {
-    void* lib = load_library("libcuda.so");
+    // First we check if the symbols are already loaded.
+    void* lib = load_library(nullptr);
+    try {
+      get_symbol(Init, lib, KVIKIO_STRINGIFY(cuInit));
+    } catch (const std::runtime_error& e) {
+      // If not, we load them.
+      lib = load_library("libcuda.so");
+    }
+
     // Notice, the API version loaded must match the version used downstream. That is,
     // if a project uses the `_v2` CUDA Driver API or the newest Runtime API, the symbols
     // loaded should also be the `_v2` symbols. Thus, we use KVIKIO_STRINGIFY() to get


### PR DESCRIPTION
CI is [failing](https://gpuci.gpuopenanalytics.com/blue/organizations/jenkins/rapidsai%2Fgpuci%2Fkvikio%2Fprb%2Fkvikio-gpu-build/detail/kvikio-gpu-build/41/pipeline#log-1560) because `dlopen("libcuda.so")` is finding a stub (`/usr/local/cuda/lib64/stubs/libcuda.so`). 

This PR fixes the issue by trying to use already loaded symbols. However, this could be a problem if the symbols are unloaded later in the execution, unlikely but possible. 

Is this the best way to handle such an issue or is there a better approach?

cc. @jakirkham @robertmaynard 


