### PR TITLE
minor docstring fixes

### DIFF
--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -190,7 +190,7 @@ class defaults {
    * @brief Get the default task size used for parallel IO operations.
    *
    * Set the default value using `kvikio::default::task_size_reset()` or by setting
-   * the `KVIKIO_TASK_SIZE` environment variable. If not set, the default value is 16 MiB.
+   * the `KVIKIO_TASK_SIZE` environment variable. If not set, the default value is 4 MiB.
    *
    * @return The default task size in bytes.
    */

--- a/python/kvikio/cufile.py
+++ b/python/kvikio/cufile.py
@@ -104,7 +104,7 @@ class CuFile:
         ----------
         buf: buffer-like or array-like
             Device buffer to read into.
-        size: int
+        size: int, optional
             Size in bytes to read.
         file_offset: int, optional
             Offset in the file to read from.
@@ -138,8 +138,8 @@ class CuFile:
         ----------
         buf: buffer-like or array-like
             Device buffer to write to.
-        size: int
-            Size in bytes to read.
+        size: int, optional
+            Size in bytes to write.
         file_offset: int, optional
             Offset in the file to write from.
         task_size: int, default=kvikio.defaults.task_size()
@@ -162,7 +162,7 @@ class CuFile:
         ----------
         buf: buffer-like or array-like
             Device buffer to read into.
-        size: int
+        size: int, optional
             Size in bytes to read.
         file_offset: int, optional
             Offset in the file to read from.
@@ -185,8 +185,8 @@ class CuFile:
         ----------
         buf: buffer-like or array-like
             Device buffer to write to.
-        size: int
-            Size in bytes to read.
+        size: int, optional
+            Size in bytes to write.
         file_offset: int, optional
             Offset in the file to write from.
         task_size: int, default=kvikio.defaults.task_size()
@@ -210,7 +210,7 @@ class CuFile:
         ----------
         buf: buffer-like or array-like
             Device buffer to read into.
-        size: int
+        size: int, optional
             Size in bytes to read.
         file_offset: int, optional
             Offset in the file to read from.
@@ -235,8 +235,8 @@ class CuFile:
         ----------
         buf: buffer-like or array-like
             Device buffer to write to.
-        size: int
-            Size in bytes to read.
+        size: int, optional
+            Size in bytes to write.
         file_offset: int, optional
             Offset in the file to write from.
         dev_offset: int, optional

--- a/python/kvikio/defaults.py
+++ b/python/kvikio/defaults.py
@@ -115,7 +115,7 @@ def task_size() -> int:
 
     Set the default value using `task_size_reset()` or by setting
     the `KVIKIO_TASK_SIZE` environment variable. If not set,
-    the default value is 16 MiB.
+    the default value is 4 MiB.
 
     Return
     ------


### PR DESCRIPTION
Just fixing a few issues that I noticed in the docstrings.

Default task size currently seems to be [4 MB rather than 16 MB](https://github.com/rapidsai/kvikio/blob/bc7a313c68c677189ff7cd78bd4e58e16a587bda/cpp/include/kvikio/defaults.hpp#L106).
