### PR TITLE
CI: build without cuFile

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -85,7 +85,7 @@ ${WORKSPACE}/libkvikio-debug-build/examples/basic_io
 
 gpuci_logger "Build and run libkvikio-no-cufile"
 mkdir "${WORKSPACE}/libkvikio-no-cufile-build"
-cd "${WORKSPACE}/libkvikio-no-cufile"
+cd "${WORKSPACE}/libkvikio-no-cufile-build"
 cmake ${WORKSPACE}/cpp -DCMAKE_DISABLE_FIND_PACKAGE_cuFile=TRUE
 make
 # Run basic_io

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -89,7 +89,7 @@ cd "${WORKSPACE}/libkvikio-no-cufile-build"
 cmake ${WORKSPACE}/cpp -DCMAKE_DISABLE_FIND_PACKAGE_cuFile=TRUE
 make
 # Run basic_io
-${WORKSPACE}/libkvikio-no-cufile/examples/basic_io
+${WORKSPACE}/libkvikio-no-cufile-build/examples/basic_io
 
 cd "${WORKSPACE}/python"
 gpuci_logger "Python py.test for kvikio"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -73,6 +73,7 @@ gpuci_logger "Python py.test for kvikio"
 cd "${WORKSPACE}/python"
 py.test --cache-clear --basetemp="${WORKSPACE}/cudf-cuda-tmp" --junitxml="${WORKSPACE}/junit-kvikio.xml" -v
 
+cd "${WORKSPACE}"
 gpuci_logger "Clean previous conda builds"
 gpuci_mamba_retry uninstall libkvikio kvikio
 rm -rf "${CONDA_BLD_DIR}"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -83,6 +83,14 @@ fi
 # Run basic_io
 ${WORKSPACE}/libkvikio-debug-build/examples/basic_io
 
+gpuci_logger "Build and run libkvikio-no-cufile"
+mkdir "${WORKSPACE}/libkvikio-no-cufile-build"
+cd "${WORKSPACE}/libkvikio-no-cufile"
+cmake ${WORKSPACE}/cpp -DCMAKE_DISABLE_FIND_PACKAGE_cuFile=TRUE
+make
+# Run basic_io
+${WORKSPACE}/libkvikio-no-cufile/examples/basic_io
+
 cd "${WORKSPACE}/python"
 gpuci_logger "Python py.test for kvikio"
 py.test --cache-clear --basetemp="${WORKSPACE}/cudf-cuda-tmp" --junitxml="${WORKSPACE}/junit-kvikio.xml" -v

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -80,18 +80,18 @@ rm -rf "${CONDA_BLD_DIR}"
 
 gpuci_logger "Build and run libkvikio-debug"
 export CMAKE_EXTRA_ARGS="-DCMAKE_BUILD_TYPE=Debug"
-gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/libkvikio
+gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} --no-remove-work-dir --keep-old-work conda/recipes/libkvikio
 gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" libkvikio
 
 # Check that `libcuda.so` is NOT being linked
-LDD_BASIC_IO=$(ldd "${CONDA_BLD_DIR}/libkvikio/work/cpp/build/examples/basic_io")
+LDD_BASIC_IO=$(ldd "${CONDA_BLD_DIR}/work/cpp/build/examples/basic_io")
 if [[ "$LDD_BASIC_IO" == *"libcuda.so"* ]]; then
   echo "[ERROR] examples/basic_io shouln't link to libcuda.so: ${LDD_BASIC_IO}"
   return 1
 fi
 
 # Run basic_io
-"${CONDA_BLD_DIR}/libkvikio/work/cpp/build/examples/basic_io"
+"${CONDA_BLD_DIR}/work/cpp/build/examples/basic_io"
 
 gpuci_logger "Clean previous conda builds"
 gpuci_mamba_retry uninstall libkvikio
@@ -99,11 +99,11 @@ rm -rf "${CONDA_BLD_DIR}"
 
 gpuci_logger "Build and run libkvikio-no-cufile"
 export CMAKE_EXTRA_ARGS="-DCMAKE_DISABLE_FIND_PACKAGE_cuFile=TRUE"
-gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/libkvikio
+gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} --no-remove-work-dir --keep-old-work conda/recipes/libkvikio
 gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" libkvikio
 
 # Run basic_io
-"${CONDA_BLD_DIR}/libkvikio/work/cpp/build/examples/basic_io"
+"${CONDA_BLD_DIR}/work/cpp/build/examples/basic_io"
 
 if [ -n "${CODECOV_TOKEN}" ]; then
     codecov -t $CODECOV_TOKEN

--- a/conda/recipes/libkvikio/build.sh
+++ b/conda/recipes/libkvikio/build.sh
@@ -5,7 +5,7 @@ mkdir cpp/build
 pushd cpp/build
 cmake .. \
       -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-
+      ${CMAKE_EXTRA_ARGS}
 make
 make install
 popd

--- a/conda/recipes/libkvikio/meta.yaml
+++ b/conda/recipes/libkvikio/meta.yaml
@@ -27,6 +27,7 @@ build:
     - SCCACHE_BUCKET=rapids-sccache
     - SCCACHE_REGION=us-west-2
     - SCCACHE_IDLE_TIMEOUT=32768
+    - CMAKE_EXTRA_ARGS
   run_exports:
     - {{ pin_subpackage("libkvikio", max_pin="x.x") }}
   ignore_run_exports_from:

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -18,6 +18,9 @@ target_link_libraries(basic_io PRIVATE kvikio CUDA::cudart)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
   set(KVIKIO_CXX_FLAGS "-Wall;-Werror;-Wno-unknown-pragmas")
+  if(NOT cuFile_FOUND)
+    set(KVIKIO_CXX_FLAGS "${KVIKIO_CXX_FLAGS};-DKVIKIO_DISABLE_CUFILE")
+  endif()
   target_compile_options(
     basic_io PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${KVIKIO_CXX_FLAGS}>"
  )

--- a/cpp/include/kvikio/driver.hpp
+++ b/cpp/include/kvikio/driver.hpp
@@ -179,10 +179,13 @@ class DriverProperties {
 
 #else
 struct DriverInitializer {
+  // Implement a non-default constructor to avoid `unused variable` warnings downstream
+  DriverInitializer() {}
 };
 
 struct DriverProperties {
-  DriverProperties() = default;
+  // Implement a non-default constructor to avoid `unused variable` warnings downstream
+  DriverProperties() {}
 
   static bool is_gds_available() { return false; }
 


### PR DESCRIPTION
Test that KvikIO can be build even when cuFile isn't available and fixes a `unused variable` compile warning