### PR TITLE
Require `python` in `run`

### DIFF
--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - scikit-build >=0.13.1
     - libkvikio {{ version }}
   run:
+    - python
     - cupy
     - zarr
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
When `python` is a dependency, it needs to be listed in `host` & `run`. This aligns the version used when installing and makes sure `python` gets installed (and the right `kvikio` package with it) at runtime.

cc @madsbk @charlesbluca 