### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/environments/kvikio_dev_cuda11.5.yml
+++ b/conda/environments/kvikio_dev_cuda11.5.yml
@@ -1,0 +1,49 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+
+name: kvikio_dev
+channels:
+  - rapidsai
+  - nvidia
+  - rapidsai-nightly
+  - conda-forge
+dependencies:
+  - c-compiler
+  - cxx-compiler
+  - clang=11.1.0
+  - clang-tools=11.1.0
+  - cupy>=9.5.0,<11.0.0a0
+  - cmake>=3.20.1,!=3.23.0
+  - cmake-format>=3.20.1,!=3.23.0
+  - cmake_setuptools>=0.1.3
+  - scikit-build>=0.13.1
+  - python>=3.8,<3.10
+  - numpy
+  - ninja
+  - wheel
+  - setuptools
+  - pyparsing
+  - distro
+  - cython>=0.29,<0.30
+  - pytest
+  - sphinx
+  - sphinxcontrib-websupport
+  - nbsphinx
+  - numpydoc
+  - ipython
+  - cudatoolkit=11.5
+  - pip
+  - dask>=2022.05.2
+  - distributed>=2022.05.2
+  - flake8=3.8.3
+  - black=22.3.0
+  - isort=5.6.4
+  - mypy=0.782
+  - doxygen=1.8.20
+  - pydocstyle=6.1.1
+  - pre-commit
+  - pydata-sphinx-theme
+  - gcc_linux-64=9.* # [linux64]
+  - sysroot_linux-64==2.17 # [linux64]
+  # Un-comment following lines for ARM specific packages.
+  # - gcc_linux-aarch64=9.* # [aarch64]
+  # - sysroot_linux-aarch64==2.17 # [aarch64]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.