### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -66,6 +66,9 @@ gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/libkvikio
 gpuci_conda_retry mambabuild --croot ${CONDA_BLD_DIR} conda/recipes/kvikio --python=$PYTHON -c "${CONDA_BLD_DIR}"
 gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" libkvikio kvikio
 
+gpuci_logger "Install test dependencies"
+gpuci_mamba_retry install -c conda-forge -c rapidsai-nightly cudf
+
 gpuci_logger "Build and run libkvikio-debug"
 mkdir "${WORKSPACE}/libkvikio-debug-build"
 cd "${WORKSPACE}/libkvikio-debug-build"
@@ -82,7 +85,7 @@ ${WORKSPACE}/libkvikio-debug-build/examples/basic_io
 
 cd "${WORKSPACE}/python"
 gpuci_logger "Python py.test for kvikio"
-py.test -n 6 --cache-clear --basetemp="${WORKSPACE}/cudf-cuda-tmp" --junitxml="${WORKSPACE}/junit-kvikio.xml" -v
+py.test --cache-clear --basetemp="${WORKSPACE}/cudf-cuda-tmp" --junitxml="${WORKSPACE}/junit-kvikio.xml" -v
 
 if [ -n "${CODECOV_TOKEN}" ]; then
     codecov -t $CODECOV_TOKEN


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.