### PR TITLE
[REVIEW] Defer loading of `custom.js`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,4 +68,4 @@ html_static_path = ['_static']
 
 def setup(app):
     app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
-    app.add_js_file("https://docs.rapids.ai/assets/js/custom.js")
+    app.add_js_file("https://docs.rapids.ai/assets/js/custom.js", loading_method="defer")


### PR DESCRIPTION
This PR switches the loading of `custom.js` to `defer` because we will need the entire page to be loading until the methods in this script can even execute correctly.

xref: https://github.com/rapidsai/cudf/pull/11465