### PR TITLE
Use rapids-cmake 22.10 best practice for RAPIDS.cmake location

### DIFF
--- a/cpp/cmake/fetch_rapids.cmake
+++ b/cpp/cmake/fetch_rapids.cmake
@@ -14,5 +14,6 @@
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake
-)
+  )
+endif()
 include(${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake)

--- a/cpp/cmake/fetch_rapids.cmake
+++ b/cpp/cmake/fetch_rapids.cmake
@@ -11,7 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
-     ${CMAKE_BINARY_DIR}/RAPIDS.cmake
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake)
+  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
+       ${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake
 )
-include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+include(${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake)


### PR DESCRIPTION
Removes possibility of another projects RAPIDS.cmake being used, and removes need to always download a version.