### PR TITLE
Fall back to compat mode if we cannot open the file with `O_DIRECT`

### DIFF
--- a/python/tests/test_basic_io.py
+++ b/python/tests/test_basic_io.py
@@ -13,16 +13,8 @@ cupy = pytest.importorskip("cupy")
 numpy = pytest.importorskip("numpy")
 
 
-def check_bit_flags(
-    x: int, y: int, add_o_direct=not kvikio.defaults.compat_mode()
-) -> bool:
-    """Check that the bits set in `y` is also set in `x`
-
-    Set `add_o_direct=True` to add the `os.O_DIRECT` bit to `y`. This is True
-    by default when KvikIO is NOT running in compatibility mode.
-    """
-    if add_o_direct:
-        y |= os.O_DIRECT
+def check_bit_flags(x: int, y: int) -> bool:
+    """Check that the bits set in `y` is also set in `x`"""
     return x & y == y
 
 


### PR DESCRIPTION
Fixes https://github.com/rapidsai/kvikio/issues/125

Some filesystems such as `tmpfs` doesn't support the `O_DIRECT` flag. We now fall back to compat mode if we cannot open the file with `O_DIRECT`.

