### PR TITLE
Set version when dlopen() cuda and cufile

### DIFF
--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -46,7 +46,7 @@ class cudaAPI {
  private:
   cudaAPI()
   {
-    void* lib = load_library("libcuda.so");
+    void* lib = load_library("libcuda.so.1");
     // Notice, the API version loaded must match the version used downstream. That is,
     // if a project uses the `_v2` CUDA Driver API or the newest Runtime API, the symbols
     // loaded should also be the `_v2` symbols. Thus, we use KVIKIO_STRINGIFY() to get

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -49,7 +49,7 @@ class cuFileAPI {
  private:
   cuFileAPI()
   {
-    void* lib = load_library("libcufile.so");
+    void* lib = load_library("libcufile.so.1");
     get_symbol(HandleRegister, lib, KVIKIO_STRINGIFY(cuFileHandleRegister));
     get_symbol(HandleDeregister, lib, KVIKIO_STRINGIFY(cuFileHandleDeregister));
     get_symbol(Read, lib, KVIKIO_STRINGIFY(cuFileRead));
@@ -80,7 +80,7 @@ class cuFileAPI {
 /**
  * @brief Check if the cuFile library is available
  *
- * Notice, this doesn't check if the runtime environment supported by cuFile.
+ * Notice, this doesn't check if the runtime environment supports cuFile.
  *
  * @return The boolean answer
  */


### PR DESCRIPTION
In order to avoid ABI incompatibilities and loading of stub libraries, we now specify the major version when loading `libcuda.so.1` and `libcufile.so.1`.

