### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/environments/kvikio_dev_cuda11.5.yml
+++ b/conda/environments/kvikio_dev_cuda11.5.yml
@@ -12,7 +12,7 @@ dependencies:
   - clang=11.1.0
   - clang-tools=11.1.0
   - cupy>=9.5.0,<12.0.0a0
-  - cmake>=3.20.1,!=3.23.0
+  - cmake>=3.23.1,!=3.25.0
   - cmake-format
   - cmake_setuptools>=0.1.3
   - scikit-build>=0.13.1

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -26,7 +26,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.20.1
+    - cmake >=3.23.1,!=3.25.0
     - ninja
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}

--- a/conda/recipes/libkvikio/meta.yaml
+++ b/conda/recipes/libkvikio/meta.yaml
@@ -36,7 +36,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.20.1
+    - cmake >=3.20.1,!=3.25.0
     - make
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 include(cmake/fetch_rapids.cmake)
 include(rapids-cmake)

--- a/cpp/examples/downstream/CMakeLists.txt
+++ b/cpp/examples/downstream/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 project(
   KvikIODownstreamExample

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 set(kvikio_version 22.12.00)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "setuptools",
     "Cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.20.1",
+    "cmake>=3.23.1,!=3.25.0",
     "ninja",
 ]
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.