### PR TITLE
Update `ops-bot.yaml`  config

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,5 +5,5 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
-external_contributors: false
 copy_prs: true
+recently_updated: true


### PR DESCRIPTION
These changes should've been included in #164.

They update the `ops-bot.yaml` file to enable the [Recently Updated Check](https://docs.rapids.ai/resources/recently-updated/) for `kvikio`.

Additionally, this PR removes the `external_contributors` key, since it is no longer in use.