### PR TITLE
[REVIEW] Fix docs build to be `pydata-sphinx-theme=0.13.0` compatible

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,6 +58,8 @@ html_logo = "_static/RAPIDS-logo-purple.png"
 
 html_theme_options = {
     "external_links": [],
+    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
+    "icon_links": [],
     "github_url": "https://github.com/rapidsai/kvikio",
     "twitter_url": "https://twitter.com/rapidsai",
     "show_toc_level": 1,


### PR DESCRIPTION
This PR fixes kvikio docs build to be compatible with `pydata-sphinx-theme=0.13.0` by adding an empty `icon_links` entry.

