### PR TITLE
Support of stream ordered device memory allocations (async mallocs)

### DIFF
--- a/cpp/include/kvikio/error.hpp
+++ b/cpp/include/kvikio/error.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,19 +61,18 @@ struct CUfileException : public std::runtime_error {
   GET_CUFILE_TRY_MACRO(__VA_ARGS__, CUFILE_TRY_2, CUFILE_TRY_1) \
   (__VA_ARGS__)
 #define GET_CUFILE_TRY_MACRO(_1, _2, NAME, ...) NAME
-#define CUFILE_TRY_2(_call, _exception_type)                                       \
-  do {                                                                             \
-    CUfileError_t const error = (_call);                                           \
-    if (error.err != CU_FILE_SUCCESS) {                                            \
-      if (error.err == CU_FILE_CUDA_DRIVER_ERROR) {                                \
-        CUresult const cuda_error = error.cu_err;                                  \
-        CUDA_DRIVER_TRY(cuda_error);                                               \
-      } else {                                                                     \
-        throw(_exception_type){std::string{"cuFile error at: "} + __FILE__ + ":" + \
-                               KVIKIO_STRINGIFY(__LINE__) + ": " +                 \
-                               cufileop_status_error(error.err)};                  \
-      }                                                                            \
-    }                                                                              \
+#define CUFILE_TRY_2(_call, _exception_type)                                     \
+  do {                                                                           \
+    CUfileError_t const error = (_call);                                         \
+    if (error.err != CU_FILE_SUCCESS) {                                          \
+      if (error.err == CU_FILE_CUDA_DRIVER_ERROR) {                              \
+        CUresult const cuda_error = error.cu_err;                                \
+        CUDA_DRIVER_TRY(cuda_error);                                             \
+      }                                                                          \
+      throw(_exception_type){std::string{"cuFile error at: "} + __FILE__ + ":" + \
+                             KVIKIO_STRINGIFY(__LINE__) + ": " +                 \
+                             cufileop_status_error(error.err)};                  \
+    }                                                                            \
   } while (0)
 #define CUFILE_TRY_1(_call) CUFILE_TRY_2(_call, CUfileException)
 #endif

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -391,7 +391,7 @@ class FileHandle {
       return parallel_io(op, buf, size, file_offset, task_size, 0);
     }
 
-    CUcontext ctx = get_context_from_device_pointer(buf);
+    CUcontext ctx = get_current_context(buf);
     auto task     = [this, ctx](void* devPtr_base,
                             std::size_t size,
                             std::size_t file_offset,
@@ -437,7 +437,7 @@ class FileHandle {
       return parallel_io(op, buf, size, file_offset, task_size, 0);
     }
 
-    CUcontext ctx = get_context_from_device_pointer(buf);
+    CUcontext ctx = get_current_context(buf);
     auto op       = [this, ctx](const void* devPtr_base,
                           std::size_t size,
                           std::size_t file_offset,

--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ class cudaAPI {
   decltype(cuPointerGetAttributes)* PointerGetAttributes{nullptr};
   decltype(cuCtxPushCurrent)* CtxPushCurrent{nullptr};
   decltype(cuCtxPopCurrent)* CtxPopCurrent{nullptr};
+  decltype(cuCtxGetCurrent)* CtxGetCurrent{nullptr};
   decltype(cuMemGetAddressRange)* MemGetAddressRange{nullptr};
   decltype(cuGetErrorName)* GetErrorName{nullptr};
   decltype(cuGetErrorString)* GetErrorString{nullptr};
@@ -59,6 +60,7 @@ class cudaAPI {
     get_symbol(PointerGetAttributes, lib, KVIKIO_STRINGIFY(cuPointerGetAttributes));
     get_symbol(CtxPushCurrent, lib, KVIKIO_STRINGIFY(cuCtxPushCurrent));
     get_symbol(CtxPopCurrent, lib, KVIKIO_STRINGIFY(cuCtxPopCurrent));
+    get_symbol(CtxGetCurrent, lib, KVIKIO_STRINGIFY(cuCtxGetCurrent));
     get_symbol(MemGetAddressRange, lib, KVIKIO_STRINGIFY(cuMemGetAddressRange));
     get_symbol(GetErrorName, lib, KVIKIO_STRINGIFY(cuGetErrorName));
     get_symbol(GetErrorString, lib, KVIKIO_STRINGIFY(cuGetErrorString));

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,10 +96,6 @@ class PushAndPopContext {
 
  public:
   PushAndPopContext(CUcontext ctx) : _ctx{ctx}
-  {
-    CUDA_DRIVER_TRY(cudaAPI::instance().CtxPushCurrent(_ctx));
-  }
-  PushAndPopContext(const void* devPtr) : _ctx{get_context_from_device_pointer(devPtr)}
   {
     CUDA_DRIVER_TRY(cudaAPI::instance().CtxPushCurrent(_ctx));
   }

--- a/python/tests/test_basic_io.py
+++ b/python/tests/test_basic_io.py
@@ -21,8 +21,7 @@ def check_bit_flags(x: int, y: int) -> bool:
 @pytest.mark.parametrize("size", [1, 10, 100, 1000, 1024, 4096, 4096 * 10])
 @pytest.mark.parametrize("nthreads", [1, 3, 4, 16])
 @pytest.mark.parametrize("tasksize", [199, 1024])
-@pytest.mark.parametrize("xp", [cupy, numpy])
-def test_read_write(tmp_path, size, nthreads, tasksize, xp):
+def test_read_write(tmp_path, xp, size, nthreads, tasksize):
     """Test basic read/write"""
     filename = tmp_path / "test-file"
 
@@ -81,7 +80,6 @@ def test_set_compat_mode_between_io(tmp_path):
             assert f.write(a) == a.nbytes
 
 
-@pytest.mark.parametrize("xp", [cupy, numpy])
 def test_write_to_files_in_chunks(tmp_path, xp):
     """Write to files in chunks"""
     filename = tmp_path / "test-file"
@@ -119,8 +117,7 @@ def test_write_to_files_in_chunks(tmp_path, xp):
     "start,end",
     [(0, 10 * 4096), (1, int(1.3 * 4096)), (int(2.1 * 4096), int(5.6 * 4096))],
 )
-@pytest.mark.parametrize("xp", [cupy, numpy])
-def test_read_write_slices(tmp_path, nthreads, tasksize, start, end, xp):
+def test_read_write_slices(tmp_path, xp, nthreads, tasksize, start, end):
     """Read and write different slices"""
 
     with kvikio.defaults.set_num_threads(nthreads):

--- a/python/tests/test_numpy.py
+++ b/python/tests/test_numpy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 
@@ -7,12 +7,10 @@ import pytest
 from kvikio.numpy import LikeWrapper, tofile
 
 
-@pytest.mark.parametrize("xp", ["numpy", "cupy"])
 @pytest.mark.parametrize("dtype", ["u1", "int64", "float32", "float64"])
 def test_tofile(tmp_path, xp, dtype):
     """Test tofile()"""
 
-    xp = pytest.importorskip(xp)
     filepath = str(tmp_path / "test_tofile")
     src = xp.arange(100, dtype=dtype)
     tofile(src, filepath)
@@ -25,12 +23,10 @@ def test_tofile(tmp_path, xp, dtype):
     xp.testing.assert_array_equal(src[::2], dst)
 
 
-@pytest.mark.parametrize("xp", ["numpy", "cupy"])
 @pytest.mark.parametrize("dtype", ["u1", "int64", "float32", "float64"])
 def test_fromfile(tmp_path, xp, dtype):
     """Test NumPy's and CuPy's fromfile() with LikeWrapper"""
 
-    xp = pytest.importorskip(xp)
     filepath = str(tmp_path / "test_fromfile")
     src = xp.arange(100, dtype=dtype)
     src.tofile(filepath)
@@ -58,9 +54,7 @@ def test_fromfile(tmp_path, xp, dtype):
         xp.testing.assert_array_equal(src, dst)
 
 
-@pytest.mark.parametrize("xp", ["numpy", "cupy"])
 def test_fromfile_error(tmp_path, xp):
-    xp = pytest.importorskip(xp)
     filepath = str(tmp_path / "test_fromfile")
     src = xp.arange(1, dtype="u1")
     src.tofile(filepath)


### PR DESCRIPTION
Currently, we call `cuPointerGetAttribute(..., CU_POINTER_ATTRIBUTE_CONTEXT)` to set the CUDA context for each IO task. However, this doesn't work for[ stream ordered device memory allocations](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#pointer-attributes) so we now get the current cuda context instead.

Closes https://github.com/rapidsai/cudf/issues/12865