### PR TITLE
Implement `build.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *.*~
 build
 python/_skbuild
+legate/_skbuild
+legate/legate_kvikio/install_info.py
+legate/record.txt
+python/record.txt
 *.so
 dask-worker-space
 __pycache__

--- a/build.sh
+++ b/build.sh
@@ -18,11 +18,12 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean libkvikio kvikio -v -g -n -s --ptds -h"
-HELP="$0 [clean] [libkvikio] [kvikio] [-v] [-g] [-n] [-s] [--ptds] [--cmake-args=\"<args>\"] [-h]
+VALIDARGS="clean libkvikio kvikio legate -v -g -n -s --ptds -h"
+HELP="$0 [clean] [libkvikio] [kvikio] [legate] [-v] [-g] [-n] [-s] [--ptds] [--cmake-args=\"<args>\"] [-h]
    clean                       - remove all existing build artifacts and configuration (start over)
    libkvikio                   - build and install the libkvikio C++ code
    kvikio                      - build and install the kvikio Python package
+   legate                      - build and install the legate-kvikio Python package
    -v                          - verbose build mode
    -g                          - build for debug
    -n                          - no install step
@@ -32,7 +33,8 @@ HELP="$0 [clean] [libkvikio] [kvikio] [-v] [-g] [-n] [-s] [--ptds] [--cmake-args
 "
 LIBKVIKIO_BUILD_DIR=${LIBKVIKIO_BUILD_DIR:=${REPODIR}/cpp/build}
 KVIKIO_BUILD_DIR="${REPODIR}/python/build ${REPODIR}/python/_skbuild"
-BUILD_DIRS="${LIBKVIKIO_BUILD_DIR} ${KVIKIO_BUILD_DIR}"
+LEGATE_BUILD_DIR="${REPODIR}/legate/build ${REPODIR}/legate/_skbuild"
+BUILD_DIRS="${LIBKVIKIO_BUILD_DIR} ${KVIKIO_BUILD_DIR} ${LEGATE_BUILD_DIR}"
 
 # Set defaults for vars modified by flags to this script
 VERBOSE_FLAG=""
@@ -129,6 +131,7 @@ if hasArg clean; then
             rmdir "${bd}" || true
         fi
     done
+    rm -f ${REPODIR}/legate/legate_kvikio/install_info.py
 fi
 
 ################################################################################
@@ -149,5 +152,14 @@ if (( NUMARGS == 0 )) || hasArg kvikio; then
     export INSTALL_PREFIX
     echo "building kvikio..."
     python setup.py build_ext --inplace
+    python setup.py install --single-version-externally-managed --record=record.txt
+fi
+
+
+# Build and install the legate-kvikio Python package
+if hasArg legate; then
+    cd "${REPODIR}/legate"
+    export INSTALL_PREFIX
+    echo "building legate..."
     python setup.py install --single-version-externally-managed --record=record.txt
 fi

--- a/legate/CMakeLists.txt
+++ b/legate/CMakeLists.txt
@@ -29,7 +29,7 @@ set(BUILD_SHARED_LIBS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # We always want to build our bindings, so we trick the legate wrappers to never search for an
-# installed version which is currently deduced by seeing if it is invoked via scikit-build See
+# installed version which is currently deduced by seeing if it is invoked via scikit-build. See
 # <https://github.com/nv-legate/legate.core/pull/645>
 find_package(legate_core REQUIRED)
 set(SKBUILD OFF)

--- a/legate/CMakeLists.txt
+++ b/legate/CMakeLists.txt
@@ -28,10 +28,11 @@ endif()
 set(BUILD_SHARED_LIBS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Look for an existing C++ editable build Not required. We will build it if not found.
-find_package(legate_kvikio QUIET)
+# We always want to build our bindings, so we trick the legate wrappers to never search for an
+# installed version which is currently deduced by seeing if it is invoked via scikit-build See
+# <https://github.com/nv-legate/legate.core/pull/645>
 find_package(legate_core REQUIRED)
-
+set(SKBUILD OFF)
 legate_add_cpp_subdirectory(cpp TARGET legate_kvikio EXPORT legate_kvikio-export)
 legate_default_python_install(legate_kvikio EXPORT legate_kvikio-export)
 

--- a/legate/cpp/CMakeLists.txt
+++ b/legate/cpp/CMakeLists.txt
@@ -12,8 +12,6 @@
 # the License.
 # =============================================================================
 
-# legate_cpp_library_template(legate_kvikio TEMPLATE_SOURCES)
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(CUDAToolkit REQUIRED)


### PR DESCRIPTION
Implement the `build.sh` that other RAPIDS projects use.  

### Need Help
Running `./build.sh libkvikio kvikio legate` now works and cleaning the environment also works  `./build.sh clean`.

However, after a clean, installing `legate` doesn't work.
```
$ ./build.sh clean legate
CMake Error at /home/mkristensen/apps/miniconda3/envs/legate-0227/lib/cmake/legate_core/legate_core-config.cmake:332 (add_library):
  add_library cannot create ALIAS target "legate::legate_kvikio_python"
  because another target with the same name already exists.
Call Stack (most recent call first):
  CMakeLists.txt:36 (legate_default_python_install)
```
If I delete the installed cmake files from the conda environment, it works again:
```
$ rm -R /home/mkristensen/apps/miniconda3/envs/legate-0227/lib/cmake/legate_kvikio
$ ./build.sh clean legate
```
Anyone knows what is going on?
