### PR TITLE
Update clang-format to 16.0.1.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
                 "python/benchmarks"]
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v11.1.0
+    rev: v16.0.1
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]

--- a/cpp/include/kvikio/driver.hpp
+++ b/cpp/include/kvikio/driver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/kvikio/driver.hpp
+++ b/cpp/include/kvikio/driver.hpp
@@ -47,9 +47,9 @@ class DriverInitializer {
  public:
   DriverInitializer() { CUFILE_TRY(cuFileAPI::instance().DriverOpen()); }
 
-  DriverInitializer(DriverInitializer const&) = delete;
-  DriverInitializer& operator=(DriverInitializer const&) = delete;
-  DriverInitializer(DriverInitializer&&) noexcept        = delete;
+  DriverInitializer(DriverInitializer const&)                = delete;
+  DriverInitializer& operator=(DriverInitializer const&)     = delete;
+  DriverInitializer(DriverInitializer&&) noexcept            = delete;
   DriverInitializer& operator=(DriverInitializer&&) noexcept = delete;
 
   ~DriverInitializer()

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -108,8 +108,7 @@ inline int open_fd(const std::string& file_path,
  */
 [[nodiscard]] inline std::size_t get_file_size(int file_descriptor)
 {
-  struct stat st {
-  };
+  struct stat st {};
   int ret = fstat(file_descriptor, &st);
   if (ret == -1) {
     throw std::system_error(errno, std::generic_category(), "Unable to query file size");
@@ -181,7 +180,7 @@ class FileHandle {
   /**
    * @brief FileHandle support move semantic but isn't copyable
    */
-  FileHandle(const FileHandle&) = delete;
+  FileHandle(const FileHandle&)            = delete;
   FileHandle& operator=(FileHandle const&) = delete;
   FileHandle(FileHandle&& o) noexcept
     : _fd_direct_on{std::exchange(o._fd_direct_on, -1)},

--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -51,10 +51,10 @@ class AllocRetain {
 
    public:
     Alloc(AllocRetain* manager, void* alloc) : _manager(manager), _alloc{alloc} {}
-    Alloc(const Alloc&) = delete;
+    Alloc(const Alloc&)            = delete;
     Alloc& operator=(Alloc const&) = delete;
     Alloc(Alloc&& o)               = delete;
-    Alloc& operator=(Alloc&& o) = delete;
+    Alloc& operator=(Alloc&& o)    = delete;
     ~Alloc() noexcept { _manager->put(_alloc); }
     void* get() noexcept { return _alloc; }
   };
@@ -93,11 +93,11 @@ class AllocRetain {
     }
   }
 
-  AllocRetain(const AllocRetain&) = delete;
+  AllocRetain(const AllocRetain&)            = delete;
   AllocRetain& operator=(AllocRetain const&) = delete;
   AllocRetain(AllocRetain&& o)               = delete;
-  AllocRetain& operator=(AllocRetain&& o) = delete;
-  ~AllocRetain() noexcept                 = default;
+  AllocRetain& operator=(AllocRetain&& o)    = delete;
+  ~AllocRetain() noexcept                    = default;
 };
 
 inline AllocRetain manager;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -73,7 +73,7 @@ class cudaAPI {
   }
 
  public:
-  cudaAPI(cudaAPI const&) = delete;
+  cudaAPI(cudaAPI const&)        = delete;
   void operator=(cudaAPI const&) = delete;
 
   static cudaAPI& instance()

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -83,7 +83,7 @@ class cuFileAPI {
   }
 
  public:
-  cuFileAPI(cuFileAPI const&) = delete;
+  cuFileAPI(cuFileAPI const&)      = delete;
   void operator=(cuFileAPI const&) = delete;
 
   static cuFileAPI& instance()

--- a/cpp/include/kvikio/shim/utils.hpp
+++ b/cpp/include/kvikio/shim/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/kvikio/shim/utils.hpp
+++ b/cpp/include/kvikio/shim/utils.hpp
@@ -87,8 +87,7 @@ void get_symbol(T& handle, void* lib, const char* name)
  */
 [[nodiscard]] inline bool is_running_in_wsl()
 {
-  struct utsname buf {
-  };
+  struct utsname buf {};
   int err = ::uname(&buf);
   if (err == 0) {
     const std::string name(static_cast<char*>(buf.release));

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -108,10 +108,10 @@ class CudaPrimaryContext {
     CUDA_DRIVER_TRY(cudaAPI::instance().DeviceGet(&dev, device_ordinal));
     CUDA_DRIVER_TRY(cudaAPI::instance().DevicePrimaryCtxRetain(&ctx, dev));
   }
-  CudaPrimaryContext(const CudaPrimaryContext&) = delete;
+  CudaPrimaryContext(const CudaPrimaryContext&)            = delete;
   CudaPrimaryContext& operator=(CudaPrimaryContext const&) = delete;
   CudaPrimaryContext(CudaPrimaryContext&&)                 = delete;
-  CudaPrimaryContext&& operator=(CudaPrimaryContext&&) = delete;
+  CudaPrimaryContext&& operator=(CudaPrimaryContext&&)     = delete;
   ~CudaPrimaryContext()
   {
     try {
@@ -220,10 +220,10 @@ class PushAndPopContext {
   {
     CUDA_DRIVER_TRY(cudaAPI::instance().CtxPushCurrent(_ctx));
   }
-  PushAndPopContext(const PushAndPopContext&) = delete;
+  PushAndPopContext(const PushAndPopContext&)            = delete;
   PushAndPopContext& operator=(PushAndPopContext const&) = delete;
   PushAndPopContext(PushAndPopContext&&)                 = delete;
-  PushAndPopContext&& operator=(PushAndPopContext&&) = delete;
+  PushAndPopContext&& operator=(PushAndPopContext&&)     = delete;
   ~PushAndPopContext()
   {
     try {

--- a/legate/cpp/legate_mapping.cpp
+++ b/legate/cpp/legate_mapping.cpp
@@ -24,7 +24,7 @@ class Mapper : public legate::mapping::LegateMapper {
  public:
   Mapper() {}
 
-  Mapper(const Mapper& rhs) = delete;
+  Mapper(const Mapper& rhs)            = delete;
   Mapper& operator=(const Mapper& rhs) = delete;
 
   // Legate mapping functions


### PR DESCRIPTION
This PR updates the clang-format version used by pre-commit.
