### PR TITLE
Add API to get compatibility mode status in a FileHandle object

### DIFF
--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -478,6 +478,16 @@ class FileHandle {
     auto [devPtr_base, base_size, devPtr_offset] = get_alloc_info(buf, &ctx);
     return parallel_io(op, devPtr_base, size, file_offset, task_size, devPtr_offset);
   }
+
+  /**
+   * @brief Returns `true` if the compatibility mode has been enabled for this file.
+   * 
+   * Compatibility mode can be explicitly enabled in object creation. The mode is also enabled
+   * automatically, if file cannot be opened with the `O_DIRECT` flag.
+   * 
+   * @return compatibility mode state for the object
+   */
+  [[nodiscard]] bool is_compat_mode_on() const noexcept { return _compat_mode; }
 };
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -481,10 +481,10 @@ class FileHandle {
 
   /**
    * @brief Returns `true` if the compatibility mode has been enabled for this file.
-   * 
+   *
    * Compatibility mode can be explicitly enabled in object creation. The mode is also enabled
    * automatically, if file cannot be opened with the `O_DIRECT` flag.
-   * 
+   *
    * @return compatibility mode state for the object
    */
   [[nodiscard]] bool is_compat_mode_on() const noexcept { return _compat_mode; }


### PR DESCRIPTION
Adding `is_compat_mode_on()` to FileHandle to make the run-time behavior more transparent for the users.