### PR TITLE
Only look for libcufile.so.0

### DIFF
--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -50,7 +50,17 @@ class cuFileAPI {
  private:
   cuFileAPI()
   {
-    void* lib = load_library("libcufile.so.0");
+    // CUDA versions before CUDA 11.7.1 did not ship libcufile.so.0, so this is
+    // a workaround that adds support for all prior versions of libcufile.
+    void* lib = load_library({"libcufile.so.0",
+                              "libcufile.so.1.3.0" /* 11.7.0 */,
+                              "libcufile.so.1.2.1" /* 11.6.2, 11.6.1 */,
+                              "libcufile.so.1.2.0" /* 11.6.0 */,
+                              "libcufile.so.1.1.1" /* 11.5.1 */,
+                              "libcufile.so.1.1.0" /* 11.5.0 */,
+                              "libcufile.so.1.0.2" /* 11.4.4, 11.4.3, 11.4.2 */,
+                              "libcufile.so.1.0.1" /* 11.4.1 */,
+                              "libcufile.so.1.0.0" /* 11.4.0 */});
     get_symbol(HandleRegister, lib, KVIKIO_STRINGIFY(cuFileHandleRegister));
     get_symbol(HandleDeregister, lib, KVIKIO_STRINGIFY(cuFileHandleDeregister));
     get_symbol(Read, lib, KVIKIO_STRINGIFY(cuFileRead));

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -50,7 +50,7 @@ class cuFileAPI {
  private:
   cuFileAPI()
   {
-    void* lib = load_library({"libcufile.so.1", "libcufile.so.0", "libcufile.so"});
+    void* lib = load_library("libcufile.so.0");
     get_symbol(HandleRegister, lib, KVIKIO_STRINGIFY(cuFileHandleRegister));
     get_symbol(HandleDeregister, lib, KVIKIO_STRINGIFY(cuFileHandleDeregister));
     get_symbol(Read, lib, KVIKIO_STRINGIFY(cuFileRead));


### PR DESCRIPTION
Rather than searching for a list of possible library names for libcufile, only look for the single ABI-compatible version of libcufile that we support. This avoids both ABI incompatibilities and loading stub libraries. It morally does what #127 attempted, but with the correct versioning suffix.

Closes #200.