### PR TITLE
Zarr+nvCOMP

### DIFF
--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -3,11 +3,18 @@
 
 import os
 import os.path
+from abc import abstractmethod
 
 import cupy
+import numpy as np
+import zarr.creation
 import zarr.storage
+from numcodecs.abc import Codec
+from numcodecs.compat import ensure_contiguous_ndarray_like
+from numcodecs.registry import register_codec
 
 import kvikio
+import kvikio.nvcomp
 from kvikio._lib.arr import asarray
 
 
@@ -51,3 +58,133 @@ class GDSStore(zarr.storage.DirectoryStore):
                 assert written == a.nbytes
         else:
             super()._tofile(a.obj, fn)
+
+
+class NVCompCompressor(Codec):
+    """Abstract base class for nvCOMP compressors
+
+    The derived classes must set `codec_id` and implement
+    `get_nvcomp_manager`
+
+    Parameters
+    ----------
+    device_ordinal
+        The device that should do the compression/decompression
+    """
+
+    def __init__(self, device_ordinal: int = 0):
+        self.device_ordinal = device_ordinal
+
+    @abstractmethod
+    def get_nvcomp_manager(self) -> kvikio.nvcomp.nvCompManager:
+        """Abstract method that should return the nvCOMP compressor manager
+
+        Returns
+        -------
+        nvCompManager
+            The nvCOMP compressor manager to use
+        """
+        pass  # TODO: cache Manager
+
+    def encode(self, buf) -> cupy.ndarray:
+        """Compress using `get_nvcomp_manager()`
+
+        Parameters
+        ----------
+        buf : buffer-like
+            The buffer to compress. Accepts both host and device memory.
+
+        Returns
+        -------
+        cupy.ndarray
+            The compressed buffer wrapped in a CuPy array
+        """
+        buf = cupy.asarray(ensure_contiguous_ndarray_like(buf))
+        return self.get_nvcomp_manager().compress(buf)
+
+    def decode(self, buf, out=None):
+        """Decompress using `get_nvcomp_manager()`
+
+        Parameters
+        ----------
+        buf : buffer-like
+            The buffer to decompress. Accepts both host and device memory.
+        out : buffer-like, optional
+            Writeable buffer to store decoded data. N.B. if provided, this buffer must
+            be exactly the right size to store the decoded data. Accepts both host and
+            device memory.
+
+        Returns
+        -------
+        buffer-like
+            Decompress data, which is either host or device memory based on the type
+            of `out`. If `out` is None, the type of `buf` determines the return buffer
+            type.
+        """
+        buf = ensure_contiguous_ndarray_like(buf)
+        is_host_buffer = not hasattr(buf, "__cuda_array_interface__")
+        if is_host_buffer:
+            buf = cupy.asarray(buf)
+
+        ret = self.get_nvcomp_manager().decompress(buf)
+
+        if is_host_buffer:
+            ret = cupy.asnumpy(ret)
+
+        if out is not None:
+            out = ensure_contiguous_ndarray_like(out)
+            if hasattr(out, "__cuda_array_interface__"):
+                cupy.copyto(out, ret.view(dtype=out.dtype), casting="no")
+            else:
+                np.copyto(out, cupy.asnumpy(ret.view(dtype=out.dtype)), casting="no")
+        return ret
+
+
+class ANS(NVCompCompressor):
+    codec_id = "nvcomp_ANS"
+
+    def get_nvcomp_manager(self):
+        return kvikio.nvcomp.ANSManager(device_id=self.device_ordinal)
+
+
+class Bitcomp(NVCompCompressor):
+    codec_id = "nvcomp_Bitcomp"
+
+    def get_nvcomp_manager(self):
+        return kvikio.nvcomp.BitcompManager(device_id=self.device_ordinal)
+
+
+class Cascaded(NVCompCompressor):
+    codec_id = "nvcomp_Cascaded"
+
+    def get_nvcomp_manager(self):
+        return kvikio.nvcomp.CascadedManager(device_id=self.device_ordinal)
+
+
+class Gdeflate(NVCompCompressor):
+    codec_id = "nvcomp_Gdeflate"
+
+    def get_nvcomp_manager(self):
+        return kvikio.nvcomp.GdeflateManager(device_id=self.device_ordinal)
+
+
+class LZ4(NVCompCompressor):
+    codec_id = "nvcomp_LZ4"
+
+    def get_nvcomp_manager(self):
+        return kvikio.nvcomp.LZ4Manager(device_id=self.device_ordinal)
+
+
+class Snappy(NVCompCompressor):
+    codec_id = "nvcomp_Snappy"
+
+    def get_nvcomp_manager(self):
+        return kvikio.nvcomp.SnappyManager(device_id=self.device_ordinal)
+
+
+register_codec(ANS)
+register_codec(Bitcomp)
+register_codec(Cascaded)
+register_codec(Gdeflate)
+register_codec(LZ4)
+register_codec(Snappy)

--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -182,9 +182,7 @@ class Snappy(NVCompCompressor):
         return kvikio.nvcomp.SnappyManager(device_id=self.device_ordinal)
 
 
-register_codec(ANS)
-register_codec(Bitcomp)
-register_codec(Cascaded)
-register_codec(Gdeflate)
-register_codec(LZ4)
-register_codec(Snappy)
+# Expose a list of available nvCOMP compressors and register them as Zarr condecs
+nvcomp_compressors = [ANS, Bitcomp, Cascaded, Gdeflate, LZ4, Snappy]
+for c in nvcomp_compressors:
+    register_codec(c)

--- a/python/tests/test_zarr.py
+++ b/python/tests/test_zarr.py
@@ -1,12 +1,14 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
+
+import math
 
 import pytest
 
 cupy = pytest.importorskip("cupy")
 zarr = pytest.importorskip("zarr")
-GDSStore = pytest.importorskip("kvikio.zarr").GDSStore
+kvikio_zarr = pytest.importorskip("kvikio.zarr")
 
 # To support CuPy arrays, we need the `meta_array` argument introduced in
 # Zarr v2.13, see <https://github.com/zarr-developers/zarr-python/pull/934>
@@ -17,7 +19,7 @@ if not hasattr(zarr.Array, "meta_array"):
 @pytest.fixture
 def store(tmp_path):
     """Fixture that creates a GDS Store"""
-    return GDSStore(tmp_path / "test-file.zarr")
+    return kvikio_zarr.GDSStore(tmp_path / "test-file.zarr")
 
 
 @pytest.mark.parametrize("array_type", ["numpy", "cupy"])
@@ -58,3 +60,29 @@ def test_group(store):
     assert isinstance(a, zarr.Array)
     assert isinstance(a[:], cupy.ndarray)
     assert (a[:] == 1).all()
+
+
+@pytest.mark.parametrize("xp_read", ["numpy", "cupy"])
+@pytest.mark.parametrize("xp_write", ["numpy", "cupy"])
+@pytest.mark.parametrize(
+    "compressor", ["ANS", "Bitcomp", "Cascaded", "Gdeflate", "LZ4", "Snappy"]
+)
+def test_compressor(store, xp_write, xp_read, compressor):
+    xp_read = pytest.importorskip(xp_read)
+    xp_write = pytest.importorskip(xp_write)
+    compressor = getattr(kvikio_zarr, compressor)
+
+    shape = (10, 1)
+    chunks = (10, 1)
+    a = xp_write.arange(math.prod(shape)).reshape(shape)
+    z = zarr.creation.create(
+        shape=shape,
+        chunks=chunks,
+        compressor=compressor(),
+        store=store,
+        meta_array=xp_read.empty(()),
+    )
+    z[:] = a
+    b = z[:]
+    assert isinstance(b, xp_read.ndarray)
+    cupy.testing.assert_array_equal(b, a)

--- a/python/tests/test_zarr.py
+++ b/python/tests/test_zarr.py
@@ -64,13 +64,10 @@ def test_group(store):
 
 @pytest.mark.parametrize("xp_read", ["numpy", "cupy"])
 @pytest.mark.parametrize("xp_write", ["numpy", "cupy"])
-@pytest.mark.parametrize(
-    "compressor", ["ANS", "Bitcomp", "Cascaded", "Gdeflate", "LZ4", "Snappy"]
-)
+@pytest.mark.parametrize("compressor", kvikio_zarr.nvcomp_compressors)
 def test_compressor(store, xp_write, xp_read, compressor):
     xp_read = pytest.importorskip(xp_read)
     xp_write = pytest.importorskip(xp_write)
-    compressor = getattr(kvikio_zarr, compressor)
 
     shape = (10, 1)
     chunks = (10, 1)


### PR DESCRIPTION
Some quick numbers (all IO reads):

|       | Compression Ratio | Throughput
| ----------- | :-----------: |-----------: |
| POSIX                               | n/a      | 1.63 GiB/s |
| KvikIO (compat mode)  | n/a        |   8.43 GiB/s |
| Zarr (no compression)   | n/a        |8.00 GiB/s | 
| Zarr+Snappy | 1000/322        | 10.57 GiB/s|
| Zarr+Gdeflate | 1000/27        | 29.05 GiB/s|
| Zarr+LZ4 | 1000/9        | 48.95 GiB/s|


Notice, this is just a quick benchmark to show the potential of nvCOMP. 
When Zarr v2.15 is released and https://github.com/rapidsai/kvikio/pull/131 merged, we can start optimizing. 
Additionally, when https://github.com/zarr-developers/zarr-python/pull/1396 is merged, we can introduce a wrapper for `zarr.open()` that seamlessly reads/writes to/from GPU memory and do on-the-fly compression.



