### PR TITLE
Enable sccache hits for local builds

### DIFF
--- a/conda/recipes/libkvikio/meta.yaml
+++ b/conda/recipes/libkvikio/meta.yaml
@@ -24,6 +24,7 @@ build:
     - SCCACHE_BUCKET
     - SCCACHE_REGION
     - SCCACHE_IDLE_TIMEOUT
+    - SCCACHE_S3_NO_CREDENTIALS
 
 requirements:
   build:


### PR DESCRIPTION
This change passes through the value of `SCCACHE_S3_NO_CREDENTIALS` to our `conda` builds, enabling devs to utilize the `sccache` cache that's populated by CI when they are reproducing build issues locally as per [these](https://docs.rapids.ai/resources/reproducing-ci/) instructions.