### PR TITLE
use rapids-upload-docs script

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -19,27 +19,29 @@ rapids-print-env
 rapids-logger "Downloading artifacts from previous jobs"
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
-VERSION_NUMBER="23.08"
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   --channel "${PYTHON_CHANNEL}" \
   kvikio libkvikio
 
-rapids-logger "Build Doxygen docs"
+export RAPIDS_VERSION_NUMBER="23.08"
+export RAPIDS_DOCS_DIR="$(mktemp -d)"
+
+rapids-logger "Build CPP docs"
 pushd cpp/doxygen
 doxygen Doxyfile
+mkdir -p "${RAPIDS_DOCS_DIR}/libkvikio/html"
+mv html/* "${RAPIDS_DOCS_DIR}/libkvikio/html"
 popd
 
-rapids-logger "Build Sphinx docs"
+rapids-logger "Build Python docs"
 pushd docs
 sphinx-build -b dirhtml source _html -W
 sphinx-build -b text source _text -W
+mkdir -p "${RAPIDS_DOCS_DIR}/kvikio/"{html,txt}
+mv _html/* "${RAPIDS_DOCS_DIR}/kvikio/html"
+mv _text/* "${RAPIDS_DOCS_DIR}/kvikio/txt"
 popd
 
-if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]]; then
-  rapids-logger "Upload Docs to S3"
-  aws s3 sync --no-progress --delete cpp/doxygen/html "s3://rapidsai-docs/libkvikio/${VERSION_NUMBER}/html"
-  aws s3 sync --no-progress --delete docs/_html "s3://rapidsai-docs/kvikio/${VERSION_NUMBER}/html"
-  aws s3 sync --no-progress --delete docs/_text "s3://rapidsai-docs/kvikio/${VERSION_NUMBER}/txt"
-fi
+rapids-upload-docs

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -58,4 +58,4 @@ done
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-action-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done
-sed_runner "s/VERSION_NUMBER=\".*/VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh
+sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh


### PR DESCRIPTION
This PR updates the `build_docs.sh` script to use the new consolidatory `rapids-upload-script` [shared script](https://github.com/rapidsai/gha-tools/pull/56). 

The shared script enables docs uploads to applicable S3 buckets for branch. nightly and PR builds.