### PR TITLE
Fix libcufile dependency.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -167,6 +167,9 @@ dependencies:
               # so 11.2 uses 11.4 packages (the oldest available).
               - *libcufile_114
               - *libcufile_dev114
+          # Fallback matrix for aarch64, which doesn't support libcufile.
+          - matrix:
+            packages:
   docs:
     common:
       - output_types: [conda, requirements]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -144,6 +144,7 @@ dependencies:
               cuda: "11.8"
               arch: x86_64
             packages:
+              # libcufile package version reference: https://anaconda.org/nvidia/libcufile/files
               - libcufile=1.4.0.31
               - libcufile-dev=1.4.0.31
           - matrix:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -124,32 +124,44 @@ dependencies:
         matrices:
           - matrix:
               cuda: "11.8"
-              arch: x86_64
-            packages:
-              - cudatoolkit=11.8
-              - libcufile=1.4.0.31
-              - libcufile-dev=1.4.0.31
-          - matrix:
-              cuda: "11.8"
-              arch: aarch64
             packages:
               - cudatoolkit=11.8
           - matrix:
               cuda: "11.5"
             packages:
               - cudatoolkit=11.5
-              - libcufile>=1.1.0.37,<=1.1.1.25
-              - libcufile-dev>=1.1.0.37,<=1.1.1.25
           - matrix:
               cuda: "11.4"
             packages:
               - cudatoolkit=11.4
-              - &libcufile_114 libcufile>=1.0.0.82,<=1.0.2.10
-              - &libcufile_dev114 libcufile-dev>=1.0.0.82,<=1.0.2.10
           - matrix:
               cuda: "11.2"
             packages:
               - cudatoolkit=11.2
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.8"
+              arch: x86_64
+            packages:
+              - libcufile=1.4.0.31
+              - libcufile-dev=1.4.0.31
+          - matrix:
+              cuda: "11.5"
+              arch: x86_64
+            packages:
+              - libcufile>=1.1.0.37,<=1.1.1.25
+              - libcufile-dev>=1.1.0.37,<=1.1.1.25
+          - matrix:
+              cuda: "11.4"
+              arch: x86_64
+            packages:
+              - &libcufile_114 libcufile>=1.0.0.82,<=1.0.2.10
+              - &libcufile_dev114 libcufile-dev>=1.0.0.82,<=1.0.2.10
+          - matrix:
+              cuda: "11.2"
+              arch: x86_64
+            packages:
               # The NVIDIA channel doesn't publish pkgs older than 11.4 for these libs,
               # so 11.2 uses 11.4 packages (the oldest available).
               - *libcufile_114


### PR DESCRIPTION
This PR fixes the libcufile dependency specification so that it's only specified for x86_64. It also fixes the redundant cudatoolkit re-specification for aarch64.