### PR TITLE
Disable the batch API when in compatibility mode

### DIFF
--- a/cpp/examples/basic_io.cpp
+++ b/cpp/examples/basic_io.cpp
@@ -145,7 +145,7 @@ int main()
          << " threads): " << read << endl;
   }
 
-  if (kvikio::is_batch_available()) {
+  if (kvikio::is_batch_available() && !kvikio::defaults::compat_mode()) {
     // Here we use the batch API to read "/tmp/test-file" into `b_dev` by
     // submitting 4 batch operations.
     constexpr int num_ops_in_batch = 4;

--- a/cpp/include/kvikio/batch.hpp
+++ b/cpp/include/kvikio/batch.hpp
@@ -118,6 +118,10 @@ class BatchHandle {
     std::vector<CUfileIOParams_t> io_batch_params;
     io_batch_params.reserve(operations.size());
     for (const auto& op : operations) {
+      if (op.file_handle.is_compat_mode_on()) {
+        throw CUfileException("Cannot submit a FileHandle opened in compatibility mode");
+      }
+
       io_batch_params.push_back(CUfileIOParams_t{.mode   = CUFILE_BATCH,
                                                  .u      = {.batch = {.devPtr_base   = op.devPtr_base,
                                                                       .file_offset   = op.file_offset,

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -90,14 +90,14 @@ class cuFileAPI {
     get_symbol(BatchIOCancel, lib, KVIKIO_STRINGIFY(cuFileBatchIOCancel));
     get_symbol(BatchIODestroy, lib, KVIKIO_STRINGIFY(cuFileBatchIODestroy));
 
-    // HACK: we use the mangled name of the `cuFileBatchContextState` to determine if cuFile's
-    // batch API is available. Notice, the symbols of `cuFileBatchIOSetUp` & co. exist all
-    // the way back to CUDA v11.5 but calling them is undefined behavior.
-    // TODO: when CUDA v12.2 is released, use `cuFileReadAsync` to determine the availability of
-    // both the batch and async API.
+    // HACK: we use the mangled name of the `CUfileOpError` to determine if cuFile's
+    // batch API is available (v12.0.1+). Notice, the symbols of `cuFileBatchIOSetUp` & co.
+    // exist all the way back to CUDA v11.5 but calling them is undefined behavior.
+    // TODO: when CUDA v12.2 is released, use `cuFileReadAsync` to determine the availability
+    // of both the batch and async API.
     try {
       void* s{};
-      get_symbol(s, lib, "_ZTS23cuFileBatchContextState");
+      get_symbol(s, lib, "_ZTS13CUfileOpError");
       batch_available = true;
     } catch (const std::runtime_error&) {
     }

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -177,7 +177,7 @@ inline bool is_cufile_available()
 inline bool is_batch_available()
 {
   try {
-    return cuFileAPI::instance().batch_available;
+    return is_cufile_available() && cuFileAPI::instance().batch_available;
   } catch (const std::runtime_error&) {
     return false;
   }


### PR DESCRIPTION
Fixes the [CI error](https://github.com/rapidsai/kvikio/actions/runs/5251546756/jobs/9486714890?pr=224) in #224.

Additionally, we now use the mangled name of the `CUfileOpError` to determine if cuFile's batch API is available (v12.0.1+). Previously, we used the mangled name of `cuFileBatchContextState`, which corresponds to v12.0.0+.