### PR TITLE
Clean up isort configs

### DIFF
--- a/legate/pyproject.toml
+++ b/legate/pyproject.toml
@@ -78,15 +78,7 @@ include_trailing_comma = true
 force_grid_wrap = 0
 combine_as_imports = true
 order_by_type = true
-known_rapids = [
-    "nvtext",
-    "cudf",
-    "cuml",
-    "cugraph",
-    "dask_cudf",
-]
 known_first_party = [
-    "cufile",
     "kvikio",
     "legate_kvikio",
 ]
@@ -95,7 +87,6 @@ sections = [
     "FUTURE",
     "STDLIB",
     "THIRDPARTY",
-    "RAPIDS",
     "FIRSTPARTY",
     "LOCALFOLDER",
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -78,24 +78,14 @@ include_trailing_comma = true
 force_grid_wrap = 0
 combine_as_imports = true
 order_by_type = true
-known_rapids = [
-    "nvtext",
-    "cudf",
-    "cuml",
-    "cugraph",
-    "dask_cudf",
-]
 known_first_party = [
-    "cufile",
     "kvikio",
-    "legate_kvikio",
 ]
 default_section = "THIRDPARTY"
 sections = [
     "FUTURE",
     "STDLIB",
     "THIRDPARTY",
-    "RAPIDS",
     "FIRSTPARTY",
     "LOCALFOLDER",
 ]


### PR DESCRIPTION
The pyproject.toml files list imports that do not actually occur in kvikio and can be removed.