### PR TITLE
Use cuda-version to constrain cudatoolkit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ conda create -n kvikio_env -c rapidsai -c conda-forge kvikio
 Install the `kvikio` conda package from the `rapidsai-nightly` channel like:
 
 ```
-conda create -n kvikio_env -c rapidsai-nightly -c conda-forge python=3.10 cudatoolkit=11.8 kvikio
+conda create -n kvikio_env -c rapidsai-nightly -c conda-forge python=3.10 cuda-version=11.8 kvikio
 ```
 
 If the nightly install doesn't work, set `channel_priority: flexible` in your `.condarc`.

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -9,7 +9,8 @@ dependencies:
 - c-compiler
 - cmake>=3.26.4
 - cuda-python>=11.7.1,<12.0a0
-- cudatoolkit=11.8
+- cuda-version=11.8
+- cudatoolkit
 - cudf==23.8.*
 - cupy>=12.0.0
 - cxx-compiler

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - pip
     - cython >=0.29,<0.30
     {% if cuda_major == "11" %}
-    - cudatoolkit ={{ cuda_version }}
+    - cudatoolkit
     {% endif %}
     - cuda-version ={{ cuda_version }}
     - scikit-build >=0.13.1
@@ -72,7 +72,7 @@ requirements:
     - packaging
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
     {% if cuda_major == "11" %}
-    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+    - cudatoolkit
     {% endif %}
 
 test:

--- a/conda/recipes/libkvikio/meta.yaml
+++ b/conda/recipes/libkvikio/meta.yaml
@@ -47,7 +47,7 @@ requirements:
   host:
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}
-    - cudatoolkit ={{ cuda_version }}
+    - cudatoolkit
     - libcufile {{ cuda11_libcufile_host_version }}      # [linux64]
     - libcufile-dev {{ cuda11_libcufile_host_version }}  # [linux64]
     {% else %}
@@ -73,7 +73,7 @@ outputs:
       run:
         - cuda-version {{ cuda_spec }}
         {% if cuda_major == "11" %}
-        - cudatoolkit {{ cuda_spec }}
+        - cudatoolkit
         - libcufile {{ cuda11_libcufile_run_version }}      # [linux64]
         - libcufile-dev {{ cuda11_libcufile_run_version }}  # [linux64]
         {% else %}
@@ -104,7 +104,7 @@ outputs:
       host:
         - cuda-version ={{ cuda_version }}
         {% if cuda_major == "11" %}
-        - cudatoolkit ={{ cuda_version }}
+        - cudatoolkit
         - libcufile {{ cuda11_libcufile_run_version }}  # [linux64]
         {% else %}
         - cuda-cudart-dev
@@ -113,7 +113,7 @@ outputs:
       run:
         - cuda-version {{ cuda_spec }}
         {% if cuda_major == "11" %}
-        - cudatoolkit {{ cuda_spec }}
+        - cudatoolkit
         - libcufile {{ cuda11_libcufile_run_version }}  # [linux64]
         {% endif %}
     about:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -149,19 +149,23 @@ dependencies:
           - matrix:
               cuda: "11.8"
             packages:
-              - cudatoolkit=11.8
+              - cuda-version=11.8
+              - cudatoolkit
           - matrix:
               cuda: "11.5"
             packages:
-              - cudatoolkit=11.5
+              - cuda-version=11.5
+              - cudatoolkit
           - matrix:
               cuda: "11.4"
             packages:
-              - cudatoolkit=11.4
+              - cuda-version=11.4
+              - cudatoolkit
           - matrix:
               cuda: "11.2"
             packages:
-              - cudatoolkit=11.2
+              - cuda-version=11.2
+              - cudatoolkit
       - output_types: conda
         matrices:
           - matrix:


### PR DESCRIPTION
This PR changes CUDA 11 packaging to rely on `cuda-version` pinnings to constrain the installed version of `cudatoolkit`.

See also: https://github.com/rapidsai/cudf/pull/13615