### PR TITLE
Add nvcomp support to older CUDA 11 versions on aarch64.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -217,6 +217,21 @@ dependencies:
               cuda: "11.8"
             packages:
               - *nvcomp
+          - matrix:
+              arch: aarch64
+              cuda: "11.5"
+            packages:
+              - *nvcomp
+          - matrix:
+              arch: aarch64
+              cuda: "11.4"
+            packages:
+              - *nvcomp
+          - matrix:
+              arch: aarch64
+              cuda: "11.2"
+            packages:
+              - *nvcomp
   docs:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
Nightly CI runs are failing for CUDA 11.4 on ARM because the `cudatoolkit` package list does not specify a matrix entry for CUDA 11.4 on ARM for `nvcomp`. This adds the missing matrix entries for supported CUDA 11 versions.

See failure below:
```
ValueError: No matching matrix found in 'cudatoolkit' for: {'cuda': '11.4', 'arch': 'aarch64'}
```

https://github.com/rapidsai/kvikio/actions/runs/5652999609/job/15313480885