### PR TITLE
Forward-merge branch-23.08 to branch-23.10

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -217,6 +217,21 @@ dependencies:
               cuda: "11.8"
             packages:
               - *nvcomp
+          - matrix:
+              arch: aarch64
+              cuda: "11.5"
+            packages:
+              - *nvcomp
+          - matrix:
+              arch: aarch64
+              cuda: "11.4"
+            packages:
+              - *nvcomp
+          - matrix:
+              arch: aarch64
+              cuda: "11.2"
+            packages:
+              - *nvcomp
   docs:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.08` that creates a PR to keep `branch-23.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.