### PR TITLE
Zarr+CuPy+GDS+nvCOMP made easy

### DIFF
--- a/python/examples/zarr_cupy_nvcomp.py
+++ b/python/examples/zarr_cupy_nvcomp.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+
+import cupy
+import numpy
+import zarr
+
+import kvikio
+import kvikio.zarr
+
+
+def main(path):
+    a = cupy.arange(20)
+
+    # Let's use KvikIO's convenience function `open_cupy_array()` to create
+    # a new Zarr file on disk. Its semantic is the same as `zarr.open_array()`
+    # but uses a GDS file store, nvCOMP compression, and CuPy arrays.
+    z = kvikio.zarr.open_cupy_array(store=path, mode="w", shape=(20,), chunks=(5,))
+
+    # `z` is a regular Zarr Array that we can write to as usual
+    z[0:10] = numpy.arange(0, 10)
+    # but it also support direct reads and writes of CuPy arrays
+    z[10:20] = cupy.arange(10, 20)
+
+    # Reading `z` returns a CuPy array
+    assert isinstance(z[:], cupy.ndarray)
+    assert (a == z[:]).all()
+
+    # By default, `open_cupy_array()` uses nvCOMP's `lz4` GPU compression, which is
+    # compatible with NumCodecs's `lz4` CPU compression (CPU). Normally, it is not
+    # possible to change which decompressor to use when reading a Zarr file. The
+    # decompressor specified in the Zarr file's metadata is always used. However,
+    # `open_cupy_array()` makes it possible to overwrite the metadata on-the-fly
+    # without having to modify the Zarr file on disk. In fact, the Zarr file written
+    # above appears, in the metadata, as if it was written by NumCodecs's `lz4` CPU
+    # compression. Thus, we can open the file using Zarr's regular API and the CPU.
+    z = zarr.open_array(path)
+    # `z` is now read as a regular NumPy array
+    assert isinstance(z[:], numpy.ndarray)
+    assert (a.get() == z[:]).all()
+    # and we can write to is as usual
+    z[:] = numpy.arange(20, 40)
+
+    # Let's read the Zarr file back into a CuPy array
+    z = kvikio.zarr.open_cupy_array(store=path, mode="r")
+    assert isinstance(z[:], cupy.ndarray)
+    assert (cupy.arange(20, 40) == z[:]).all()
+
+
+if __name__ == "__main__":
+    main("/tmp/zarr-cupy-nvcomp")

--- a/python/examples/zarr_cupy_nvcomp.py
+++ b/python/examples/zarr_cupy_nvcomp.py
@@ -41,7 +41,9 @@ def main(path):
     # and we can write to is as usual
     z[:] = numpy.arange(20, 40)
 
-    # Let's read the Zarr file back into a CuPy array
+    # Let's read the Zarr file back into a CuPy array. Notice, even though the metadata
+    # on disk is specifying NumCodecs's `lz4` CPU decompressor, `open_cupy_array` will
+    # use nvCOMP to decompress the files.
     z = kvikio.zarr.open_cupy_array(store=path, mode="r")
     assert isinstance(z[:], cupy.ndarray)
     assert (cupy.arange(20, 40) == z[:]).all()

--- a/python/examples/zarr_cupy_nvcomp.py
+++ b/python/examples/zarr_cupy_nvcomp.py
@@ -48,7 +48,7 @@ def main(path):
     # and we can write to is as usual
     z[:] = numpy.arange(20, 40)
 
-    # Let's read the Zarr file back into a CuPy array.
+    # And we can read the Zarr file back into a CuPy array.
     z = kvikio.zarr.open_cupy_array(store=path, mode="r")
     assert isinstance(z[:], cupy.ndarray)
     assert (cupy.arange(20, 40) == z[:]).all()

--- a/python/kvikio/nvcomp_codec.py
+++ b/python/kvikio/nvcomp_codec.py
@@ -8,7 +8,7 @@ import numpy as np
 from numcodecs.abc import Codec
 from numcodecs.compat import ensure_contiguous_ndarray_like
 
-import kvikio._lib.libnvcomp_ll as _ll
+from kvikio._lib.libnvcomp_ll import SUPPORTED_ALGORITHMS
 
 
 class NvCompBatchCodec(Codec):
@@ -34,11 +34,11 @@ class NvCompBatchCodec(Codec):
         stream: Optional[cp.cuda.Stream] = None,
     ) -> None:
         algo_id = algorithm.lower()
-        algo_t = _ll.SUPPORTED_ALGORITHMS.get(algo_id, None)
+        algo_t = SUPPORTED_ALGORITHMS.get(algo_id, None)
         if algo_t is None:
             raise ValueError(
                 f"{algorithm} is not supported. "
-                f"Must be one of: {list(_ll.SUPPORTED_ALGORITHMS.keys())}"
+                f"Must be one of: {list(SUPPORTED_ALGORITHMS.keys())}"
             )
 
         self.algorithm = algo_id

--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -336,7 +336,7 @@ def open_cupy_array(
         exist); 'w' means create (overwrite if exists); 'w-' means create
         (fail if exists).
     compressor
-        The compressor use when create a Zarr file or None if no compressor
+        The compressor used when creating a Zarr file or None if no compressor
         is to be used. If a `CompatCompressor` is given, `CompatCompressor.gpu`
         is used for compression and decompression; and `CompatCompressor.cpu`
         is written as the compressor in the Zarr file metadata on disk.

--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -5,7 +5,7 @@ import contextlib
 import os
 import os.path
 from abc import abstractmethod
-from typing import Any, Literal, Mapping, Optional, Sequence
+from typing import Any, Literal, Mapping, Optional, Sequence, Union
 
 import cupy
 import numcodecs
@@ -175,7 +175,7 @@ lz4_gpu_compressor = NvCompBatchCodec("lz4")
 
 
 def open_cupy_array(
-    store: os.PathLike | str,
+    store: Union[os.PathLike, str],
     mode: Literal["r", "r+", "a", "w", "w-"] = "a",
     compressor: Codec = lz4_gpu_compressor,
     meta_array=cupy.empty(()),

--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -323,7 +323,7 @@ def open_cupy_array(
 
     This function is a CUDA friendly version of `zarr.open_array` that reads
     and writes to CuPy arrays. Beside the arguments listed below, the arguments
-    have the same semantic as in `zarr.open_array`.
+    have the same semantics as in `zarr.open_array`.
 
     Parameters
     ----------

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 import os
@@ -16,3 +16,13 @@ def test_hello_world(tmp_path, monkeypatch):
 
     monkeypatch.syspath_prepend(str(examples_path))
     import_module("hello_world").main(tmp_path / "test-file")
+
+
+def test_zarr_cupy_nvcomp(tmp_path, monkeypatch):
+    """Test examples/zarr_cupy_nvcomp.py"""
+
+    # `examples/zarr_cupy_nvcomp.py` requires the Zarr submodule
+    pytest.importorskip("kvikio.zarr")
+
+    monkeypatch.syspath_prepend(str(examples_path))
+    import_module("zarr_cupy_nvcomp").main(tmp_path / "test-file")

--- a/python/tests/test_zarr.py
+++ b/python/tests/test_zarr.py
@@ -220,6 +220,7 @@ def test_open_cupy_array(tmp_path):
         shape=a.shape,
         dtype=a.dtype,
         chunks=(2,),
+        compressor=kvikio_zarr.CompatCompressor.lz4(),
     )
     z[:] = a
     assert a.shape == z.shape
@@ -242,5 +243,5 @@ def test_open_cupy_array(tmp_path):
     assert a.shape == z.shape
     assert a.dtype == z.dtype
     assert isinstance(z[:], numpy.ndarray)
-    assert z.compressor == kvikio_zarr.lz4_cpu_compressor
+    assert z.compressor == kvikio_zarr.CompatCompressor.lz4().cpu
     numpy.testing.assert_array_equal(a.get(), z[:])

--- a/python/tests/test_zarr.py
+++ b/python/tests/test_zarr.py
@@ -4,12 +4,14 @@
 
 import math
 
+import numpy
 import pytest
 
 cupy = pytest.importorskip("cupy")
 zarr = pytest.importorskip("zarr")
 kvikio_zarr = pytest.importorskip("kvikio.zarr")
-
+kvikio_nvcomp_codec = pytest.importorskip("kvikio.nvcomp_codec")
+numcodecs = pytest.importorskip("numcodecs")
 
 if not kvikio_zarr.supported:
     pytest.skip(
@@ -156,3 +158,89 @@ def test_compressor(store, xp_write, xp_read, compressor):
     b = z[:]
     assert isinstance(b, xp_read.ndarray)
     cupy.testing.assert_array_equal(b, a)
+
+
+@pytest.mark.parametrize("algo", ["lz4", "zstd"])
+def test_decompressor_config_overwrite(tmp_path, xp, algo):
+    cpu_codec = numcodecs.registry.get_codec({"id": algo})
+    gpu_codec = kvikio_nvcomp_codec.NvCompBatchCodec(algo)
+
+    # Write using Zarr's default file store and the `cpu_codec` compressor
+    z = zarr.open_array(tmp_path, mode="w", shape=(10,), compressor=cpu_codec)
+    z[:] = range(10)
+    assert z.compressor == cpu_codec
+
+    # Open file using GDSStore and use `gpu_codec` as decompressor.
+    z = zarr.open_array(
+        kvikio_zarr.GDSStore(
+            tmp_path,
+            decompressor_config_overwrite=gpu_codec.get_config(),
+        ),
+        mode="r",
+        meta_array=xp.empty(()),
+    )
+    assert z.compressor == gpu_codec
+    assert isinstance(z[:], xp.ndarray)
+    xp.testing.assert_array_equal(z[:], range(10))
+
+
+@pytest.mark.parametrize("algo", ["lz4"])
+def test_compressor_config_overwrite(tmp_path, xp, algo):
+    cpu_codec = numcodecs.registry.get_codec({"id": algo})
+    gpu_codec = kvikio_nvcomp_codec.NvCompBatchCodec(algo)
+
+    # Write file using GDSStore and the `gpu_codec` compressor. In order
+    # to make the file compatible with Zarr's builtin CPU decompressor,
+    # we set `cpu_codec` as the compressor in the meta file on disk.
+    z = zarr.open_array(
+        kvikio_zarr.GDSStore(
+            tmp_path,
+            compressor_config_overwrite=cpu_codec.get_config(),
+            decompressor_config_overwrite=gpu_codec.get_config(),
+        ),
+        mode="w",
+        shape=10,
+        compressor=gpu_codec,
+        meta_array=xp.empty(()),
+    )
+    assert z.compressor == gpu_codec
+    z[:] = xp.arange(10)
+
+    # We can now open the file using Zarr's builtin CPU decompressor
+    z = zarr.open_array(tmp_path, mode="r")
+    assert isinstance(z[:], numpy.ndarray)
+    numpy.testing.assert_array_equal(z[:], range(10))
+
+
+def test_open_cupy_array(tmp_path):
+    a = cupy.arange(10)
+    z = kvikio_zarr.open_cupy_array(
+        tmp_path,
+        mode="w",
+        shape=a.shape,
+        dtype=a.dtype,
+        chunks=(2,),
+    )
+    z[:] = a
+    assert a.shape == z.shape
+    assert a.dtype == z.dtype
+    assert isinstance(z[:], type(a))
+    assert z.compressor == kvikio_nvcomp_codec.NvCompBatchCodec("lz4")
+    cupy.testing.assert_array_equal(a, z[:])
+
+    z = kvikio_zarr.open_cupy_array(
+        tmp_path,
+        mode="r",
+    )
+    assert a.shape == z.shape
+    assert a.dtype == z.dtype
+    assert isinstance(z[:], type(a))
+    assert z.compressor == kvikio_nvcomp_codec.NvCompBatchCodec("lz4")
+    cupy.testing.assert_array_equal(a, z[:])
+
+    z = zarr.open_array(tmp_path, mode="r")
+    assert a.shape == z.shape
+    assert a.dtype == z.dtype
+    assert isinstance(z[:], numpy.ndarray)
+    assert z.compressor == kvikio_zarr.lz4_cpu_compressor
+    numpy.testing.assert_array_equal(a.get(), z[:])


### PR DESCRIPTION
Introducing `open_cupy_array()`, which is a CUDA friendly version of `zarr.open_array` that reads and writes to CuPy arrays.
