### PR TITLE
Update to clang 16.0.6.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
                 "python/benchmarks"]
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.4
+    rev: v16.0.6
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]


### PR DESCRIPTION
This PR updates kvikio to use clang 16.0.6. The previous version has some minor formatting issues affecting several RAPIDS repos.