### PR TITLE
Use branch-23.10 for devcontainers workflow.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -60,7 +60,7 @@ jobs:
       run_script: "ci/build_docs.sh"
   devcontainer:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/build-in-devcontainer.yaml@fea/devcontainers
+    uses: rapidsai/shared-action-workflows/.github/workflows/build-in-devcontainer.yaml@branch-23.10
     with:
       build_command: |
         sccache -z;


### PR DESCRIPTION
https://github.com/rapidsai/shared-action-workflows/pull/122 was merged, so the devcontainers workflow should use `branch-23.10` for the release.