### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -60,7 +60,7 @@ jobs:
       run_script: "ci/build_docs.sh"
   devcontainer:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/build-in-devcontainer.yaml@fea/devcontainers
+    uses: rapidsai/shared-action-workflows/.github/workflows/build-in-devcontainer.yaml@branch-23.10
     with:
       build_command: |
         sccache -z;


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.