### PR TITLE
Improve performance of nvCOMP batch codec.

### DIFF
--- a/python/kvikio/_lib/libnvcomp_ll.pyx
+++ b/python/kvikio/_lib/libnvcomp_ll.pyx
@@ -399,7 +399,7 @@ class nvCompBatchAlgorithmLZ4(nvCompBatchAlgorithm):
         self._set_chunk_size_header_kernel = cupy.ElementwiseKernel(
             "uint64 uncomp_chunk_size",
             "uint64 comp_chunk_ptr",
-            "((unsigned int *)comp_chunk_ptr)[0] = uncomp_chunk_size",
+            "((unsigned int *)comp_chunk_ptr)[0] = (unsigned int)uncomp_chunk_size",
             "set_chunk_size_header",
             no_return=True,
         )

--- a/python/kvikio/_lib/libnvcomp_ll.pyx
+++ b/python/kvikio/_lib/libnvcomp_ll.pyx
@@ -387,6 +387,14 @@ class nvCompBatchAlgorithmLZ4(nvCompBatchAlgorithm):
         self.options = nvcompBatchedLZ4Opts_t(data_type)
         self.has_header = has_header
 
+        # Note on LZ4 header structure: numcodecs LZ4 codec prepends
+        # a 4-byte (uint32_t) header to each compressed chunk.
+        # The header stores the size of the original (uncompressed) data:
+        # https://github.com/zarr-developers/numcodecs/blob/cb155432e36536e17a2d054c8c24b7bf6f4a7347/numcodecs/lz4.pyx#L89
+        #
+        # The following CUDA kernels read / write chunk header by
+        # casting the chunk pointer to a pointer to unsigned int.
+
         # CUDA kernel that copies uncompressed chunk size from the chunk header.
         self._get_size_from_header_kernel = cupy.ElementwiseKernel(
             "uint64 comp_chunk_ptr",

--- a/python/kvikio/_lib/libnvcomp_ll.pyx
+++ b/python/kvikio/_lib/libnvcomp_ll.pyx
@@ -143,19 +143,14 @@ class nvCompBatchAlgorithm(ABC):
             The number of chunks to compress.
         temp_buf: cp.ndarray
             The temporary GPU workspace.
-        comp_chunks: np.ndarray[uintp]
+        comp_chunks: cp.ndarray[uintp]
             (output) The list of pointers on the GPU, to the output location for each
             compressed batch item.
-        comp_chunk_sizes: np.ndarray[uint64]
+        comp_chunk_sizes: cp.ndarray[uint64]
             (output) The compressed size in bytes of each chunk.
         stream: cp.cuda.Stream
             CUDA stream.
         """
-
-        # nvCOMP requires comp_chunks pointers container and
-        # comp_chunk_sizes to be in GPU memory.
-        comp_chunks_d = cupy.array(comp_chunks, dtype=cupy.uintp)
-        comp_chunk_sizes_d = cupy.empty_like(comp_chunk_sizes)
 
         err = self._compress(
             uncomp_chunks,
@@ -163,14 +158,12 @@ class nvCompBatchAlgorithm(ABC):
             max_uncomp_chunk_bytes,
             batch_size,
             temp_buf,
-            comp_chunks_d,
-            comp_chunk_sizes_d,
+            comp_chunks,
+            comp_chunk_sizes,
             stream,
         )
         if err != nvcompStatus_t.nvcompSuccess:
             raise RuntimeError(f"Compression failed, error: {nvCompStatus(err)!r}.")
-        # Copy resulting compressed chunk sizes back to the host buffer.
-        comp_chunk_sizes[:] = comp_chunk_sizes_d.get()
 
     @abstractmethod
     def _compress(
@@ -238,9 +231,9 @@ class nvCompBatchAlgorithm(ABC):
 
         Parameters
         ----------
-        comp_chunks: np.ndarray[uintp]
+        comp_chunks: cp.ndarray[uintp]
             The pointers on the GPU, to compressed batched items.
-        comp_chunk_sizes: np.ndarray[uint64]
+        comp_chunk_sizes: cp.ndarray[uint64]
             The size in bytes of each compressed batch item.
         stream: cp.cuda.Stream
             CUDA stream.
@@ -256,15 +249,13 @@ class nvCompBatchAlgorithm(ABC):
         batch_size = len(comp_chunks)
 
         # nvCOMP requires all buffers to be in GPU memory.
-        comp_chunks_d = cupy.array(comp_chunks, dtype=cupy.uintp)
-        comp_chunk_sizes_d = cupy.array(comp_chunk_sizes, dtype=cupy.uint64)
-        uncomp_chunk_sizes_d = cupy.empty_like(comp_chunk_sizes_d)
+        uncomp_chunk_sizes = cupy.empty_like(comp_chunk_sizes)
 
         err = self._get_decomp_size(
-            comp_chunks_d,
-            comp_chunk_sizes_d,
+            comp_chunks,
+            comp_chunk_sizes,
             batch_size,
-            uncomp_chunk_sizes_d,
+            uncomp_chunk_sizes,
             stream,
         )
         if err != nvcompStatus_t.nvcompSuccess:
@@ -272,7 +263,7 @@ class nvCompBatchAlgorithm(ABC):
                 f"Could not get decompress buffer size, error: {nvCompStatus(err)!r}."
             )
 
-        return uncomp_chunk_sizes_d
+        return uncomp_chunk_sizes
 
     @abstractmethod
     def _get_decomp_size(
@@ -302,9 +293,9 @@ class nvCompBatchAlgorithm(ABC):
 
         Parameters
         ----------
-        comp_chunks: np.ndarray[uintp]
+        comp_chunks: cp.ndarray[uintp]
             The pointers on the GPU, to compressed batched items.
-        comp_chunk_sizes: np.ndarray[uint64]
+        comp_chunk_sizes: cp.ndarray[uint64]
             The size in bytes of each compressed batch item.
         batch_size: int
             The number of chunks to decompress.
@@ -323,14 +314,9 @@ class nvCompBatchAlgorithm(ABC):
             CUDA stream.
         """
 
-        # nvCOMP requires comp_chunks pointers container and
-        # comp_chunk_sizes to be in GPU memory.
-        comp_chunks_d = cupy.array(comp_chunks, dtype=cupy.uintp)
-        comp_chunk_sizes_d = cupy.array(comp_chunk_sizes, dtype=cupy.uint64)
-
         err = self._decompress(
-            comp_chunks_d,
-            comp_chunk_sizes_d,
+            comp_chunks,
+            comp_chunk_sizes,
             batch_size,
             temp_buf,
             uncomp_chunks,
@@ -407,6 +393,23 @@ class nvCompBatchAlgorithmLZ4(nvCompBatchAlgorithm):
         self.options = nvcompBatchedLZ4Opts_t(data_type)
         self.has_header = has_header
 
+        # CUDA kernel that copies uncompressed chunk size from the chunk header.
+        self._get_size_from_header_kernel = cupy.ElementwiseKernel(
+            "uint64 comp_chunk_ptr",
+            "uint64 uncomp_chunk_size",
+            "uncomp_chunk_size = *((unsigned int *)comp_chunk_ptr)",
+            "get_size_from_header",
+        )
+
+        # CUDA kernel that copies uncompressed chunk size to the chunk header.
+        self._set_chunk_size_header_kernel = cupy.ElementwiseKernel(
+            "uint64 uncomp_chunk_size",
+            "uint64 comp_chunk_ptr",
+            "((unsigned int *)comp_chunk_ptr)[0] = uncomp_chunk_size",
+            "set_chunk_size_header",
+            no_return=True,
+        )
+
     def _get_comp_temp_size(
         self,
         size_t batch_size,
@@ -455,20 +458,9 @@ class nvCompBatchAlgorithmLZ4(nvCompBatchAlgorithm):
             # 2. Update target pointers in comp_chunks to skip the header portion,
             # which is not compressed.
             #
-            # Get the base pointers to sizes.
-            psize = to_ptr(uncomp_chunk_sizes)
-            for i in range(batch_size):
-                # Copy the original data size to the header.
-                memcpyAsync(
-                    <uintptr_t>comp_chunks[i],
-                    psize,
-                    self.HEADER_SIZE_BYTES,
-                    cudaMemcpyKind.cudaMemcpyDeviceToDevice,
-                    stream.ptr
-                )
-                psize += sizeof(uint64_t)
-                # Update chunk pointer to skip the header.
-                comp_chunks[i] += self.HEADER_SIZE_BYTES
+            self._set_chunk_size_header_kernel(uncomp_chunk_sizes, comp_chunks)
+            # Update chunk pointer to skip the header.
+            comp_chunks += self.HEADER_SIZE_BYTES
 
         super().compress(
             uncomp_chunks,
@@ -482,10 +474,9 @@ class nvCompBatchAlgorithmLZ4(nvCompBatchAlgorithm):
         )
 
         if self.has_header:
-            for i in range(batch_size):
-                # Update chunk pointer and size to include the header.
-                comp_chunks[i] -= self.HEADER_SIZE_BYTES
-                comp_chunk_sizes[i] += self.HEADER_SIZE_BYTES
+            # Update chunk pointer and size to include the header.
+            comp_chunks -= self.HEADER_SIZE_BYTES
+            comp_chunk_sizes += self.HEADER_SIZE_BYTES
 
     def _compress(
         self,
@@ -541,26 +532,7 @@ class nvCompBatchAlgorithmLZ4(nvCompBatchAlgorithm):
                 stream,
             )
 
-        assert comp_chunks.shape == comp_chunk_sizes.shape
-        batch_size = len(comp_chunks)
-
-        # uncomp_chunk_sizes is uint32 array to match the type in LZ4 header.
-        uncomp_chunk_sizes = cupy.empty(batch_size, dtype=cupy.uint32)
-
-        psize = to_ptr(uncomp_chunk_sizes)
-        for i in range(batch_size):
-            # Get pointer to the header and copy the data.
-            memcpyAsync(
-                psize,
-                <uintptr_t>comp_chunks[i],
-                sizeof(uint32_t),
-                cudaMemcpyKind.cudaMemcpyDeviceToDevice,
-                stream.ptr
-            )
-            psize += sizeof(uint32_t)
-        stream.synchronize()
-
-        return uncomp_chunk_sizes.astype(cupy.uint64)
+        return self._get_size_from_header_kernel(comp_chunks)
 
     def _get_decomp_size(
         self,
@@ -591,10 +563,9 @@ class nvCompBatchAlgorithmLZ4(nvCompBatchAlgorithm):
         stream,
     ):
         if self.has_header:
-            for i in range(batch_size):
-                # Update chunk pointer and size to exclude the header.
-                comp_chunks[i] += self.HEADER_SIZE_BYTES
-                comp_chunk_sizes[i] -= self.HEADER_SIZE_BYTES
+            # Update chunk pointer and size to exclude the header.
+            comp_chunks += self.HEADER_SIZE_BYTES
+            comp_chunk_sizes -= self.HEADER_SIZE_BYTES
 
         super().decompress(
             comp_chunks,
@@ -607,12 +578,6 @@ class nvCompBatchAlgorithmLZ4(nvCompBatchAlgorithm):
             statuses,
             stream,
         )
-
-        if self.has_header:
-            for i in range(batch_size):
-                # Update chunk pointer and size to include the header.
-                comp_chunks[i] -= self.HEADER_SIZE_BYTES
-                comp_chunk_sizes[i] += self.HEADER_SIZE_BYTES
 
     def _decompress(
         self,

--- a/python/kvikio/_lib/libnvcomp_ll.pyx
+++ b/python/kvikio/_lib/libnvcomp_ll.pyx
@@ -6,17 +6,11 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import IntEnum
 
-from libc.stdint cimport uint32_t, uint64_t, uintptr_t
+from libc.stdint cimport uint32_t, uintptr_t
 
-from kvikio._lib.nvcomp_ll_cxx_api cimport (
-    cudaMemcpyKind,
-    cudaStream_t,
-    nvcompStatus_t,
-    nvcompType_t,
-)
+from kvikio._lib.nvcomp_ll_cxx_api cimport cudaStream_t, nvcompStatus_t, nvcompType_t
 
 import cupy
-from cupy.cuda.runtime import memcpyAsync
 
 
 class nvCompStatus(IntEnum):

--- a/python/kvikio/nvcomp_codec.py
+++ b/python/kvikio/nvcomp_codec.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
-from typing import Any, List, Mapping, Optional
+from typing import Any, Mapping, Optional, Sequence
 
 import cupy as cp
 import numpy as np
@@ -66,18 +66,18 @@ class NvCompBatchCodec(Codec):
         """
         return self.encode_batch([buf])[0]
 
-    def encode_batch(self, bufs: List[Any]) -> List[Any]:
+    def encode_batch(self, bufs: Sequence[Any]) -> Sequence[Any]:
         """Encode data in `bufs` using nvCOMP.
 
         Parameters
         ----------
-        bufs : List[buffer-like].
+        bufs : Sequence[buffer-like].
             Data to be encoded. Each buffer in the list may be any object
             supporting the new-style buffer protocol.
 
         Returns
         -------
-        enc : List[buffer-like]
+        enc : Sequence[buffer-like]
             List of encoded buffers. Each buffer may be any object supporting
             the new-style buffer protocol.
         """
@@ -104,9 +104,9 @@ class NvCompBatchCodec(Codec):
 
         comp_chunks = cp.empty((num_chunks, comp_chunk_size), dtype=cp.uint8)
         # Array of pointers to each compressed chunk.
-        comp_chunk_ptrs = np.array([c.data.ptr for c in comp_chunks], dtype=cp.uintp)
+        comp_chunk_ptrs = cp.array([c.data.ptr for c in comp_chunks], dtype=cp.uintp)
         # Resulting compressed chunk sizes.
-        comp_chunk_sizes = np.empty(num_chunks, dtype=np.uint64)
+        comp_chunk_sizes = cp.empty(num_chunks, dtype=cp.uint64)
 
         self._algo.compress(
             uncomp_chunks,
@@ -120,6 +120,11 @@ class NvCompBatchCodec(Codec):
         )
 
         res = []
+        # Copy to host to subsequently avoid many smaller D2H copies.
+        comp_chunks = cp.asnumpy(comp_chunks, self._stream)
+        comp_chunk_sizes = cp.asnumpy(comp_chunk_sizes, self._stream)
+        self._stream.synchronize()
+
         for i in range(num_chunks):
             res.append(comp_chunks[i, : comp_chunk_sizes[i]].tobytes())
         return res
@@ -145,23 +150,23 @@ class NvCompBatchCodec(Codec):
         return self.decode_batch([buf], [out])[0]
 
     def decode_batch(
-        self, bufs: List[Any], out: Optional[List[Any]] = None
-    ) -> List[Any]:
+        self, bufs: Sequence[Any], out: Optional[Sequence[Any]] = None
+    ) -> Sequence[Any]:
         """Decode data in `bufs` using nvCOMP.
 
         Parameters
         ----------
-        bufs : List[buffer-like]
+        bufs : Sequence[buffer-like]
             Encoded data. Each buffer in the list may be any object
             supporting the new-style buffer protocol.
-        out : List[buffer-like], optional
+        out : Sequence[buffer-like], optional
             List of writeable buffers to store decoded data.
             N.B. if provided, each buffer must be exactly the right size
             to store the decoded data.
 
         Returns
         -------
-        dec : List[buffer-like]
+        dec : Sequence[buffer-like]
             List of decoded buffers. Each buffer may be any object supporting
             the new-style buffer protocol.
         """
@@ -176,8 +181,8 @@ class NvCompBatchCodec(Codec):
             bufs = [cp.asarray(ensure_contiguous_ndarray_like(b)) for b in bufs]
 
         # Prepare compressed chunks buffers.
-        comp_chunks = np.array([b.data.ptr for b in bufs], dtype=np.uintp)
-        comp_chunk_sizes = np.array([b.size for b in bufs], dtype=np.uint64)
+        comp_chunks = cp.array([b.data.ptr for b in bufs], dtype=cp.uintp)
+        comp_chunk_sizes = cp.array([b.size for b in bufs], dtype=cp.uint64)
 
         # Get uncompressed chunk sizes.
         uncomp_chunk_sizes = self._algo.get_decompress_size(
@@ -185,10 +190,12 @@ class NvCompBatchCodec(Codec):
             comp_chunk_sizes,
             self._stream,
         )
-        # Copy to host since we'll need it to properly allocate buffers.
-        uncomp_chunk_sizes_h = uncomp_chunk_sizes.get()
 
-        max_chunk_size = uncomp_chunk_sizes_h.max()
+        # Check whether the uncompressed chunks are all the same size.
+        # cupy.unique returns sorted sizes.
+        sorted_chunk_sizes = cp.unique(uncomp_chunk_sizes)
+        max_chunk_size = sorted_chunk_sizes[-1].item()
+        is_equal_chunks = sorted_chunk_sizes.shape[0] == 1
 
         # Get temp buffer size.
         temp_size = self._algo.get_decompress_temp_size(num_chunks, max_chunk_size)
@@ -196,14 +203,14 @@ class NvCompBatchCodec(Codec):
         temp_buf = cp.empty(temp_size, dtype=cp.uint8)
 
         # Prepare uncompressed chunks buffers.
-        # First, allocate chunks of appropriate sizes and then
+        # First, allocate chunks of max_chunk_size and then
         # copy the pointers to a pointer array in GPU memory as required by nvCOMP.
-        # TODO(akamenev): probably can allocate single contiguous buffer.
-        uncomp_chunks = [
-            cp.empty(size, dtype=cp.uint8) for size in uncomp_chunk_sizes_h
-        ]
-        uncomp_chunk_ptrs = cp.array(
-            [c.data.ptr for c in uncomp_chunks], dtype=cp.uintp
+        # For performance reasons, we use max_chunk_size so we can create
+        # a rectangular array with the same pointer increments.
+        uncomp_chunks = cp.empty((num_chunks, max_chunk_size), dtype=cp.uint8)
+        p_start = uncomp_chunks.data.ptr
+        uncomp_chunk_ptrs = p_start + (
+            cp.arange(0, num_chunks * max_chunk_size, max_chunk_size)
         )
 
         # TODO(akamenev): currently we provide the following 2 buffers to decompress()
@@ -226,20 +233,23 @@ class NvCompBatchCodec(Codec):
             self._stream,
         )
 
+        # If all chunks are the same size, we can just return uncomp_chunks.
+        if is_equal_chunks and out is None:
+            return cp.asnumpy(uncomp_chunks) if is_host_buffer else uncomp_chunks
+
         res = []
         for i in range(num_chunks):
-            ret = uncomp_chunks[i]
-            if out is not None and out[i] is not None:
+            ret = uncomp_chunks[i, : uncomp_chunk_sizes[i].item()]
+            if out is None or out[i] is None:
+                res.append(cp.asnumpy(ret) if is_host_buffer else ret)
+            else:
                 o = ensure_contiguous_ndarray_like(out[i])
                 if hasattr(o, "__cuda_array_interface__"):
                     cp.copyto(o, ret.view(dtype=o.dtype), casting="no")
                 else:
+                    # TODO(akamenev): remove redundant H2H copy?
                     np.copyto(o, cp.asnumpy(ret.view(dtype=o.dtype)), casting="no")
                 res.append(o)
-            elif is_host_buffer:
-                res.append(cp.asnumpy(ret))
-            else:
-                res.append(ret)
 
         return res
 

--- a/python/kvikio/nvcomp_codec.py
+++ b/python/kvikio/nvcomp_codec.py
@@ -71,13 +71,12 @@ class NvCompBatchCodec(Codec):
 
         Parameters
         ----------
-        bufs : Sequence[buffer-like].
+        bufs :
             Data to be encoded. Each buffer in the list may be any object
             supporting the new-style buffer protocol.
 
         Returns
         -------
-        enc : Sequence[buffer-like]
             List of encoded buffers. Each buffer may be any object supporting
             the new-style buffer protocol.
         """
@@ -156,17 +155,16 @@ class NvCompBatchCodec(Codec):
 
         Parameters
         ----------
-        bufs : Sequence[buffer-like]
+        bufs :
             Encoded data. Each buffer in the list may be any object
             supporting the new-style buffer protocol.
-        out : Sequence[buffer-like], optional
+        out :
             List of writeable buffers to store decoded data.
             N.B. if provided, each buffer must be exactly the right size
             to store the decoded data.
 
         Returns
         -------
-        dec : Sequence[buffer-like]
             List of decoded buffers. Each buffer may be any object supporting
             the new-style buffer protocol.
         """


### PR DESCRIPTION
This PR contains a set of performance-related improvements for the batch nvCOMP codec.
The short summary of the changes:
* Replaced multiple calls to CUDA  `memcpyAsync` with a single call to a CUDA kernel.
* Removed redundant memory allocations and copies (some of them are the result of the previous change).
* Vectorized loops, removed redundant loops.

As a result, decompression throughput on ERA5 data increased from **4** GB/s to **31** GB/s for LZ4 algorithm. For highly-compressible data from [nvCOMP benchmark](https://github.com/NVIDIA/nvcomp/blob/main/doc/Benchmarks.md), the increase is even higher: from **6** GB/s to about **110** GB/s. Other algorithms, such as GDeflate, show performance improvements as well.

Compression throughput was also improved, though the main target was decompression (compress once - decompress many kind of scenario).

Limitations: 
* these improvements are available only when directly using the codec's batch methods, such as `decode_batch` while passing reasonably-sized batches to saturate the GPU. That means these changes will not be available (for now) to `zarr` users as `zarr` serializes the calls into a sequence of `decode` calls.
* to get maximum performance, users should use equal-sized chunks (this is the default behavior in most of the cases anyway, such as `zarr`).