### PR TITLE
Unify the CUDA Codecs

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==========
 
-KvikIO can be used inplace of Python's built-in `open() <https://docs.python.org/3/library/functions.html#open>`_ function with the caveat that a file is always opened in binary (``"b"``) mode.
+KvikIO can be used in place of Python's built-in `open() <https://docs.python.org/3/library/functions.html#open>`_ function with the caveat that a file is always opened in binary (``"b"``) mode.
 In order to open a file, use KvikIO's filehandle :py:meth:`kvikio.cufile.CuFile`.
 
 .. code-block:: python

--- a/python/kvikio/numcodecs.py
+++ b/python/kvikio/numcodecs.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+
+"""
+This module implements CUDA compression and transformation codecs for Numcodecs.
+See <https://numcodecs.readthedocs.io/en/stable/>
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, Optional, Union
+
+import cupy.typing
+import numpy.typing
+from numcodecs.abc import Codec
+
+# TODO: replace `ANY` with `collections.abc.Buffer` from PEP-688
+# when it becomes available.
+BufferLike = Union[cupy.typing.NDArray, numpy.typing.ArrayLike, Any]
+
+
+class CudaCodec(Codec):
+    """Abstract base class for CUDA codecs"""
+
+    @abstractmethod
+    def encode(self, buf: BufferLike) -> cupy.typing.NDArray:
+        """Encode `buf` using CUDA.
+
+        Parameters
+        ----------
+        buf
+            A numpy array like object such as numpy.ndarray, cupy.ndarray,
+            or any object exporting a buffer interface.
+
+        Returns
+        -------
+        The compressed buffer wrapped in a CuPy array
+        """
+
+    @abstractmethod
+    def decode(self, buf: BufferLike, out: Optional[BufferLike] = None) -> BufferLike:
+        """Encode `buf` using CUDA.
+
+        Parameters
+        ----------
+        buf
+            A numpy array like object such as numpy.ndarray, cupy.ndarray,
+            or any object exporting a buffer interface.
+        out
+            A numpy array like object such as numpy.ndarray, cupy.ndarray,
+            or any object exporting a buffer interface. If provided, this buffer must
+            be exactly the right size to store the decoded data.
+
+        Returns
+        -------
+            Decoded data, which is either host or device memory based on the type
+            of `out`. If `out` is None, the type of `buf` determines the return buffer
+            type.
+        """

--- a/python/kvikio/nvcomp_codec.py
+++ b/python/kvikio/nvcomp_codec.py
@@ -4,14 +4,15 @@
 from typing import Any, List, Mapping, Optional
 
 import cupy as cp
+import cupy.typing
 import numpy as np
-from numcodecs.abc import Codec
 from numcodecs.compat import ensure_contiguous_ndarray_like
 
 from kvikio._lib.libnvcomp_ll import SUPPORTED_ALGORITHMS
+from kvikio.numcodecs import BufferLike, CudaCodec
 
 
-class NvCompBatchCodec(Codec):
+class NvCompBatchCodec(CudaCodec):
     """Codec that uses batch algorithms from nvCOMP library.
 
     An algorithm is selected using `algorithm` parameter.
@@ -49,21 +50,7 @@ class NvCompBatchCodec(Codec):
         # Use default stream, if needed.
         self._stream = stream if stream is not None else cp.cuda.Stream.ptds
 
-    def encode(self, buf):
-        """Encode data in `buf` using nvCOMP.
-
-        Parameters
-        ----------
-        buf : buffer-like
-            Data to be encoded. May be any object supporting the new-style
-            buffer protocol.
-
-        Returns
-        -------
-        enc : buffer-like
-            Encoded data. May be any object supporting the new-style buffer
-            protocol.
-        """
+    def encode(self, buf: BufferLike) -> cupy.typing.NDArray:
         return self.encode_batch([buf])[0]
 
     def encode_batch(self, bufs: List[Any]) -> List[Any]:
@@ -124,24 +111,7 @@ class NvCompBatchCodec(Codec):
             res.append(comp_chunks[i, : comp_chunk_sizes[i]].tobytes())
         return res
 
-    def decode(self, buf, out=None):
-        """Decode data in `buf` using nvCOMP.
-
-        Parameters
-        ----------
-        buf : buffer-like
-            Encoded data. May be any object supporting the new-style buffer
-            protocol.
-        out : buffer-like, optional
-            Writeable buffer to store decoded data. N.B. if provided, this buffer must
-            be exactly the right size to store the decoded data.
-
-        Returns
-        -------
-        dec : buffer-like
-            Decoded data. May be any object supporting the new-style
-            buffer protocol.
-        """
+    def decode(self, buf: BufferLike, out: Optional[BufferLike] = None) -> BufferLike:
         return self.decode_batch([buf], [out])[0]
 
     def decode_batch(

--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -381,6 +381,12 @@ def open_cupy_array(
                 meta_array=meta_array,
                 **kwargs,
             )
+        elif not isinstance(ret.compressor, CudaCodec):
+            raise ValueError(
+                "The Zarr file was written using a non-CUDA compatible "
+                f"compressor, {ret.compressor}, please use something "
+                "like kvikio.zarr.CompatCompressor"
+            )
         return ret
 
     if isinstance(compressor, CompatCompressor):

--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -24,6 +24,7 @@ import kvikio
 import kvikio.nvcomp
 import kvikio.nvcomp_codec
 import kvikio.zarr
+from kvikio.numcodecs import BufferLike, CudaCodec
 from kvikio.nvcomp_codec import NvCompBatchCodec
 
 MINIMUM_ZARR_VERSION = "2.15"
@@ -171,7 +172,7 @@ class GDSStore(zarr.storage.DirectoryStore):
         return ret
 
 
-class NVCompCompressor(Codec):
+class NVCompCompressor(CudaCodec):
     """Abstract base class for nvCOMP compressors
 
     The derived classes must set `codec_id` and implement
@@ -197,7 +198,7 @@ class NVCompCompressor(Codec):
         """
         pass  # TODO: cache Manager
 
-    def encode(self, buf) -> cupy.ndarray:
+    def encode(self, buf: BufferLike) -> cupy.typing.NDArray:
         """Compress using `get_nvcomp_manager()`
 
         Parameters
@@ -302,7 +303,7 @@ for c in nvcomp_compressors:
 class CompatCompressor:
     """A pair of compatible compressors one using the CPU and one using the GPU"""
 
-    def __init__(self, cpu: Codec, gpu: Codec) -> None:
+    def __init__(self, cpu: Codec, gpu: CudaCodec) -> None:
         self.cpu = cpu
         self.gpu = gpu
 

--- a/python/tests/test_zarr.py
+++ b/python/tests/test_zarr.py
@@ -245,3 +245,11 @@ def test_open_cupy_array(tmp_path):
     assert isinstance(z[:], numpy.ndarray)
     assert z.compressor == kvikio_zarr.CompatCompressor.lz4().cpu
     numpy.testing.assert_array_equal(a.get(), z[:])
+
+
+@pytest.mark.parametrize("mode", ["r", "r+"])
+def test_open_cupy_array_incompatible_compressor(tmp_path, mode):
+    zarr.create((10,), store=tmp_path, compressor=numcodecs.Blosc())
+
+    with pytest.raises(ValueError, match="non-CUDA compatible compressor"):
+        kvikio_zarr.open_cupy_array(tmp_path, mode=mode)

--- a/python/tests/test_zarr.py
+++ b/python/tests/test_zarr.py
@@ -212,11 +212,13 @@ def test_compressor_config_overwrite(tmp_path, xp, algo):
     numpy.testing.assert_array_equal(z[:], range(10))
 
 
-def test_open_cupy_array(tmp_path):
+@pytest.mark.parametrize("write_mode", ["w", "w-", "a"])
+@pytest.mark.parametrize("read_mode", ["r", "r+", "a"])
+def test_open_cupy_array(tmp_path, write_mode, read_mode):
     a = cupy.arange(10)
     z = kvikio_zarr.open_cupy_array(
         tmp_path,
-        mode="w",
+        mode=write_mode,
         shape=a.shape,
         dtype=a.dtype,
         chunks=(2,),
@@ -231,7 +233,7 @@ def test_open_cupy_array(tmp_path):
 
     z = kvikio_zarr.open_cupy_array(
         tmp_path,
-        mode="r",
+        mode=read_mode,
     )
     assert a.shape == z.shape
     assert a.dtype == z.dtype
@@ -239,7 +241,7 @@ def test_open_cupy_array(tmp_path):
     assert z.compressor == kvikio_nvcomp_codec.NvCompBatchCodec("lz4")
     cupy.testing.assert_array_equal(a, z[:])
 
-    z = zarr.open_array(tmp_path, mode="r")
+    z = zarr.open_array(tmp_path, mode=read_mode)
     assert a.shape == z.shape
     assert a.dtype == z.dtype
     assert isinstance(z[:], numpy.ndarray)
@@ -247,7 +249,7 @@ def test_open_cupy_array(tmp_path):
     numpy.testing.assert_array_equal(a.get(), z[:])
 
 
-@pytest.mark.parametrize("mode", ["r", "r+"])
+@pytest.mark.parametrize("mode", ["r", "r+", "a"])
 def test_open_cupy_array_incompatible_compressor(tmp_path, mode):
     zarr.create((10,), store=tmp_path, compressor=numcodecs.Blosc())
 


### PR DESCRIPTION
It this PR we introduce `CudaCodec`, which is a base class for all CUDA Condecs/Compressors.
This makes it possible to detect if an user tries to open a Zarr file using an incompatible compressor (see https://github.com/rapidsai/kvikio/issues/297). 

Additionally, `kvikio.zarr.open_cupy_array()` now handles `mode="a"`

