### PR TITLE
Add numcodecs pin

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -22,7 +22,7 @@ dependencies:
 - libcufile-dev=1.4.0.31
 - libcufile=1.4.0.31
 - ninja
-- numcodecs <=0.12.0
+- numcodecs <0.12.0
 - numpy>=1.21
 - numpydoc
 - nvcc_linux-64=11.8

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - libcufile-dev=1.4.0.31
 - libcufile=1.4.0.31
 - ninja
+- numcodecs <=0.12.0
 - numpy>=1.21
 - numpydoc
 - nvcc_linux-64=11.8

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - libcufile
 - libcufile-dev
 - ninja
+- numcodecs <=0.12.0
 - numpy>=1.21
 - numpydoc
 - nvcomp==2.6.1

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -22,7 +22,7 @@ dependencies:
 - libcufile
 - libcufile-dev
 - ninja
-- numcodecs <=0.12.0
+- numcodecs <0.12.0
 - numpy>=1.21
 - numpydoc
 - nvcomp==2.6.1

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -70,6 +70,8 @@ requirements:
     - numpy >=1.20
     - cupy >=12.0.0
     - zarr
+    # See https://github.com/zarr-developers/numcodecs/pull/475
+    - numcodecs <0.12.0
     - packaging
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
     {% if cuda_major == "11" %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -265,7 +265,7 @@ dependencies:
           - numpy>=1.21
           - zarr
           # See https://github.com/zarr-developers/numcodecs/pull/475
-          - numcodecs <=0.12.0
+          - numcodecs <0.12.0
           - packaging
       - output_types: conda
         packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -264,6 +264,8 @@ dependencies:
         packages:
           - numpy>=1.21
           - zarr
+          # See https://github.com/zarr-developers/numcodecs/pull/475
+          - numcodecs <=0.12.0
           - packaging
       - output_types: conda
         packages:

--- a/legate/pyproject.toml
+++ b/legate/pyproject.toml
@@ -24,6 +24,7 @@ license = { text = "Apache 2.0" }
 requires-python = ">=3.9"
 dependencies = [
     "cupy-cuda11x>=12.0.0",
+    "numcodecs <=0.12.0",
     "numpy>=1.21",
     "packaging",
     "zarr",

--- a/legate/pyproject.toml
+++ b/legate/pyproject.toml
@@ -24,7 +24,7 @@ license = { text = "Apache 2.0" }
 requires-python = ">=3.9"
 dependencies = [
     "cupy-cuda11x>=12.0.0",
-    "numcodecs <=0.12.0",
+    "numcodecs <0.12.0",
     "numpy>=1.21",
     "packaging",
     "zarr",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,6 +24,7 @@ license = { text = "Apache 2.0" }
 requires-python = ">=3.9"
 dependencies = [
     "cupy-cuda11x>=12.0.0",
+    "numcodecs <=0.12.0",
     "numpy>=1.21",
     "packaging",
     "zarr",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ license = { text = "Apache 2.0" }
 requires-python = ">=3.9"
 dependencies = [
     "cupy-cuda11x>=12.0.0",
-    "numcodecs <=0.12.0",
+    "numcodecs <0.12.0",
     "numpy>=1.21",
     "packaging",
     "zarr",


### PR DESCRIPTION
numcodecs 0.12 appears to have some breaking changes. I've submitted a fix upstream, but for this release of RAPIDS we'll need to upper bound the version to be safe.

xref: https://github.com/zarr-developers/numcodecs/pull/475