### PR TITLE
Update rapids-cmake functions to non-deprecated signatures

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -125,12 +125,10 @@ install(FILES ${KvikIO_BINARY_DIR}/include/kvikio/version_config.hpp DESTINATION
 
 include("${rapids-cmake-dir}/export/find_package_file.cmake")
 rapids_export_find_package_file(
-  BUILD "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake"
-  EXPORT_SET kvikio-exports
+  BUILD "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" EXPORT_SET kvikio-exports
 )
 rapids_export_find_package_file(
-  INSTALL "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake"
-  EXPORT_SET kvikio-exports
+  INSTALL "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" EXPORT_SET kvikio-exports
 )
 
 set(doc_string

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -125,10 +125,12 @@ install(FILES ${KvikIO_BINARY_DIR}/include/kvikio/version_config.hpp DESTINATION
 
 include("${rapids-cmake-dir}/export/find_package_file.cmake")
 rapids_export_find_package_file(
-  BUILD "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" kvikio-exports
+  BUILD "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake"
+  EXPORT_SET kvikio-exports
 )
 rapids_export_find_package_file(
-  INSTALL "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake" kvikio-exports
+  INSTALL "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindcuFile.cmake"
+  EXPORT_SET kvikio-exports
 )
 
 set(doc_string

--- a/cpp/cmake/thirdparty/get_gtest.cmake
+++ b/cpp/cmake/thirdparty/get_gtest.cmake
@@ -32,7 +32,8 @@ function(find_and_configure_gtest)
 
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
     rapids_export_find_package_root(
-      BUILD GTest [=[${CMAKE_CURRENT_LIST_DIR}]=] kvikio-testing-exports
+      BUILD GTest [=[${CMAKE_CURRENT_LIST_DIR}]=]
+      EXPORT_SET kvikio-testing-exports
     )
   endif()
 

--- a/cpp/cmake/thirdparty/get_gtest.cmake
+++ b/cpp/cmake/thirdparty/get_gtest.cmake
@@ -32,8 +32,7 @@ function(find_and_configure_gtest)
 
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
     rapids_export_find_package_root(
-      BUILD GTest [=[${CMAKE_CURRENT_LIST_DIR}]=]
-      EXPORT_SET kvikio-testing-exports
+      BUILD GTest [=[${CMAKE_CURRENT_LIST_DIR}]=] EXPORT_SET kvikio-testing-exports
     )
   endif()
 


### PR DESCRIPTION
Update to use non deprecated signatures for `rapids_export` functions