### PR TITLE
Support no compressor in `open_cupy_array()`

### DIFF
--- a/python/examples/zarr_cupy_nvcomp.py
+++ b/python/examples/zarr_cupy_nvcomp.py
@@ -30,6 +30,9 @@ def main(path):
     # E.g., `open_cupy_array()` uses nvCOMP's Snappy GPU compression by default,
     # which, as far as we know, isn’t compatible with any CPU compressor. Thus,
     # let's re-write our Zarr array using a CPU and GPU compatible compressor.
+    # Warning: `CompatCompressor` is only supported by KvikIO's `open_cupy_array()`
+    #          and cannot be used as a compressor argument in Zarr functions like
+    #          `open()` and `open_array()`.
     z = kvikio.zarr.open_cupy_array(
         store=path,
         mode="w",

--- a/python/examples/zarr_cupy_nvcomp.py
+++ b/python/examples/zarr_cupy_nvcomp.py
@@ -30,9 +30,11 @@ def main(path):
     # E.g., `open_cupy_array()` uses nvCOMP's Snappy GPU compression by default,
     # which, as far as we know, isn’t compatible with any CPU compressor. Thus,
     # let's re-write our Zarr array using a CPU and GPU compatible compressor.
+    #
     # Warning: `CompatCompressor` is only supported by KvikIO's `open_cupy_array()`
     #          and cannot be used as a compressor argument in Zarr functions like
-    #          `open()` and `open_array()`.
+    #          `open()` and `open_array()` directly. However, it is possible to use
+    #          its `.cpu` like: `open(..., compressor=CompatCompressor.lz4().cpu)`.
     z = kvikio.zarr.open_cupy_array(
         store=path,
         mode="w",

--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -280,7 +280,8 @@ class CompatCompressor:
     -------
     `CompatCompressor` is only supported by KvikIO's `open_cupy_array()` and
     cannot be used as a compressor argument in Zarr functions like `open()`
-    and `open_array()`.
+    and `open_array()` directly. However, it is possible to use its `.cpu`
+    like: `open(..., compressor=CompatCompressor.lz4().cpu)`.
 
     Parameters
     ----------

--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -274,7 +274,21 @@ for c in nvcomp_compressors:
 
 
 class CompatCompressor:
-    """A pair of compatible compressors one using the CPU and one using the GPU"""
+    """A pair of compatible compressors one using the CPU and one using the GPU
+
+    Warning
+    -------
+    `CompatCompressor` is only supported by KvikIO's `open_cupy_array()` and
+    cannot be used as a compressor argument in Zarr functions like `open()`
+    and `open_array()`.
+
+    Parameters
+    ----------
+    cpu
+        The CPU compressor.
+    gpu
+        The GPU compressor.
+    """
 
     def __init__(self, cpu: Codec, gpu: CudaCodec) -> None:
         self.cpu = cpu

--- a/python/kvikio/zarr.py
+++ b/python/kvikio/zarr.py
@@ -362,6 +362,8 @@ def open_cupy_array(
             if mode in ("r", "r+"):
                 raise
         else:
+            if ret.compressor is None:
+                return ret
             # If we are reading a LZ4-CPU compressed file, we overwrite the
             # metadata on-the-fly to make Zarr use LZ4-GPU for both compression
             # and decompression.

--- a/python/tests/test_zarr.py
+++ b/python/tests/test_zarr.py
@@ -249,6 +249,21 @@ def test_open_cupy_array(tmp_path, write_mode, read_mode):
     numpy.testing.assert_array_equal(a.get(), z[:])
 
 
+def test_open_cupy_array_written_by_zarr(tmp_path):
+    data = numpy.arange(100)
+    z = zarr.open_array(
+        tmp_path,
+        shape=data.shape,
+        mode="w",
+        compressor=kvikio_zarr.CompatCompressor.lz4().cpu,
+    )
+    z[:] = data
+
+    z = kvikio_zarr.open_cupy_array(tmp_path, mode="r")
+    assert isinstance(z[:], cupy.ndarray)
+    cupy.testing.assert_array_equal(z[:], data)
+
+
 @pytest.mark.parametrize("mode", ["r", "r+", "a"])
 def test_open_cupy_array_incompatible_compressor(tmp_path, mode):
     zarr.create((10,), store=tmp_path, compressor=numcodecs.Blosc())

--- a/python/tests/test_zarr.py
+++ b/python/tests/test_zarr.py
@@ -249,13 +249,14 @@ def test_open_cupy_array(tmp_path, write_mode, read_mode):
     numpy.testing.assert_array_equal(a.get(), z[:])
 
 
-def test_open_cupy_array_written_by_zarr(tmp_path):
+@pytest.mark.parametrize("compressor", [None, kvikio_zarr.CompatCompressor.lz4().cpu])
+def test_open_cupy_array_written_by_zarr(tmp_path, compressor):
     data = numpy.arange(100)
     z = zarr.open_array(
         tmp_path,
         shape=data.shape,
         mode="w",
-        compressor=kvikio_zarr.CompatCompressor.lz4().cpu,
+        compressor=compressor,
     )
     z[:] = data
 


### PR DESCRIPTION
... also added some more examples.