### PR TITLE
Update nvcomp to 3.0.4.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
       - conda-python-build
       - conda-python-tests
       - docs-build
-      - devcontainer
+#     - devcontainer
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-23.12
   checks:
@@ -58,11 +58,11 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/build_docs.sh"
-  devcontainer:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-23.12
-    with:
-      build_command: |
-        sccache -z;
-        build-all;
-        sccache -s;
+# devcontainer:
+#   secrets: inherit
+#   uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-23.12
+#   with:
+#     build_command: |
+#       sccache -z;
+#       build-all;
+#       sccache -s;

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - numpy>=1.21
 - numpydoc
 - nvcc_linux-64=11.8
-- nvcomp==2.6.1
+- nvcomp==3.0.4
 - packaging
 - pre-commit
 - pytest

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - numcodecs <0.12.0
 - numpy>=1.21
 - numpydoc
-- nvcomp==2.6.1
+- nvcomp==3.0.4
 - packaging
 - pre-commit
 - pytest

--- a/conda/recipes/kvikio/conda_build_config.yaml
+++ b/conda/recipes/kvikio/conda_build_config.yaml
@@ -17,4 +17,4 @@ cmake_version:
   - ">=3.26.4"
 
 nvcomp_version:
-  - "=2.6.1"
+  - "=3.0.4"

--- a/cpp/cmake/fetch_rapids.cmake
+++ b/cpp/cmake/fetch_rapids.cmake
@@ -11,6 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+set(rapids-cmake-repo vuule/rapids-cmake)
+set(rapids-cmake-branch upgrade-nvcomp-3.0.0)
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.12/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -142,7 +142,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - nvcomp==2.6.1
+          - nvcomp==3.0.4
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
## Description
Update the nvCOMP version used for compression/decompression to 3.0.4.

See also:
- https://github.com/rapidsai/cudf/pull/13815
- https://github.com/rapidsai/rapids-cmake/pull/451