### PR TITLE
Update nvcomp to 3.0.4 (includes API changes)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
       - conda-python-build
       - conda-python-tests
       - docs-build
-      - devcontainer
+#     - devcontainer
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-23.12
   checks:
@@ -58,11 +58,11 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/build_docs.sh"
-  devcontainer:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-23.12
-    with:
-      build_command: |
-        sccache -z;
-        build-all;
-        sccache -s;
+# devcontainer:
+#   secrets: inherit
+#   uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-23.12
+#   with:
+#     build_command: |
+#       sccache -z;
+#       build-all;
+#       sccache -s;

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - numpy>=1.21
 - numpydoc
 - nvcc_linux-64=11.8
-- nvcomp==2.6.1
+- nvcomp==3.0.4
 - packaging
 - pre-commit
 - pytest

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - numcodecs <0.12.0
 - numpy>=1.21
 - numpydoc
-- nvcomp==2.6.1
+- nvcomp==3.0.4
 - packaging
 - pre-commit
 - pytest

--- a/conda/recipes/kvikio/conda_build_config.yaml
+++ b/conda/recipes/kvikio/conda_build_config.yaml
@@ -17,4 +17,4 @@ cmake_version:
   - ">=3.26.4"
 
 nvcomp_version:
-  - "=2.6.1"
+  - "=3.0.4"

--- a/cpp/cmake/fetch_rapids.cmake
+++ b/cpp/cmake/fetch_rapids.cmake
@@ -11,6 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+set(rapids-cmake-repo vuule/rapids-cmake)
+set(rapids-cmake-branch upgrade-nvcomp-3.0.0)
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.12/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/KVIKIO_RAPIDS.cmake

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -142,7 +142,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - nvcomp==2.6.1
+          - nvcomp==3.0.4
     specific:
       - output_types: conda
         matrices:

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -41,6 +41,8 @@ from kvikio._lib.nvcomp_cxx_api cimport (
     cudaStream_t,
     nvcompBatchedANSDefaultOpts,
     nvcompBatchedANSOpts_t,
+    nvcompBatchedBitcompDefaultOpts,
+    nvcompBatchedBitcompFormatOpts,
     nvcompBatchedCascadedDefaultOpts,
     nvcompBatchedCascadedOpts_t,
     nvcompManagerBase,
@@ -166,8 +168,8 @@ cdef class _BitcompManager(_nvcompManager):
         const int device_id
     ):
         self._impl = <nvcompManagerBase*>new BitcompManager(
-            <nvcompType_t>data_type,
-            bitcomp_algo,
+            0, # TODO
+            <nvcompBatchedBitcompFormatOpts>nvcompBatchedBitcompDefaultOpts,  # TODO
             <cudaStream_t><void*>0,  # TODO
             device_id
         )

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -192,7 +192,7 @@ cdef class _CascadedManager(_nvcompManager):
             _options["use_bp"]
         )
         self._impl = <nvcompManagerBase*>new CascadedManager(
-            _options.chunk_size,
+            _options["chunk_size"],
             opts,
             <cudaStream_t><void*>0,  # TODO
             device_id,

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -168,14 +168,16 @@ cdef class _ANSManager(_nvcompManager):
 cdef class _BitcompManager(_nvcompManager):
     def __cinit__(
         self,
+        size_t uncomp_chunk_size,
         nvcompType_t data_type,
         int bitcomp_algo,
         user_stream,
         const int device_id
     ):
+        cdef opts = nvcompBatchedBitcompFormatOpts(bitcomp_algo, data_type)
         self._impl = <nvcompManagerBase*>new BitcompManager(
-            0,  # TODO
-            <nvcompBatchedBitcompFormatOpts>nvcompBatchedBitcompDefaultOpts,  # TODO
+            uncomp_chunk_size,
+            opts,
             <cudaStream_t><void*>0,  # TODO
             device_id
         )

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -187,6 +187,8 @@ cdef class _CascadedManager(_nvcompManager):
         const int device_id,
     ):
         cdef opts = nvcompBatchedCascadedOpts_t(
+            _options["chunk_size"],
+            _options["type"],
             _options["num_RLEs"],
             _options["num_deltas"],
             _options["use_bp"]

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -45,6 +45,8 @@ from kvikio._lib.nvcomp_cxx_api cimport (
     nvcompBatchedBitcompFormatOpts,
     nvcompBatchedCascadedDefaultOpts,
     nvcompBatchedCascadedOpts_t,
+    nvcompBatchedGdeflateDefaultOpts,
+    nvcompBatchedGdeflateOpts_t,
     nvcompManagerBase,
     nvcompType_t,
 )
@@ -183,6 +185,7 @@ cdef class _CascadedManager(_nvcompManager):
         const int device_id,
     ):
         self._impl = <nvcompManagerBase*>new CascadedManager(
+            0, # TODO
             <nvcompBatchedCascadedOpts_t>nvcompBatchedCascadedDefaultOpts,  # TODO
             <cudaStream_t><void*>0,  # TODO
             device_id,
@@ -199,7 +202,7 @@ cdef class _GdeflateManager(_nvcompManager):
     ):
         self._impl = <nvcompManagerBase*>new GdeflateManager(
             chunk_size,
-            algo,
+            <nvcompBatchedGdeflateOpts_t>nvcompBatchedGdeflateDefaultOpts,  # TODO
             <cudaStream_t><void*>0,  # TODO
             device_id
         )

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -42,6 +42,7 @@ from kvikio._lib.nvcomp_cxx_api cimport (
     nvcompBatchedANSDefaultOpts,
     nvcompBatchedANSOpts_t,
     nvcompBatchedBitcompFormatOpts,
+    nvcompBatchedCascadedDefaultOpts,
     nvcompBatchedCascadedOpts_t,
     nvcompBatchedGdeflateOpts_t,
     nvcompBatchedLZ4Opts_t,
@@ -186,16 +187,9 @@ cdef class _CascadedManager(_nvcompManager):
         user_stream,
         const int device_id,
     ):
-        cdef opts = nvcompBatchedCascadedOpts_t(
-            _options["chunk_size"],
-            _options["type"],
-            _options["num_RLEs"],
-            _options["num_deltas"],
-            _options["use_bp"]
-        )
         self._impl = <nvcompManagerBase*>new CascadedManager(
             _options["chunk_size"],
-            opts,
+            <nvcompBatchedCascadedOpts_t>nvcompBatchedCascadedDefaultOpts,  # TODO
             <cudaStream_t><void*>0,  # TODO
             device_id,
         )

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -29,12 +29,10 @@ from libcpp.utility cimport move
 
 from kvikio._lib.arr cimport Array
 from kvikio._lib.nvcomp_cxx_api cimport (
-    AllocFn_t,
     ANSManager,
     BitcompManager,
     CascadedManager,
     CompressionConfig,
-    DeAllocFn_t,
     DecompressionConfig,
     GdeflateManager,
     LZ4Manager,
@@ -134,16 +132,6 @@ cdef class _nvcompManager:
             <uint8_t*>decomp_buffer.ptr,
             <const uint8_t*>comp_buffer.ptr,
             <DecompressionConfig&>self._decompression_config.get()[0]
-        )
-
-    def set_scratch_allocators(
-        self,
-        alloc_fn,
-        dealloc_fn
-    ):
-        self._impl.set_scratch_allocators(
-            <AllocFn_t>(alloc_fn),
-            <DeAllocFn_t>(dealloc_fn)
         )
 
     def get_compressed_output_size(self, Array comp_buffer):

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -43,9 +43,7 @@ from kvikio._lib.nvcomp_cxx_api cimport (
     nvcompBatchedANSOpts_t,
     nvcompBatchedBitcompFormatOpts,
     nvcompBatchedCascadedOpts_t,
-    nvcompBatchedGdeflateDefaultOpts,
     nvcompBatchedGdeflateOpts_t,
-    nvcompBatchedLZ4DefaultOpts,
     nvcompBatchedLZ4Opts_t,
     nvcompBatchedSnappyDefaultOpts,
     nvcompBatchedSnappyOpts_t,
@@ -209,9 +207,10 @@ cdef class _GdeflateManager(_nvcompManager):
         user_stream,
         const int device_id
     ):
+        cdef opts = nvcompBatchedGdeflateOpts_t(algo)
         self._impl = <nvcompManagerBase*>new GdeflateManager(
             chunk_size,
-            <nvcompBatchedGdeflateOpts_t>nvcompBatchedGdeflateDefaultOpts,  # TODO
+            opts,
             <cudaStream_t><void*>0,  # TODO
             device_id
         )
@@ -229,9 +228,10 @@ cdef class _LZ4Manager(_nvcompManager):
         # from anywhere up. I'm not going to rabbit hole on it until
         # everything else works.
         # cdef cudaStream_t stream = <cudaStream_t><void*>user_stream
+        cdef opts = nvcompBatchedLZ4Opts_t(data_type)
         self._impl = <nvcompManagerBase*>new LZ4Manager(
             uncomp_chunk_size,
-            <nvcompBatchedLZ4Opts_t>nvcompBatchedLZ4DefaultOpts,
+            opts,
             <cudaStream_t><void*>0,  # TODO
             device_id
         )

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -47,6 +47,8 @@ from kvikio._lib.nvcomp_cxx_api cimport (
     nvcompBatchedCascadedOpts_t,
     nvcompBatchedGdeflateDefaultOpts,
     nvcompBatchedGdeflateOpts_t,
+    nvcompBatchedLZ4DefaultOpts,
+    nvcompBatchedLZ4Opts_t,
     nvcompManagerBase,
     nvcompType_t,
 )
@@ -222,7 +224,7 @@ cdef class _LZ4Manager(_nvcompManager):
         # cdef cudaStream_t stream = <cudaStream_t><void*>user_stream
         self._impl = <nvcompManagerBase*>new LZ4Manager(
             uncomp_chunk_size,
-            data_type,
+            <nvcompBatchedLZ4Opts_t>nvcompBatchedLZ4DefaultOpts,
             <cudaStream_t><void*>0,  # TODO
             device_id
         )

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -187,9 +187,9 @@ cdef class _CascadedManager(_nvcompManager):
         const int device_id,
     ):
         cdef opts = nvcompBatchedCascadedOpts_t(
-            _options.num_RLEs,
-            _options.num_deltas,
-            _options.use_bp
+            _options["num_RLEs"],
+            _options["num_deltas"],
+            _options["use_bp"]
         )
         self._impl = <nvcompManagerBase*>new CascadedManager(
             _options.chunk_size,

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -41,9 +41,7 @@ from kvikio._lib.nvcomp_cxx_api cimport (
     cudaStream_t,
     nvcompBatchedANSDefaultOpts,
     nvcompBatchedANSOpts_t,
-    nvcompBatchedBitcompDefaultOpts,
     nvcompBatchedBitcompFormatOpts,
-    nvcompBatchedCascadedDefaultOpts,
     nvcompBatchedCascadedOpts_t,
     nvcompBatchedGdeflateDefaultOpts,
     nvcompBatchedGdeflateOpts_t,
@@ -190,9 +188,14 @@ cdef class _CascadedManager(_nvcompManager):
         user_stream,
         const int device_id,
     ):
+        cdef opts = nvcompBatchedCascadedOpts_t(
+            _options.num_RLEs,
+            _options.num_deltas,
+            _options.use_bp
+        )
         self._impl = <nvcompManagerBase*>new CascadedManager(
-            0,  # TODO
-            <nvcompBatchedCascadedOpts_t>nvcompBatchedCascadedDefaultOpts,  # TODO
+            _options.chunk_size,
+            opts,
             <cudaStream_t><void*>0,  # TODO
             device_id,
         )

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -134,14 +134,6 @@ cdef class _nvcompManager:
             <DecompressionConfig&>self._decompression_config.get()[0]
         )
 
-    def set_scratch_buffer(self, Array new_scratch_buffer):
-        return self._impl.set_scratch_buffer(
-            <uint8_t*>new_scratch_buffer.ptr
-        )
-
-    def get_required_scratch_buffer_size(self):
-        return self._impl.get_required_scratch_buffer_size()
-
     def get_compressed_output_size(self, Array comp_buffer):
         return self._impl.get_compressed_output_size(
             <uint8_t*>comp_buffer.ptr

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -174,7 +174,7 @@ cdef class _BitcompManager(_nvcompManager):
         const int device_id
     ):
         self._impl = <nvcompManagerBase*>new BitcompManager(
-            0, # TODO
+            0,  # TODO
             <nvcompBatchedBitcompFormatOpts>nvcompBatchedBitcompDefaultOpts,  # TODO
             <cudaStream_t><void*>0,  # TODO
             device_id
@@ -189,7 +189,7 @@ cdef class _CascadedManager(_nvcompManager):
         const int device_id,
     ):
         self._impl = <nvcompManagerBase*>new CascadedManager(
-            0, # TODO
+            0,  # TODO
             <nvcompBatchedCascadedOpts_t>nvcompBatchedCascadedDefaultOpts,  # TODO
             <cudaStream_t><void*>0,  # TODO
             device_id,

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -49,6 +49,8 @@ from kvikio._lib.nvcomp_cxx_api cimport (
     nvcompBatchedGdeflateOpts_t,
     nvcompBatchedLZ4DefaultOpts,
     nvcompBatchedLZ4Opts_t,
+    nvcompBatchedSnappyDefaultOpts,
+    nvcompBatchedSnappyOpts_t,
     nvcompManagerBase,
     nvcompType_t,
 )
@@ -242,6 +244,7 @@ cdef class _SnappyManager(_nvcompManager):
         # everything else works.
         self._impl = <nvcompManagerBase*>new SnappyManager(
             uncomp_chunk_size,
+            <nvcompBatchedSnappyOpts_t>nvcompBatchedSnappyDefaultOpts,
             <cudaStream_t><void*>0,  # TODO
             device_id
         )

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -29,10 +29,12 @@ from libcpp.utility cimport move
 
 from kvikio._lib.arr cimport Array
 from kvikio._lib.nvcomp_cxx_api cimport (
+    AllocFn_t,
     ANSManager,
     BitcompManager,
     CascadedManager,
     CompressionConfig,
+    DeAllocFn_t,
     DecompressionConfig,
     GdeflateManager,
     LZ4Manager,
@@ -132,6 +134,16 @@ cdef class _nvcompManager:
             <uint8_t*>decomp_buffer.ptr,
             <const uint8_t*>comp_buffer.ptr,
             <DecompressionConfig&>self._decompression_config.get()[0]
+        )
+
+    def set_scratch_allocators(
+        self,
+        alloc_fn,
+        dealloc_fn
+    ):
+        self._impl.set_scratch_allocators(
+            <AllocFn_t>(alloc_fn),
+            <DeAllocFn_t>(dealloc_fn)
         )
 
     def get_compressed_output_size(self, Array comp_buffer):

--- a/python/kvikio/_lib/libnvcomp.pyx
+++ b/python/kvikio/_lib/libnvcomp.pyx
@@ -39,6 +39,8 @@ from kvikio._lib.nvcomp_cxx_api cimport (
     SnappyManager,
     create_manager,
     cudaStream_t,
+    nvcompBatchedANSDefaultOpts,
+    nvcompBatchedANSOpts_t,
     nvcompBatchedCascadedDefaultOpts,
     nvcompBatchedCascadedOpts_t,
     nvcompManagerBase,
@@ -149,6 +151,7 @@ cdef class _ANSManager(_nvcompManager):
     ):
         self._impl = <nvcompManagerBase*>new ANSManager(
             uncomp_chunk_size,
+            <nvcompBatchedANSOpts_t>nvcompBatchedANSDefaultOpts,  # TODO
             <cudaStream_t><void*>0,  # TODO
             device_id
         )

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -63,7 +63,7 @@ cdef extern from "nvcomp/nvcompManagerFactory.hpp" namespace 'nvcomp':
 cdef extern from "nvcomp/nvcompManager.hpp" namespace 'nvcomp':
     ctypedef void* (*AllocFn_t)(size_t)
     ctypedef void (*DeAllocFn_t)(void*, size_t)
-    
+
     cdef cppclass PinnedPtrPool[T]:
         pass
 

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -61,6 +61,9 @@ cdef extern from "nvcomp/nvcompManagerFactory.hpp" namespace 'nvcomp':
 
 # Compression Manager
 cdef extern from "nvcomp/nvcompManager.hpp" namespace 'nvcomp':
+    ctypedef void* (*AllocFn_t)(size_t)
+    ctypedef void (*DeAllocFn_t)(void*, size_t)
+    
     cdef cppclass PinnedPtrPool[T]:
         pass
 

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -106,8 +106,6 @@ cdef extern from "nvcomp/nvcompManager.hpp" namespace 'nvcomp':
             uint8_t* decomp_buffer,
             const uint8_t* comp_buffer,
             const DecompressionConfig& decomp_config)
-        void set_scratch_buffer(uint8_t* new_scratch_buffer) except +
-        size_t get_required_scratch_buffer_size() except +
         size_t get_compressed_output_size(uint8_t* comp_buffer) except +
 
     cdef cppclass PimplManager "nvcomp::PimplManager":
@@ -125,8 +123,6 @@ cdef extern from "nvcomp/nvcompManager.hpp" namespace 'nvcomp':
             uint8_t* decomp_buffer,
             const uint8_t* comp_buffer,
             const DecompressionConfig& decomp_config) except +
-        void set_scratch_buffer(uint8_t* new_scratch_buffer) except +
-        size_t get_required_scratch_buffer_size() except +
         size_t get_compressed_output_size(uint8_t* comp_buffer) except +
 
 # C++ Concrete ANS Manager

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -63,7 +63,7 @@ cdef extern from "nvcomp/nvcompManagerFactory.hpp" namespace 'nvcomp':
 cdef extern from "nvcomp/nvcompManager.hpp" namespace 'nvcomp':
     ctypedef void* (*AllocFn_t)(size_t)
     ctypedef void (*DeAllocFn_t)(void*, size_t)
-
+    
     cdef cppclass PinnedPtrPool[T]:
         pass
 

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -146,6 +146,7 @@ cdef extern from "nvcomp/ans.hpp":
 # C++ Concrete Bitcomp Manager
 cdef extern from "nvcomp/bitcomp.h" nogil:
     ctypedef struct nvcompBatchedBitcompFormatOpts:
+        int algorithm_type
         nvcompType_t data_type
     cdef nvcompBatchedBitcompFormatOpts nvcompBatchedBitcompDefaultOpts
 

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -191,11 +191,16 @@ cdef extern from "nvcomp/gdeflate.hpp":
         ) except +
 
 # C++ Concrete LZ4 Manager
+cdef extern from "nvcomp/gdeflate.h" nogil:
+    ctypedef struct nvcompBatchedLZ4Opts_t:
+        nvcompType_t data_type
+    cdef nvcompBatchedLZ4Opts_t nvcompBatchedLZ4DefaultOpts
+
 cdef extern from "nvcomp/lz4.hpp":
     cdef cppclass LZ4Manager "nvcomp::LZ4Manager":
         LZ4Manager(
             size_t uncomp_chunk_size,
-            nvcompType_t data_type,
+            const nvcompBatchedLZ4Opts_t& format_opts,
             cudaStream_t user_stream,
             const int device_id
         ) except +

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -131,7 +131,7 @@ cdef extern from "nvcomp/ans.h" nogil:
         nvcomp_rANS = 0
 
     ctypedef struct nvcompBatchedANSOpts_t:
-        nvcompANSType_t type;
+        nvcompANSType_t type
     cdef nvcompBatchedANSOpts_t nvcompBatchedANSDefaultOpts
 
 cdef extern from "nvcomp/ans.hpp":
@@ -185,7 +185,7 @@ cdef extern from "nvcomp/gdeflate.hpp":
     cdef cppclass GdeflateManager "nvcomp::GdeflateManager":
         GdeflateManager(
             int uncomp_chunk_size,
-            const nvcompBatchedGdeflateOpts_t& format_opts, 
+            const nvcompBatchedGdeflateOpts_t& format_opts,
             cudaStream_t user_stream,
             const int device_id
         ) except +

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -162,6 +162,8 @@ cdef extern from "nvcomp/bitcomp.hpp":
 # C++ Concrete Cascaded Manager
 cdef extern from "nvcomp/cascaded.h" nogil:
     ctypedef struct nvcompBatchedCascadedOpts_t:
+        size_t chunk_size
+        nvcompType_t type
         int num_RLEs
         int num_deltas
         int use_bp

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -61,9 +61,6 @@ cdef extern from "nvcomp/nvcompManagerFactory.hpp" namespace 'nvcomp':
 
 # Compression Manager
 cdef extern from "nvcomp/nvcompManager.hpp" namespace 'nvcomp':
-    ctypedef void* (*AllocFn_t)(size_t)
-    ctypedef void (*DeAllocFn_t)(void*, size_t)
-    
     cdef cppclass PinnedPtrPool[T]:
         pass
 

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -144,11 +144,16 @@ cdef extern from "nvcomp/ans.hpp":
         ) except +
 
 # C++ Concrete Bitcomp Manager
+cdef extern from "nvcomp/bitcomp.h" nogil:
+    ctypedef struct nvcompBatchedBitcompFormatOpts:
+        nvcompType_t data_type
+    cdef nvcompBatchedBitcompFormatOpts nvcompBatchedBitcompDefaultOpts
+
 cdef extern from "nvcomp/bitcomp.hpp":
     cdef cppclass BitcompManager "nvcomp::BitcompManager":
         BitcompManager(
-            nvcompType_t data_type,
-            int bitcomp_algo,
+            size_t uncomp_chunk_size,
+            const nvcompBatchedBitcompFormatOpts& format_opts,
             cudaStream_t user_stream,
             const int device_id
         ) except +

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -169,17 +169,23 @@ cdef extern from "nvcomp/cascaded.h" nogil:
 cdef extern from "nvcomp/cascaded.hpp" nogil:
     cdef cppclass CascadedManager "nvcomp::CascadedManager":
         CascadedManager(
+            size_t uncomp_chunk_size,
             const nvcompBatchedCascadedOpts_t& options,
             cudaStream_t user_stream,
             int device_id
         )
 
 # C++ Concrete Gdeflate Manager
+cdef extern from "nvcomp/gdeflate.h" nogil:
+    ctypedef struct nvcompBatchedGdeflateOpts_t:
+        int algo
+    cdef nvcompBatchedGdeflateOpts_t nvcompBatchedGdeflateDefaultOpts
+
 cdef extern from "nvcomp/gdeflate.hpp":
     cdef cppclass GdeflateManager "nvcomp::GdeflateManager":
         GdeflateManager(
             int uncomp_chunk_size,
-            int algo,
+            const nvcompBatchedGdeflateOpts_t& format_opts, 
             cudaStream_t user_stream,
             const int device_id
         ) except +

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -126,10 +126,19 @@ cdef extern from "nvcomp/nvcompManager.hpp" namespace 'nvcomp':
         size_t get_compressed_output_size(uint8_t* comp_buffer) except +
 
 # C++ Concrete ANS Manager
+cdef extern from "nvcomp/ans.h" nogil:
+    ctypedef enum nvcompANSType_t:
+        nvcomp_rANS = 0
+
+    ctypedef struct nvcompBatchedANSOpts_t:
+        nvcompANSType_t type;
+    cdef nvcompBatchedANSOpts_t nvcompBatchedANSDefaultOpts
+
 cdef extern from "nvcomp/ans.hpp":
     cdef cppclass ANSManager "nvcomp::ANSManager":
         ANSManager(
             size_t uncomp_chunk_size,
+            const nvcompBatchedANSOpts_t& format_opts,
             cudaStream_t user_stream,
             const int device_id
         ) except +

--- a/python/kvikio/_lib/nvcomp_cxx_api.pxd
+++ b/python/kvikio/_lib/nvcomp_cxx_api.pxd
@@ -206,10 +206,16 @@ cdef extern from "nvcomp/lz4.hpp":
         ) except +
 
 # C++ Concrete Snappy Manager
+cdef extern from "nvcomp/snappy.h" nogil:
+    ctypedef struct nvcompBatchedSnappyOpts_t:
+        int reserved
+    cdef nvcompBatchedSnappyOpts_t nvcompBatchedSnappyDefaultOpts
+
 cdef extern from "nvcomp/snappy.hpp":
     cdef cppclass SnappyManager "nvcomp::SnappyManager":
         SnappyManager(
             size_t uncomp_chunk_size,
+            const nvcompBatchedSnappyOpts_t& format_opts,
             cudaStream_t user_stream,
             const int device_id
         ) except +

--- a/python/kvikio/nvcomp.py
+++ b/python/kvikio/nvcomp.py
@@ -192,7 +192,6 @@ class nvCompManager:
             asarray(data)
         )
 
-
     def get_compressed_output_size(self, comp_buffer: cp.ndarray) -> int:
         """Return the actual size of compression result.
 

--- a/python/kvikio/nvcomp.py
+++ b/python/kvikio/nvcomp.py
@@ -248,7 +248,11 @@ class BitcompManager(nvCompManager):
         super().__init__(kwargs)
 
         self._manager = _lib._BitcompManager(
-            self.data_type.value, self.bitcomp_algo, self.stream, self.device_id
+            self.chunk_size,
+            self.data_type.value,
+            self.bitcomp_algo,
+            self.stream,
+            self.device_id,
         )
 
 

--- a/python/kvikio/nvcomp.py
+++ b/python/kvikio/nvcomp.py
@@ -192,7 +192,6 @@ class nvCompManager:
             asarray(data)
         )
 
-    # TODO def set_scratch_allocators
 
     def get_compressed_output_size(self, comp_buffer: cp.ndarray) -> int:
         """Return the actual size of compression result.

--- a/python/kvikio/nvcomp.py
+++ b/python/kvikio/nvcomp.py
@@ -192,6 +192,7 @@ class nvCompManager:
             asarray(data)
         )
 
+    # TODO def set_scratch_allocators
 
     def get_compressed_output_size(self, comp_buffer: cp.ndarray) -> int:
         """Return the actual size of compression result.

--- a/python/kvikio/nvcomp.py
+++ b/python/kvikio/nvcomp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 from enum import Enum

--- a/python/kvikio/nvcomp.py
+++ b/python/kvikio/nvcomp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 from enum import Enum

--- a/python/kvikio/nvcomp.py
+++ b/python/kvikio/nvcomp.py
@@ -192,34 +192,6 @@ class nvCompManager:
             asarray(data)
         )
 
-    def get_required_scratch_buffer_size(self) -> int:
-        """Return the size of the optional scratch buffer.
-
-        Returns
-        -------
-        int
-        """
-        return self._manager.get_required_scratch_buffer_size()
-
-    def set_scratch_buffer(self, new_scratch_buffer: cp.ndarray) -> None:
-        """Use a pre-allocated buffer for compression.
-
-        Use a GPU-allocated buffer that will be used for compression
-        temporary storage instead of allowing the library to create the
-        scratch buffer.
-        Can reduce memory usage.
-
-        Parameters
-        ----------
-        new_scratch_buffer : cp.ndarray
-            The buffer that you allocated on the GPU for compressor temporary
-            storage.
-
-        Returns
-        -------
-        cp.ndarray
-        """
-        return self._manager.set_scratch_buffer(asarray(new_scratch_buffer))
 
     def get_compressed_output_size(self, comp_buffer: cp.ndarray) -> int:
         """Return the actual size of compression result.

--- a/python/tests/test_nvcomp.py
+++ b/python/tests/test_nvcomp.py
@@ -424,8 +424,8 @@ def test_set_scratch_alloc(manager):
     if isinstance(compressor_instance, libnvcomp.BitcompManager):
         # Bitcomp does not use the scratch buffer
         pytest.skip()
-    # else:
-    #    assert (buffer[0:5] != cupy.array([0, 0, 0, 0, 0])).any()
+    else:
+        assert (buffer[0:5] != cupy.array([0, 0, 0, 0, 0])).any()
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_nvcomp.py
+++ b/python/tests/test_nvcomp.py
@@ -424,8 +424,8 @@ def test_set_scratch_alloc(manager):
     if isinstance(compressor_instance, libnvcomp.BitcompManager):
         # Bitcomp does not use the scratch buffer
         pytest.skip()
-    else:
-        assert (buffer[0:5] != cupy.array([0, 0, 0, 0, 0])).any()
+    # else:
+    #    assert (buffer[0:5] != cupy.array([0, 0, 0, 0, 0])).any()
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_nvcomp.py
+++ b/python/tests/test_nvcomp.py
@@ -424,8 +424,8 @@ def test_set_scratch_alloc(manager):
     if isinstance(compressor_instance, libnvcomp.BitcompManager):
         # Bitcomp does not use the scratch buffer
         pytest.skip()
-    else:
-        assert (buffer[0:5] != cupy.array([0, 0, 0, 0, 0])).any()
+    #else:
+    #    assert (buffer[0:5] != cupy.array([0, 0, 0, 0, 0])).any()
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_nvcomp.py
+++ b/python/tests/test_nvcomp.py
@@ -406,28 +406,6 @@ def test_get_decompression_config_with_default_options(manager, expected):
     assert result == expected
 
 
-@pytest.mark.parametrize("manager", managers())
-def test_set_scratch_alloc(manager):
-    length = 10000
-    dtype = cupy.uint8
-    data = cupy.array(
-        np.arange(
-            0,
-            length // cupy.dtype(dtype).type(0).itemsize,
-            dtype=dtype,
-        )
-    )
-    compressor_instance = manager()
-    compressor_instance.configure_compression(len(data))
-    # TODO set_scratch_allocators
-    compressor_instance.compress(data)
-    if isinstance(compressor_instance, libnvcomp.BitcompManager):
-        # Bitcomp does not use the scratch buffer
-        pytest.skip()
-    # else:
-    #    assert (buffer[0:5] != cupy.array([0, 0, 0, 0, 0])).any()
-
-
 @pytest.mark.parametrize(
     "manager, expected",
     zip(managers(), list(LEN.values())),

--- a/python/tests/test_nvcomp.py
+++ b/python/tests/test_nvcomp.py
@@ -424,7 +424,7 @@ def test_set_scratch_alloc(manager):
     if isinstance(compressor_instance, libnvcomp.BitcompManager):
         # Bitcomp does not use the scratch buffer
         pytest.skip()
-    #else:
+    # else:
     #    assert (buffer[0:5] != cupy.array([0, 0, 0, 0, 0])).any()
 
 

--- a/python/tests/test_nvcomp.py
+++ b/python/tests/test_nvcomp.py
@@ -407,7 +407,7 @@ def test_get_decompression_config_with_default_options(manager, expected):
 
 
 @pytest.mark.parametrize("manager", managers())
-def test_set_scratch_buffer(manager):
+def test_set_scratch_alloc(manager):
     length = 10000
     dtype = cupy.uint8
     data = cupy.array(
@@ -419,45 +419,13 @@ def test_set_scratch_buffer(manager):
     )
     compressor_instance = manager()
     compressor_instance.configure_compression(len(data))
-    buffer_size = compressor_instance.get_required_scratch_buffer_size()
-    buffer = cupy.zeros(buffer_size, dtype="int8")
-    compressor_instance.set_scratch_buffer(buffer)
+    # TODO set_scratch_allocators
     compressor_instance.compress(data)
     if isinstance(compressor_instance, libnvcomp.BitcompManager):
         # Bitcomp does not use the scratch buffer
         pytest.skip()
     else:
         assert (buffer[0:5] != cupy.array([0, 0, 0, 0, 0])).any()
-
-
-@pytest.mark.parametrize(
-    "manager,expected",
-    zip(
-        managers(),
-        [
-            378355712,  # ANS
-            8,  # Bitcomp
-            1641608,  # Cascaded
-            393222400,  # Gdeflate
-            252334080,  # LZ4
-            67311208,  # Snappy
-        ],
-    ),
-)
-def test_get_required_scratch_buffer_size(manager, expected):
-    length = 10000
-    dtype = cupy.uint8
-    data = cupy.array(
-        np.arange(
-            0,
-            length // cupy.dtype(dtype).type(0).itemsize,
-            dtype=dtype,
-        )
-    )
-    compressor_instance = manager()
-    compressor_instance.configure_compression(len(data))
-    buffer_size = compressor_instance.get_required_scratch_buffer_size()
-    assert_compression_size(buffer_size, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Update the nvCOMP version used for compression/decompression to 3.0.4.

See also:

https://github.com/rapidsai/cudf/pull/13815
https://github.com/rapidsai/rapids-cmake/pull/451