### PR TITLE
Use libcufile in aarch64 CUDA 12 builds.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -188,7 +188,6 @@ dependencies:
         matrices:
           - matrix:
               cuda: "12.*"
-              arch: x86_64
             packages:
               - libcufile
               - libcufile-dev


### PR DESCRIPTION
CUDA 12.2 has conda-forge packages of `libcufile` and `libcufile-dev`. This PR updates `dependencies.yaml` so that environments can be generated on ARM.