### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -113,5 +113,6 @@ build-dir = "build/{wheel_tag}"
 cmake.build-type = "Release"
 cmake.minimum-version = "3.26.4"
 ninja.make-fallback = true
+sdist.exclude = ["*tests*"]
 sdist.reproducible = true
 wheel.packages = ["kvikio"]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.