### PR TITLE
Add environment-agnostic scripts for running ctests and pytests

### DIFF
--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -3,9 +3,8 @@
 
 set -euo pipefail
 
-if [ -d "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/tests/libkvikio/" ]; then
-    # Support customizing the ctests' install location
-    cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/tests/libkvikio/"
-    # Run BASIC_IO_TEST
-    ./BASIC_IO_TEST
-fi
+# Support customizing the ctests' install location
+cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/tests/libkvikio/"
+
+# Run BASIC_IO_TEST
+./BASIC_IO_TEST

--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+# Support customizing the ctests' install location
+cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/tests/libkvikio/"
+
+# Run BASIC_IO_TEST
+./BASIC_IO_TEST

--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -3,8 +3,9 @@
 
 set -euo pipefail
 
-# Support customizing the ctests' install location
-cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/tests/libkvikio/"
-
-# Run BASIC_IO_TEST
-./BASIC_IO_TEST
+if [ -d "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/tests/libkvikio/" ]; then
+    # Support customizing the ctests' install location
+    cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/tests/libkvikio/"
+    # Run BASIC_IO_TEST
+    ./BASIC_IO_TEST
+fi

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/
 
-py.test --cache-clear --verbose "$@" tests
+python -m pytest --cache-clear --verbose "$@" tests

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+# Support invoking run_pytests.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/
+
+pytest --cache-clear --verbose "$@" tests

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/
 
-pytest --cache-clear --verbose "$@" tests
+py.test --cache-clear --verbose "$@" tests

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/
 
-python -m pytest --cache-clear --verbose "$@" tests
+pytest --cache-clear --verbose "$@" tests

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -32,12 +32,9 @@ rapids-mamba-retry install \
 rapids-logger "Check GPU usage"
 nvidia-smi
 
-EXITCODE=0
-trap "EXITCODE=1" ERR
-set +e
-
-# Run BASIC_IO_TEST
-"$CONDA_PREFIX"/bin/tests/libkvikio/BASIC_IO_TEST
+# Support invoking test_cpp.sh outside the script directory
+"$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/run_ctests.sh \
+ && EXITCODE=$? || EXITCODE=$?;
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
+# Support invoking test_python.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Generate Python testing dependencies"
@@ -37,8 +40,7 @@ rapids-logger "Check GPU usage"
 nvidia-smi
 
 rapids-logger "pytest kvikio"
-# Support invoking test_python.sh outside the script directory
-"$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/run_pytests.sh \
+./run_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-kvikio.xml" \
   --cov-config=.coveragerc \
   --cov=kvikio \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -36,21 +36,15 @@ rapids-mamba-retry install \
 rapids-logger "Check GPU usage"
 nvidia-smi
 
-EXITCODE=0
-trap "EXITCODE=1" ERR
-set +e
-
 rapids-logger "pytest kvikio"
-pushd python/
-pytest \
-  --cache-clear \
+# Support invoking test_python.sh outside the script directory
+"$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/run_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-kvikio.xml" \
-  --verbose \
   --cov-config=.coveragerc \
   --cov=kvikio \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/kvikio-coverage.xml" \
   --cov-report=term \
-  tests
+ && EXITCODE=$? || EXITCODE=$?;
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Support invoking test_python.sh outside the script directory
-cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
@@ -40,7 +40,7 @@ rapids-logger "Check GPU usage"
 nvidia-smi
 
 rapids-logger "pytest kvikio"
-./run_pytests.sh \
+./ci/run_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-kvikio.xml" \
   --cov-config=.coveragerc \
   --cov=kvikio \


### PR DESCRIPTION
This PR adds environment-agnostic `run_{ctests,pytests}.sh` scripts, and updates `test_{cpp,python}.sh` to call them.

The `test_{cpp,python}.sh` scripts assume they're running in our CI environment, and they do more than just run the tests.

This PR allows devs and downstream consumers to only run the tests, and skip the unrelated logic in `test_{cpp,python}.sh`.
