### PR TITLE
Bump to nvcomp 3.0.6.

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 ##########################
 # KvikIO Version Updater #
 ##########################
@@ -59,15 +59,6 @@ sed_runner 's/PROJECT_NUMBER         = .*/PROJECT_NUMBER         = '${NEXT_FULL_
 # sphinx docs update
 sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py
 sed_runner 's/release = .*/release = '"'${NEXT_FULL_TAG}'"'/g' docs/source/conf.py
-
-DEPENDENCIES=(
-  cudf
-)
-for DEP in "${DEPENDENCIES[@]}"; do
-  for FILE in dependencies.yaml conda/environments/*.yaml; do
-    sed_runner "/-.* ${DEP}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*/g" ${FILE}
-  done
-done
 
 # CI files
 for FILE in .github/workflows/*.yaml; do

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -11,7 +11,6 @@ dependencies:
 - cuda-python>=11.7.1,<12.0a0
 - cuda-version=11.8
 - cudatoolkit
-- cudf==24.2.*
 - cupy>=12.0.0
 - cxx-compiler
 - cython>=3.0.0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - numpy>=1.21
 - numpydoc
 - nvcc_linux-64=11.8
-- nvcomp==3.0.5
+- nvcomp==3.0.6
 - packaging
 - pre-commit
 - pytest

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -11,7 +11,6 @@ dependencies:
 - cuda-nvcc
 - cuda-python>=12.0,<13.0a0
 - cuda-version=12.0
-- cudf==24.2.*
 - cupy>=12.0.0
 - cxx-compiler
 - cython>=3.0.0

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - numcodecs <0.12.0
 - numpy>=1.21
 - numpydoc
-- nvcomp==3.0.5
+- nvcomp==3.0.6
 - packaging
 - pre-commit
 - pytest

--- a/conda/recipes/kvikio/conda_build_config.yaml
+++ b/conda/recipes/kvikio/conda_build_config.yaml
@@ -17,4 +17,4 @@ cmake_version:
   - ">=3.26.4"
 
 nvcomp_version:
-  - "=3.0.5"
+  - "=3.0.6"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -173,7 +173,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - nvcomp==3.0.5
+          - nvcomp==3.0.6
     specific:
       - output_types: conda
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -12,7 +12,6 @@ files:
       - cuda
       - cuda_version
       - docs
-      - notebooks
       - py_version
       - run
       - test_python
@@ -283,8 +282,3 @@ dependencies:
         packages:
           - *dask
           - distributed>=2022.05.2
-  notebooks:
-    common:
-      - output_types: conda
-        packages:
-          - cudf==24.2.*


### PR DESCRIPTION
This PR bumps nvcomp to 3.0.6. This is needed as a hotfix for https://github.com/rapidsai/cudf/issues/15096.

Depends on:
- https://github.com/conda-forge/nvcomp-feedstock/pull/14
- https://github.com/rapidsai/rapids-cmake/pull/542