### PR TITLE
Migrate to `{{ stdlib("c") }}`

### DIFF
--- a/conda/recipes/kvikio/conda_build_config.yaml
+++ b/conda/recipes/kvikio/conda_build_config.yaml
@@ -10,6 +10,9 @@ cuda_compiler:
 cuda11_compiler:
   - nvcc
 
+c_stdlib:
+  - sysroot
+
 c_stdlib_version:
   - "2.17"
 

--- a/conda/recipes/kvikio/conda_build_config.yaml
+++ b/conda/recipes/kvikio/conda_build_config.yaml
@@ -10,7 +10,7 @@ cuda_compiler:
 cuda11_compiler:
   - nvcc
 
-sysroot_version:
+c_stdlib_version:
   - "2.17"
 
 cmake_version:

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     {% else %}
     - {{ compiler('cuda') }}
     {% endif %}
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     - python
     - setuptools

--- a/conda/recipes/libkvikio/conda_build_config.yaml
+++ b/conda/recipes/libkvikio/conda_build_config.yaml
@@ -13,6 +13,9 @@ cuda_compiler:
 cuda11_compiler:
   - nvcc
 
+c_stdlib:
+  - sysroot
+
 c_stdlib_version:
   - "2.17"
 

--- a/conda/recipes/libkvikio/conda_build_config.yaml
+++ b/conda/recipes/libkvikio/conda_build_config.yaml
@@ -13,7 +13,7 @@ cuda_compiler:
 cuda11_compiler:
   - nvcc
 
-sysroot_version:
+c_stdlib_version:
   - "2.17"
 
 # The CTK libraries below are missing from the conda-forge::cudatoolkit package

--- a/conda/recipes/libkvikio/meta.yaml
+++ b/conda/recipes/libkvikio/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - {{ compiler('cuda') }}
     {% endif %}
     - ninja
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}


### PR DESCRIPTION
The `sysroot*` syntax is getting phased out (conda-forge/conda-forge.github.io#2102).
The recommendation is to move to `{{ stdlib("c") }}`.

Ref https://github.com/rapidsai/build-planning/issues/39
