### PR TITLE
Refactor: move cufile header checks to the shim layer

### DIFF
--- a/cpp/include/kvikio/buffer.hpp
+++ b/cpp/include/kvikio/buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,6 @@ inline void buffer_register(const void* devPtr_base,
                             const std::vector<int>& errors_to_ignore = std::vector<int>())
 {
   if (defaults::compat_mode()) { return; }
-#ifdef KVIKIO_CUFILE_FOUND
   CUfileError_t status = cuFileAPI::instance().BufRegister(devPtr_base, size, flags);
   if (status.err != CU_FILE_SUCCESS) {
     // Check if `status.err` is in `errors_to_ignore`
@@ -59,7 +58,6 @@ inline void buffer_register(const void* devPtr_base,
       CUFILE_TRY(status);
     }
   }
-#endif
 }
 
 /**
@@ -70,9 +68,7 @@ inline void buffer_register(const void* devPtr_base,
 inline void buffer_deregister(const void* devPtr_base)
 {
   if (defaults::compat_mode()) { return; }
-#ifdef KVIKIO_CUFILE_FOUND
   CUFILE_TRY(cuFileAPI::instance().BufDeregister(devPtr_base));
-#endif
 }
 
 /**

--- a/cpp/include/kvikio/error.hpp
+++ b/cpp/include/kvikio/error.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,6 @@ struct CUfileException : public std::runtime_error {
 #define CUDA_DRIVER_TRY_1(_call) CUDA_DRIVER_TRY_2(_call, kvikio::CUfileException)
 #endif
 
-#ifdef KVIKIO_CUFILE_FOUND
 #ifndef CUFILE_TRY
 #define CUFILE_TRY(...)                                         \
   GET_CUFILE_TRY_MACRO(__VA_ARGS__, CUFILE_TRY_2, CUFILE_TRY_1) \
@@ -77,7 +76,6 @@ struct CUfileException : public std::runtime_error {
   } while (0)
 #define CUFILE_TRY_1(_call) CUFILE_TRY_2(_call, kvikio::CUfileException)
 #endif
-#endif
 
 #ifndef CUFILE_CHECK_STREAM_IO
 #define CUFILE_CHECK_STREAM_IO(...)                                  \
@@ -85,7 +83,6 @@ struct CUfileException : public std::runtime_error {
     __VA_ARGS__, CUFILE_CHECK_STREAM_IO_2, CUFILE_CHECK_STREAM_IO_1) \
   (__VA_ARGS__)
 #define GET_CUFILE_CHECK_STREAM_IO_MACRO(_1, _2, NAME, ...) NAME
-#ifdef KVIKIO_CUFILE_FOUND
 #define CUFILE_CHECK_STREAM_IO_2(_nbytes_done, _exception_type)                            \
   do {                                                                                     \
     auto const _nbytes = *(_nbytes_done);                                                  \
@@ -94,12 +91,6 @@ struct CUfileException : public std::runtime_error {
                              KVIKIO_STRINGIFY(__LINE__) + ": " + std::to_string(_nbytes)}; \
     }                                                                                      \
   } while (0)
-#else
-// if cufile isn't available, we don't do anything in the body
-#define CUFILE_CHECK_STREAM_IO_2(_nbytes_done, _exception_type) \
-  do {                                                          \
-  } while (0)
-#endif
 #define CUFILE_CHECK_STREAM_IO_1(_call) CUFILE_CHECK_STREAM_IO_2(_call, kvikio::CUfileException)
 #endif
 

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -526,14 +526,11 @@ class FileHandle {
                   ssize_t* bytes_read_p,
                   CUstream stream)
   {
-#ifdef KVIKIO_CUFILE_STREAM_API_FOUND
     if (kvikio::is_batch_and_stream_available() && !_compat_mode) {
       CUFILE_TRY(cuFileAPI::instance().ReadAsync(
         _handle, devPtr_base, size_p, file_offset_p, devPtr_offset_p, bytes_read_p, stream));
       return;
     }
-#endif
-
     CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
     *bytes_read_p =
       static_cast<ssize_t>(read(devPtr_base, *size_p, *file_offset_p, *devPtr_offset_p));
@@ -619,14 +616,11 @@ class FileHandle {
                    ssize_t* bytes_written_p,
                    CUstream stream)
   {
-#ifdef KVIKIO_CUFILE_STREAM_API_FOUND
     if (kvikio::is_batch_and_stream_available() && !_compat_mode) {
       CUFILE_TRY(cuFileAPI::instance().WriteAsync(
         _handle, devPtr_base, size_p, file_offset_p, devPtr_offset_p, bytes_written_p, stream));
       return;
     }
-#endif
-
     CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
     *bytes_written_p =
       static_cast<ssize_t>(write(devPtr_base, *size_p, *file_offset_p, *devPtr_offset_p));

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -44,21 +44,16 @@ class cuFileAPI {
   decltype(cuFileDriverSetPollMode)* DriverSetPollMode{nullptr};
   decltype(cuFileDriverSetMaxCacheSize)* DriverSetMaxCacheSize{nullptr};
   decltype(cuFileDriverSetMaxPinnedMemSize)* DriverSetMaxPinnedMemSize{nullptr};
-
-#ifdef KVIKIO_CUFILE_BATCH_API_FOUND
   decltype(cuFileBatchIOSetUp)* BatchIOSetUp{nullptr};
   decltype(cuFileBatchIOSubmit)* BatchIOSubmit{nullptr};
   decltype(cuFileBatchIOGetStatus)* BatchIOGetStatus{nullptr};
   decltype(cuFileBatchIOCancel)* BatchIOCancel{nullptr};
   decltype(cuFileBatchIODestroy)* BatchIODestroy{nullptr};
-#endif
-
-#ifdef KVIKIO_CUFILE_STREAM_API_FOUND
   decltype(cuFileReadAsync)* ReadAsync{nullptr};
   decltype(cuFileWriteAsync)* WriteAsync{nullptr};
   decltype(cuFileStreamRegister)* StreamRegister{nullptr};
   decltype(cuFileStreamDeregister)* StreamDeregister{nullptr};
-#endif
+
   bool stream_available = false;
 
  private:

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@
 #include <kvikio/shim/utils.hpp>
 
 namespace kvikio {
-
-#ifdef KVIKIO_CUFILE_FOUND
 
 /**
  * @brief Shim layer of the cuFile C-API
@@ -64,6 +62,7 @@ class cuFileAPI {
   bool stream_available = false;
 
  private:
+#ifdef KVIKIO_CUFILE_FOUND
   cuFileAPI()
   {
     // CUDA versions before CUDA 11.7.1 did not ship libcufile.so.0, so this is
@@ -128,10 +127,16 @@ class cuFileAPI {
                 << std::endl;
     }
   }
+#else
+  cuFileAPI() { throw std::runtime_error("KvikIO not compiled with cuFile.h"); }
+  ~cuFileAPI() = default;
+#endif
 
  public:
-  cuFileAPI(cuFileAPI const&)      = delete;
-  void operator=(cuFileAPI const&) = delete;
+  cuFileAPI(cuFileAPI const&)       = delete;
+  void operator=(cuFileAPI const&)  = delete;
+  cuFileAPI(cuFileAPI const&&)      = delete;
+  void operator=(cuFileAPI const&&) = delete;
 
   static cuFileAPI& instance()
   {
@@ -139,8 +144,6 @@ class cuFileAPI {
     return _instance;
   }
 };
-
-#endif
 
 /**
  * @brief Check if the cuFile library is available

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -123,8 +123,7 @@ class cuFileAPI {
     }
   }
 #else
-  cuFileAPI() { throw std::runtime_error("KvikIO not compiled with cuFile.h"); }
-  ~cuFileAPI() = default;
+  cuFileAPI() { throw std::runtime_error(CUFILE_ERRSTR(0)); }
 #endif
 
  public:

--- a/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
@@ -74,7 +74,9 @@ CUfileError_t cuFileDriverSetMaxPinnedMemSize(...);
 #endif
 
 // If the Batch API isn't defined, we define some of the data types here.
-// Notice, this doesn't need to be ABI compatible with the cufile definitions.
+// Notice, this doesn't need to be ABI compatible with the cufile definitions and
+// the lack of definitions is not a problem because the linker will never look for
+// these symbols because the "real" function calls are made through the shim instance.
 #ifndef KVIKIO_CUFILE_BATCH_API_FOUND
 typedef enum CUfileOpcode { CUFILE_READ = 0, CUFILE_WRITE } CUfileOpcode_t;
 
@@ -102,7 +104,6 @@ CUfileError_t cuFileBatchIODestroy(...);
 #endif
 
 // If the Stream API isn't defined, we define some of the data types here.
-// Notice, this doesn't need to be ABI compatible with the cufile definitions.
 #ifndef KVIKIO_CUFILE_STREAM_API_FOUND
 CUfileError_t cuFileReadAsync(...);
 CUfileError_t cuFileWriteAsync(...);

--- a/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
@@ -66,6 +66,15 @@ CUfileError_t cuFileDriverGetProperties(...);
 CUfileError_t cuFileDriverSetPollMode(...);
 CUfileError_t cuFileDriverSetMaxCacheSize(...);
 CUfileError_t cuFileDriverSetMaxPinnedMemSize(...);
+CUfileError_t cuFileBatchIOSetUp(...);
+CUfileError_t cuFileBatchIOSubmit(...);
+CUfileError_t cuFileBatchIOGetStatus(...);
+CUfileError_t cuFileBatchIOCancel(...);
+CUfileError_t cuFileBatchIODestroy(...);
+CUfileError_t cuFileReadAsync(...);
+CUfileError_t cuFileWriteAsync(...);
+CUfileError_t cuFileStreamRegister(...);
+CUfileError_t cuFileStreamDeregister(...);
 
 #endif
 

--- a/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
@@ -28,6 +28,10 @@
 #ifdef KVIKIO_CUFILE_FOUND
 #include <cufile.h>
 #else
+
+// If cuFile isn't defined, we define some of the data types here.
+// Notice, this doesn't need to be ABI compatible with the cufile definitions.
+
 using CUfileHandle_t = void*;
 using CUfileOpError  = int;
 #define CUFILE_ERRSTR(x)          ("KvikIO not compiled with cuFile.h")
@@ -66,15 +70,6 @@ CUfileError_t cuFileDriverGetProperties(...);
 CUfileError_t cuFileDriverSetPollMode(...);
 CUfileError_t cuFileDriverSetMaxCacheSize(...);
 CUfileError_t cuFileDriverSetMaxPinnedMemSize(...);
-CUfileError_t cuFileBatchIOSetUp(...);
-CUfileError_t cuFileBatchIOSubmit(...);
-CUfileError_t cuFileBatchIOGetStatus(...);
-CUfileError_t cuFileBatchIOCancel(...);
-CUfileError_t cuFileBatchIODestroy(...);
-CUfileError_t cuFileReadAsync(...);
-CUfileError_t cuFileWriteAsync(...);
-CUfileError_t cuFileStreamRegister(...);
-CUfileError_t cuFileStreamDeregister(...);
 
 #endif
 
@@ -99,4 +94,18 @@ typedef struct CUfileIOEvents {
   size_t ret;            /* -ve error or amount of I/O done. */
 } CUfileIOEvents_t;
 
+CUfileError_t cuFileBatchIOSetUp(...);
+CUfileError_t cuFileBatchIOSubmit(...);
+CUfileError_t cuFileBatchIOGetStatus(...);
+CUfileError_t cuFileBatchIOCancel(...);
+CUfileError_t cuFileBatchIODestroy(...);
+#endif
+
+// If the Stream API isn't defined, we define some of the data types here.
+// Notice, this doesn't need to be ABI compatible with the cufile definitions.
+#ifndef KVIKIO_CUFILE_STREAM_API_FOUND
+CUfileError_t cuFileReadAsync(...);
+CUfileError_t cuFileWriteAsync(...);
+CUfileError_t cuFileStreamRegister(...);
+CUfileError_t cuFileStreamDeregister(...);
 #endif

--- a/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
@@ -57,7 +57,7 @@ struct CUfileDescr_t {
   } handle;
 };
 
-const char* cufileop_status_error(...) { return "KvikIO not compiled with cuFile.h"; };
+static inline const char* cufileop_status_error(CUfileOpError err) { return CUFILE_ERRSTR(err); };
 CUfileError_t cuFileHandleRegister(...);
 CUfileError_t cuFileHandleDeregister(...);
 ssize_t cuFileRead(...);


### PR DESCRIPTION
Moving all the `#ifdef KVIKIO_CUFILE_FOUND` to the shim layer