### PR TITLE
Initial Python Interface for cufile Async IO

### DIFF
--- a/python/kvikio/_lib/kvikio_cxx_api.pxd
+++ b/python/kvikio/_lib/kvikio_cxx_api.pxd
@@ -4,17 +4,16 @@
 # distutils: language = c++
 # cython: language_level=3
 
-cdef extern from "driver_types.h":
-    ctypedef struct CUstream_st:
-        pass
-    ctypedef CUstream_st *cudaStream_t
-
 from posix cimport fcntl
 
 from libcpp cimport bool
 from libcpp.string cimport string
 from libcpp.utility cimport pair
 from libcpp.vector cimport vector
+
+
+cdef extern from "cuda.h":
+    ctypedef void* CUstream
 
 
 cdef extern from "<future>" namespace "std" nogil:
@@ -114,12 +113,12 @@ cdef extern from "<kvikio/file_handle.hpp>" namespace "kvikio" nogil:
             size_t size,
             size_t file_offset,
             size_t devPtr_offset,
-            cudaStream_t stream
+            CUstream stream
         ) except +
         StreamFuture write_async(
             void* devPtr_base,
             size_t size,
             size_t file_offset,
             size_t devPtr_offset,
-            cudaStream_t stream
+            CUstream stream
         ) except +

--- a/python/kvikio/_lib/kvikio_cxx_api.pxd
+++ b/python/kvikio/_lib/kvikio_cxx_api.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 # distutils: language = c++

--- a/python/kvikio/_lib/kvikio_cxx_api.pxd
+++ b/python/kvikio/_lib/kvikio_cxx_api.pxd
@@ -4,6 +4,12 @@
 # distutils: language = c++
 # cython: language_level=3
 
+cdef extern from "driver_types.h":
+    # Adapted from https://github.com/andersbll/cudarray/blob/a2cffbb1434db9a7e6ed83211300d23d47630d2e/cudarray/wrap/cudart.pxd#L16
+    ctypedef struct CUstream_st:
+        pass
+    ctypedef CUstream_st *cudaStream_t
+
 from posix cimport fcntl
 
 from libcpp cimport bool
@@ -17,6 +23,10 @@ cdef extern from "<future>" namespace "std" nogil:
         future() except +
         T get() except +
 
+cdef extern from "<kvikio/stream.hpp>" namespace "kvikio" nogil:
+    cdef cppclass StreamFuture:
+        StreamFuture() except +
+        size_t check_bytes_done() except +
 
 cdef extern from "<kvikio/utils.hpp>" namespace "kvikio" nogil:
     bool is_future_done[T](const T& future) except +
@@ -96,4 +106,18 @@ cdef extern from "<kvikio/file_handle.hpp>" namespace "kvikio" nogil:
             size_t size,
             size_t file_offset,
             size_t devPtr_offset
+        ) except +
+        StreamFuture read_async(
+            void* devPtr_base,
+            size_t size,
+            size_t file_offset,
+            size_t devPtr_offset,
+            cudaStream_t stream
+        ) except +
+        StreamFuture write_async(
+            void* devPtr_base,
+            size_t size,
+            size_t file_offset,
+            size_t devPtr_offset,
+            cudaStream_t stream
         ) except +

--- a/python/kvikio/_lib/kvikio_cxx_api.pxd
+++ b/python/kvikio/_lib/kvikio_cxx_api.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 # distutils: language = c++

--- a/python/kvikio/_lib/kvikio_cxx_api.pxd
+++ b/python/kvikio/_lib/kvikio_cxx_api.pxd
@@ -1,11 +1,10 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 # distutils: language = c++
 # cython: language_level=3
 
 cdef extern from "driver_types.h":
-    # Adapted from https://github.com/andersbll/cudarray/blob/a2cffbb1434db9a7e6ed83211300d23d47630d2e/cudarray/wrap/cudart.pxd#L16
     ctypedef struct CUstream_st:
         pass
     ctypedef CUstream_st *cudaStream_t
@@ -23,10 +22,13 @@ cdef extern from "<future>" namespace "std" nogil:
         future() except +
         T get() except +
 
+
 cdef extern from "<kvikio/stream.hpp>" namespace "kvikio" nogil:
     cdef cppclass StreamFuture:
         StreamFuture() except +
+        StreamFuture(StreamFuture&&) except +
         size_t check_bytes_done() except +
+
 
 cdef extern from "<kvikio/utils.hpp>" namespace "kvikio" nogil:
     bool is_future_done[T](const T& future) except +

--- a/python/kvikio/_lib/libkvikio.pyx
+++ b/python/kvikio/_lib/libkvikio.pyx
@@ -184,7 +184,6 @@ cdef class CuFile:
                    st: uintptr_t) -> IOFutureStream:
         stream = <CUstream>st
         cdef pair[uintptr_t, size_t] info = _parse_buffer(buf, size, False)
-        # TODO: return StreamFuture
         return _wrap_stream_future(self._handle.read_async(
             <void*>info.first,
             info.second,
@@ -197,7 +196,6 @@ cdef class CuFile:
                     st: uintptr_t) -> IOFutureStream:
         stream = <CUstream>st
         cdef pair[uintptr_t, size_t] info = _parse_buffer(buf, size, False)
-        # TODO: return StreamFuture
         return _wrap_stream_future(self._handle.write_async(
             <void*>info.first,
             info.second,

--- a/python/kvikio/cufile.py
+++ b/python/kvikio/cufile.py
@@ -16,7 +16,8 @@ class IOFutureStream:
 
     The instance must be kept alive alive until all data has been read from disk. One
     way to do this, is by calling `StreamFuture.check_bytes_done()`, which will
-    synchronize the associated stream and return the number of bytes read."""
+    synchronize the associated stream and return the number of bytes read.
+    """
 
     __slots__ = "_handle"
 
@@ -297,18 +298,21 @@ class CuFile:
         ----------
         buf: buffer-like or array-like
             Device buffer to read into.
+        stream: cuda.Stream
+            CUDA stream to perform the read operation asynchronously.
         size: int, optional
             Size in bytes to read.
         file_offset: int, optional
             Offset in the file to read from.
-        stream: cuda.Stream, optional
-            CUDA stream to perform the read operation asynchronously.
 
         Returns
         -------
-        IOFuture
+        IOFutureStream
             Future that when executed ".check_bytes_done()" returns the size of bytes
-            that were successfully read.
+            that were successfully read. The instance must be kept alive alive until
+            all data has been read from disk. One way to do this, is by calling
+            `StreamFuture.check_bytes_done()`, which will synchronize the associated
+            stream and return the number of bytes read.
         """
         return self._handle.read_async(buf, size, file_offset, dev_offset, stream)
 
@@ -329,18 +333,21 @@ class CuFile:
         ----------
         buf: buffer-like or array-like
             Device buffer to write to.
+        stream: cuda.Stream
+            CUDA stream to perform the write operation asynchronously.
         size: int, optional
             Size in bytes to write.
         file_offset: int, optional
             Offset in the file to write from.
-        stream: cuda.Stream, optional
-            CUDA stream to perform the write operation asynchronously.
 
         Returns
         -------
-        IOFuture
+        IOFutureStream
             Future that when executed ".check_bytes_done()" returns the size of bytes
-            that were successfully written.
+            that were successfully written. The instance must be kept alive alive until
+            all data has been written to disk. One way to do this, is by calling
+            `StreamFuture.check_bytes_done()`, which will synchronize the associated
+            stream and return the number of bytes written.
         """
         return self._handle.write_async(buf, size, file_offset, dev_offset, stream)
 

--- a/python/kvikio/cufile.py
+++ b/python/kvikio/cufile.py
@@ -7,13 +7,16 @@ from typing import Optional, Union
 from ._lib import libkvikio  # type: ignore
 
 
-class PyStreamFuture:
+class IOFutureStream:
     """Future for CuFile async IO
 
     This class shouldn't be used directly, instead non-blocking async IO operations
-    such as `CuFile.read_async` and `CuFile.write_async` returns an instance of this
-    class. Use `.check_bytes_done()` to check the number of bytes that were read or
-    written successfully."""
+    such as `CuFile.raw_read_async` and `CuFile.raw_write_async` returns an instance
+    of this class.
+
+    The instance must be kept alive alive until all data has been read from disk. One
+    way to do this, is by calling `StreamFuture.check_bytes_done()`, which will
+    synchronize the associated stream and return the number of bytes read."""
 
     __slots__ = "_handle"
 
@@ -277,14 +280,14 @@ class CuFile:
         """
         return self.pwrite(buf, size, file_offset, task_size).get()
 
-    def read_async(
+    def raw_read_async(
         self,
         buf,
         stream,
         size: Optional[int] = None,
         file_offset: int = 0,
         dev_offset: int = 0,
-    ) -> PyStreamFuture:
+    ) -> IOFutureStream:
         """Reads specified bytes from the file into the device memory asynchronously
 
         This is a low-level version of `.read` that doesn't use threads and
@@ -308,14 +311,14 @@ class CuFile:
         """
         return self._handle.read_async(buf, size, file_offset, dev_offset, stream)
 
-    def write_async(
+    def raw_write_async(
         self,
         buf,
         stream,
         size: Optional[int] = None,
         file_offset: int = 0,
         dev_offset: int = 0,
-    ) -> PyStreamFuture:
+    ) -> IOFutureStream:
         """Writes specified bytes from the device memory into the file asynchronously
 
         This is a low-level version of `.write` that doesn't use threads and

--- a/python/kvikio/cufile.py
+++ b/python/kvikio/cufile.py
@@ -309,7 +309,7 @@ class CuFile:
         -------
         IOFutureStream
             Future that when executed ".check_bytes_done()" returns the size of bytes
-            that were successfully read. The instance must be kept alive alive until
+            that were successfully read. The instance must be kept alive until
             all data has been read from disk. One way to do this, is by calling
             `IOFutureStream.check_bytes_done()`, which will synchronize the associated
             stream and return the number of bytes read.
@@ -344,7 +344,7 @@ class CuFile:
         -------
         IOFutureStream
             Future that when executed ".check_bytes_done()" returns the size of bytes
-            that were successfully written. The instance must be kept alive alive until
+            that were successfully written. The instance must be kept alive until
             all data has been written to disk. One way to do this, is by calling
             `IOFutureStream.check_bytes_done()`, which will synchronize the associated
             stream and return the number of bytes written.

--- a/python/kvikio/cufile.py
+++ b/python/kvikio/cufile.py
@@ -290,7 +290,7 @@ class CuFile:
     ) -> IOFutureStream:
         """Reads specified bytes from the file into the device memory asynchronously
 
-        This is a low-level version of `.read` that doesn't use threads and
+        This is an async version of `.raw_read` that doesn't use threads and
         does not support host memory.
 
         Parameters
@@ -306,8 +306,9 @@ class CuFile:
 
         Returns
         -------
-        int
-            The size of bytes that were successfully read.
+        IOFuture
+            Future that when executed ".check_bytes_done()" returns the size of bytes
+            that were successfully read.
         """
         return self._handle.read_async(buf, size, file_offset, dev_offset, stream)
 
@@ -321,7 +322,7 @@ class CuFile:
     ) -> IOFutureStream:
         """Writes specified bytes from the device memory into the file asynchronously
 
-        This is a low-level version of `.write` that doesn't use threads and
+        This is an async version of `.raw_write` that doesn't use threads and
         does not support host memory.
 
         Parameters
@@ -337,8 +338,9 @@ class CuFile:
 
         Returns
         -------
-        int
-            The size of bytes that were successfully written.
+        IOFuture
+            Future that when executed ".check_bytes_done()" returns the size of bytes
+            that were successfully written.
         """
         return self._handle.write_async(buf, size, file_offset, dev_offset, stream)
 

--- a/python/kvikio/cufile.py
+++ b/python/kvikio/cufile.py
@@ -311,7 +311,7 @@ class CuFile:
             Future that when executed ".check_bytes_done()" returns the size of bytes
             that were successfully read. The instance must be kept alive alive until
             all data has been read from disk. One way to do this, is by calling
-            `StreamFuture.check_bytes_done()`, which will synchronize the associated
+            `IOFutureStream.check_bytes_done()`, which will synchronize the associated
             stream and return the number of bytes read.
         """
         return self._handle.read_async(buf, size, file_offset, dev_offset, stream)
@@ -346,7 +346,7 @@ class CuFile:
             Future that when executed ".check_bytes_done()" returns the size of bytes
             that were successfully written. The instance must be kept alive alive until
             all data has been written to disk. One way to do this, is by calling
-            `StreamFuture.check_bytes_done()`, which will synchronize the associated
+            `IOFutureStream.check_bytes_done()`, which will synchronize the associated
             stream and return the number of bytes written.
         """
         return self._handle.write_async(buf, size, file_offset, dev_offset, stream)

--- a/python/kvikio/cufile.py
+++ b/python/kvikio/cufile.py
@@ -260,8 +260,78 @@ class CuFile:
         """
         return self.pwrite(buf, size, file_offset, task_size).get()
 
+    def read_async(
+        self,
+        buf,
+        stream,
+        size: Optional[int] = None,
+        file_offset: int = 0,
+        dev_offset: int = 0,
+    ) -> int:
+        """Reads specified bytes from the file into the device memory asynchronously
+
+        This is a low-level version of `.read` that doesn't use threads and
+        does not support host memory.
+
+        Parameters
+        ----------
+        buf: buffer-like or array-like
+            Device buffer to read into.
+        size: int, optional
+            Size in bytes to read.
+        file_offset: int, optional
+            Offset in the file to read from.
+        stream: cuda.Stream, optional
+            CUDA stream to perform the read operation asynchronously.
+
+        Returns
+        -------
+        int
+            The size of bytes that were successfully read.
+        """
+        return self._handle.read_async(
+            buf, size, file_offset, dev_offset, stream
+        )
+
+    def write_async(
+        self,
+        buf,
+        stream,
+        size: Optional[int] = None,
+        file_offset: int = 0,
+        dev_offset: int = 0,
+    ) -> int:
+        """Writes specified bytes from the device memory into the file asynchronously
+
+        This is a low-level version of `.write` that doesn't use threads and
+        does not support host memory.
+
+        Parameters
+        ----------
+        buf: buffer-like or array-like
+            Device buffer to write to.
+        size: int, optional
+            Size in bytes to write.
+        file_offset: int, optional
+            Offset in the file to write from.
+        stream: cuda.Stream, optional
+            CUDA stream to perform the write operation asynchronously.
+
+        Returns
+        -------
+        int
+            The size of bytes that were successfully written.
+        """
+        return self._handle.write_async(
+            buf, size, file_offset, dev_offset, stream
+        )
+
     def raw_read(
-        self, buf, size: Optional[int] = None, file_offset: int = 0, dev_offset: int = 0
+        self,
+        buf,
+        size: Optional[int] = None,
+        file_offset: int = 0,
+        dev_offset: int = 0,
     ) -> int:
         """Reads specified bytes from the file into the device memory
 
@@ -297,7 +367,11 @@ class CuFile:
         return self._handle.read(buf, size, file_offset, dev_offset)
 
     def raw_write(
-        self, buf, size: Optional[int] = None, file_offset: int = 0, dev_offset: int = 0
+        self,
+        buf,
+        size: Optional[int] = None,
+        file_offset: int = 0,
+        dev_offset: int = 0,
     ) -> int:
         """Writes specified bytes from the device memory into the file
 

--- a/python/tests/test_async_io.py
+++ b/python/tests/test_async_io.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 import os
@@ -16,34 +16,43 @@ def check_bit_flags(x: int, y: int) -> bool:
 
 
 @pytest.mark.parametrize("size", [1, 10, 100, 1000, 1024, 4096, 4096 * 10])
-@pytest.mark.parametrize("nthreads", [1, 3, 4, 16])
-@pytest.mark.parametrize("tasksize", [199, 1024])
-def test_read_write(tmp_path, gds_threshold, size, nthreads, tasksize):
+def test_read_write(tmp_path, size):
     """Test basic read/write"""
     filename = tmp_path / "test-file"
 
     stream = cupy.cuda.Stream()
 
-    with kvikio.defaults.set_num_threads(nthreads):
-        with kvikio.defaults.set_task_size(tasksize):
-            # Write file
-            a = cupy.arange(size)
-            f = kvikio.CuFile(filename, "w")
-            assert not f.closed
-            assert check_bit_flags(f.open_flags(), os.O_WRONLY)
-            assert f.raw_write_async(a, stream.ptr).check_bytes_done() == a.nbytes
+    # Write file
+    a = cupy.arange(size)
+    f = kvikio.CuFile(filename, "w")
+    assert not f.closed
+    assert check_bit_flags(f.open_flags(), os.O_WRONLY)
+    assert f.raw_write_async(a, stream.ptr).check_bytes_done() == a.nbytes
 
-            # Try to read file opened in write-only mode
-            with pytest.raises(RuntimeError, match="unsupported file open flags"):
-                f.raw_read_async(a, stream.ptr).check_bytes_done()
+    # Try to read file opened in write-only mode
+    with pytest.raises(RuntimeError, match="unsupported file open flags"):
+        # The exception is raised when we call the raw_read_async API.
+        future_stream = f.raw_read_async(a, stream.ptr)
+        future_stream.check_bytes_done()
 
-            # Close file
-            f.close()
-            assert f.closed
+    # Close file
+    f.close()
+    assert f.closed
 
-            # Read file into a new array and compare
-            b = cupy.empty_like(a)
-            f = kvikio.CuFile(filename, "r")
-            assert check_bit_flags(f.open_flags(), os.O_RDONLY)
-            assert f.raw_read_async(b, stream.ptr).check_bytes_done() == b.nbytes
-            assert all(a == b)
+    # Read file into a new array and compare
+    b = cupy.empty_like(a)
+    c = cupy.empty_like(a)
+    f = kvikio.CuFile(filename, "r+")
+    assert check_bit_flags(f.open_flags(), os.O_RDWR)
+
+    future_stream = f.raw_read_async(b, stream.ptr)
+    future_stream2 = f.raw_write_async(b, stream.ptr)
+    future_stream3 = f.raw_read_async(c, stream.ptr)
+    assert (
+        future_stream.check_bytes_done()
+        == future_stream2.check_bytes_done()
+        == future_stream3.check_bytes_done()
+        == b.nbytes
+    )
+    assert all(a == b)
+    assert all(a == c)

--- a/python/tests/test_async_io.py
+++ b/python/tests/test_async_io.py
@@ -1,0 +1,51 @@
+import os
+import cupy
+import pytest
+import torch
+
+import kvikio
+import kvikio.defaults
+
+import torch
+
+
+def check_bit_flags(x: int, y: int) -> bool:
+    """Check that the bits set in `y` is also set in `x`"""
+    return x & y == y
+
+
+@pytest.mark.parametrize("size", [1, 10, 100, 1000, 1024, 4096, 4096 * 10])
+@pytest.mark.parametrize("nthreads", [1, 3, 4, 16])
+@pytest.mark.parametrize("tasksize", [199, 1024])
+def test_read_write(tmp_path, gds_threshold, size, nthreads, tasksize):
+    """Test basic read/write"""
+    filename = tmp_path / "test-file"
+
+    stream = torch.cuda.stream(torch.cuda.Stream())
+    stream_ptr = stream.stream.cuda_stream
+
+    with kvikio.defaults.set_num_threads(nthreads):
+        with kvikio.defaults.set_task_size(tasksize):
+            # Write file
+            a = cupy.arange(size)
+            f = kvikio.CuFile(filename, "w")
+            assert not f.closed
+            assert check_bit_flags(f.open_flags(), os.O_WRONLY)
+            assert f.write_async(a, stream_ptr) == a.nbytes
+
+            # Try to read file opened in write-only mode
+            with pytest.raises(
+                RuntimeError, match="unsupported file open flags"
+            ):
+                f.read_async(a, stream_ptr)
+
+            # Close file
+            f.close()
+            assert f.closed
+
+            # Read file into a new array and compare
+            b = cupy.empty_like(a)
+            f = kvikio.CuFile(filename, "r")
+            assert check_bit_flags(f.open_flags(), os.O_RDONLY)
+            assert f.read_async(b, stream_ptr) == b.nbytes
+            assert all(a == b)


### PR DESCRIPTION
Hi there,

Thanks for this great repository! I want to use the cuFile async IO in my research project and noticed this kvikio repo. However, the initial support has been done in #259 and tracked in #204, but the Python interface hasn't been done yet. So I exported the write_async and read_async to the CuFile Python class and added test case. This will be very helpful for my project where I want to do the PyTorch training computation and simultaneously load tensors from the SSDs. I created this PR because hopefully, it could be helpful for your repository as well as keeping the Python interface current.

Please let me know your thoughts. Thank you.

Best Regards,
Kun