### PR TITLE
remove unnecessary 'setuptools' dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,6 @@ The Python packages depends on the following packages:
 
 * Cython
 * Pip
-* Setuptools
 
 For testing:
 * pytest

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -54,7 +54,6 @@ requirements:
     - {{ stdlib("c") }}
   host:
     - python
-    - setuptools
     - pip
     - cython >=3.0.0
     {% if cuda_major == "11" %}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/62.

It looks like this some of the `kvikio` conda package recipe has an unnecessary dependency on `setuptools`. I suspect that's left over from before the project was cut over to `scikit-build-core`.

This proposes removing it.

## Notes for Reviewers

How I confirmed there were no direct uses of `setuptools` in  this project:

```shell
git grep -i setuptools
```