### PR TITLE
Remove text builds of documentation

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -40,10 +40,8 @@ popd
 rapids-logger "Build Python docs"
 pushd docs
 sphinx-build -b dirhtml source _html -W
-sphinx-build -b text source _text -W
-mkdir -p "${RAPIDS_DOCS_DIR}/kvikio/"{html,txt}
+mkdir -p "${RAPIDS_DOCS_DIR}/kvikio/"html
 mv _html/* "${RAPIDS_DOCS_DIR}/kvikio/html"
-mv _text/* "${RAPIDS_DOCS_DIR}/kvikio/txt"
 popd
 
 rapids-upload-docs


### PR DESCRIPTION
This PR removes text builds of the documentation, which we do not currently use for anything. Contributes to https://github.com/rapidsai/build-planning/issues/71.
