### PR TITLE
Avoid --find-links in wheel jobs

### DIFF
--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -17,7 +17,14 @@ CPP_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libkvikio_${RAPIDS_PY_CUDA_SUFFIX}" rapid
 
 cd "${package_dir}"
 
-python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check --find-links ${CPP_WHEELHOUSE}
+# ensure 'kvikio wheel builds always use the 'libkvikio' just built in the same CI run
+#
+# using env variable PIP_CONSTRAINT is necessary to ensure the constraints
+# are used when creating the isolated build environment
+echo "libkvikio-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${CPP_WHEELHOUSE}/libkvikio_*.whl)" > ./constraints.txt
+
+PIP_CONSTRAINT="${PWD}/constraints.txt" \
+    python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
 mkdir -p final_dist
 python -m auditwheel repair -w final_dist dist/*

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -17,7 +17,7 @@ CPP_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libkvikio_${RAPIDS_PY_CUDA_SUFFIX}" rapid
 
 cd "${package_dir}"
 
-# ensure 'kvikio wheel builds always use the 'libkvikio' just built in the same CI run
+# ensure 'kvikio' wheel builds always use the 'libkvikio' just built in the same CI run
 #
 # using env variable PIP_CONSTRAINT is necessary to ensure the constraints
 # are used when creating the isolated build environment


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/69.

Proposes a stricter pattern for passing a `libkvikio` wheel from the `wheel-build-cpp` job that produced it into the `wheel-build-python` job wanting to use it (as a build dependency of `kvikio`). This change improves the likelihood that issues with the `libkivkio` wheels will be caught in CI.

## Notes for Reviewers

See https://github.com/rapidsai/rmm/pull/1586 and https://github.com/rapidsai/build-planning/issues/69#issuecomment-2174556118 for details on how I tested this approach.

I didn't propose this on #369 because I hadn't quite finished testing the approach yet. But I do think we should do this for all of the C++ wheels (https://github.com/rapidsai/build-planning/issues/33).