### PR TITLE
Properly quote items in __all__

### DIFF
--- a/python/libkvikio/libkvikio/__init__.py
+++ b/python/libkvikio/libkvikio/__init__.py
@@ -14,4 +14,4 @@
 
 from libkvikio._version import __git_commit__, __version__
 
-__all__ = [__git_commit__, __version__]
+__all__ = ["__git_commit__", "__version__"]


### PR DESCRIPTION
__all__ tells you the names of the members, not the members themselves. Quote the members.