### PR TITLE
cufile-wrapper: include the cuda-wrapper

### DIFF
--- a/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
@@ -17,6 +17,8 @@
 
 #include <sys/types.h>
 
+#include <kvikio/shim/cuda_h_wrapper.hpp>
+
 /**
  * In order to support compilation when `cufile.h` isn't available, we
  * wrap all use of cufile in a `#ifdef KVIKIO_CUFILE_FOUND` guard.


### PR DESCRIPTION
Fix the cufile-wrapper when `cuda.h` isn't available