### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -27,7 +27,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
-- python>=3.9,<3.12
+- python>=3.10,<3.12
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core>=0.10.0
 - sphinx

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -29,7 +29,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
-- python>=3.9,<3.12
+- python>=3.10,<3.12
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core>=0.10.0
 - sphinx

--- a/conda/environments/all_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-125_arch-aarch64.yaml
@@ -27,7 +27,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
-- python>=3.9,<3.12
+- python>=3.10,<3.12
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core>=0.10.0
 - sphinx

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -27,7 +27,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
-- python>=3.9,<3.12
+- python>=3.10,<3.12
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core>=0.10.0
 - sphinx

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -278,10 +278,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              py: "3.9"
-            packages:
-              - python=3.9
-          - matrix:
               py: "3.10"
             packages:
               - python=3.10
@@ -291,7 +287,7 @@ dependencies:
               - python=3.11
           - matrix:
             packages:
-              - python>=3.9,<3.12
+              - python>=3.10,<3.12
   rapids_build_skbuild:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/kvikio/pyproject.toml
+++ b/python/kvikio/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = { text = "Apache 2.0" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "cupy-cuda11x>=12.0.0",
     "numcodecs <0.12.0",
@@ -31,7 +31,6 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
@@ -49,7 +48,7 @@ Homepage = "https://github.com/rapidsai/kvikio"
 
 [tool.black]
 line-length = 88
-target-version = ["py39"]
+target-version = ["py310"]
 include = '\.py?$'
 exclude = '''
 /(

--- a/python/libkvikio/pyproject.toml
+++ b/python/libkvikio/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/88

Finishes the work of dropping Python 3.9 support.

This project stopped building / testing against Python 3.9 as of https://github.com/rapidsai/shared-workflows/pull/235.
This PR updates configuration and docs to reflect that.

## Notes for Reviewers

### How I tested this

Checked that there were no remaining uses like this:

```shell
git grep -E '3\.9'
git grep '39'
git grep 'py39'
```

And similar for variations on Python 3.8 (to catch things that were missed the last time this was done).
