### PR TITLE
remove pytest dependency in kvikio conda recipe

### DIFF
--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -78,8 +78,6 @@ requirements:
     {% endif %}
 
 test:
-  requires:
-    - pytest
   imports:
     - kvikio
 


### PR DESCRIPTION
`kvikio`'s conda recipe only has an `import:` test (basically, makes `conda-build` run `python -c "import kvikio"` after building).

It doesn't ask `conda-build` to run any other tests.

Therefore, its `test:` dependency on `pytest` is unnecessary. This proposes removing it.

## Notes for Reviewers

conda docs on how the `test:` section of a recipe works: https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#test-section