### PR TITLE
Intentionally leak static CUDA resources to avoid crash (part 2)

### DIFF
--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -41,7 +41,7 @@ class StreamsByThread {
   std::map<std::pair<CUcontext, std::thread::id>, CUstream> _streams;
 
  public:
-  StreamsByThread() = default;
+  StreamsByThread()  = default;
   ~StreamsByThread() = default;
 
   static CUstream get(CUcontext ctx, std::thread::id thd_id)

--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -41,7 +41,12 @@ class StreamsByThread {
   std::map<std::pair<CUcontext, std::thread::id>, CUstream> _streams;
 
  public:
-  StreamsByThread()  = default;
+  StreamsByThread() = default;
+
+  // Here we intentionally do not destroy in the destructor the CUDA resources
+  // (e.g. CUstream) with static storage duration, but instead let them leak
+  // on program termination. This is to prevent undefined behavior in CUDA. See
+  // <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#initialization>
   ~StreamsByThread() = default;
 
   static CUstream get(CUcontext ctx, std::thread::id thd_id)

--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -42,16 +42,7 @@ class StreamsByThread {
 
  public:
   StreamsByThread() = default;
-  ~StreamsByThread() noexcept
-  {
-    for (auto& [_, stream] : _streams) {
-      try {
-        CUDA_DRIVER_TRY(cudaAPI::instance().StreamDestroy(stream));
-      } catch (const CUfileException& e) {
-        std::cerr << e.what() << std::endl;
-      }
-    }
-  }
+  ~StreamsByThread() = default;
 
   static CUstream get(CUcontext ctx, std::thread::id thd_id)
   {

--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -47,6 +47,8 @@ class StreamsByThread {
   // (e.g. CUstream) with static storage duration, but instead let them leak
   // on program termination. This is to prevent undefined behavior in CUDA. See
   // <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#initialization>
+  // This also prevents crash (segmentation fault) if clients call
+  // cuDevicePrimaryCtxReset() or cudaDeviceReset() before program termination.
   ~StreamsByThread() = default;
 
   static CUstream get(CUcontext ctx, std::thread::id thd_id)


### PR DESCRIPTION
The NVbench application `PARQUET_READER_NVBENCH` in libcudf currently crashes with the segmentation fault. To reproduce:

```
./PARQUET_READER_NVBENCH -d 0 -b 1 --run-once -a io_type=FILEPATH -a compression_type=SNAPPY -a cardinality=0 -a run_length=1
```
 
The root cause is that some (1) `thread_local`  objects on the main thread in `libcudf` and (2) `static` objects in `kvikio` are destroyed after `cudaDeviceReset()` in NVbench and upon program termination. These objects should simply be leaked, since their destructors making CUDA calls upon program termination constitutes UB in CUDA.

This simple PR is the kvikIO side of the fix. The other part is done here https://github.com/rapidsai/cudf/pull/16787.
