### PR TITLE
Update to flake8 7.1.1.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         files: python/.*
         args: ["--config", "python/kvikio/pyproject.toml"]
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         args: ["--config=.flake8"]


### PR DESCRIPTION
We need to update flake8 to fix a false-positive that appears with older flake8 versions on Python 3.12.
