### PR TITLE
Remove now unnecessary variable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -127,11 +127,6 @@ if hasArg --pydevelop; then
     PYTHON_ARGS_FOR_INSTALL="${PYTHON_ARGS_FOR_INSTALL} -e"
 fi
 
-# Append `-DFIND_KVIKIO_CPP=ON` to EXTRA_CMAKE_ARGS unless a user specified the option.
-if [[ "${EXTRA_CMAKE_ARGS}" != *"DFIND_KVIKIO_CPP"* ]]; then
-    EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DFIND_KVIKIO_CPP=ON"
-fi
-
 # If clean given, run it prior to any other steps
 if hasArg clean; then
     # If the dirs to clean are mounted dirs in a container, the

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -24,7 +24,6 @@ cd "${package_dir}"
 echo "libkvikio-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${CPP_WHEELHOUSE}/libkvikio_*.whl)" > ./constraints.txt
 
 PIP_CONSTRAINT="${PWD}/constraints.txt" \
-SKBUILD_CMAKE_ARGS="-DFIND_KVIKIO_CPP=ON" \
     python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
 mkdir -p final_dist

--- a/python/kvikio/CMakeLists.txt
+++ b/python/kvikio/CMakeLists.txt
@@ -26,32 +26,19 @@ project(
   LANGUAGES CXX CUDA
 )
 
-option(FIND_KVIKIO_CPP
-       "Search for existing KVIKIO C++ installations before defaulting to local files" OFF
-)
-
 # TODO: Should we symlink FindcuFile.cmake into python/cmake? find cuFile
 include(../../cpp/cmake/Modules/FindcuFile.cmake)
 
-if(FIND_KVIKIO_CPP)
-  find_package(KvikIO REQUIRED "${RAPIDS_VERSION}")
-else()
-  set(KvikIO_FOUND OFF)
-endif()
+find_package(KvikIO REQUIRED "${RAPIDS_VERSION}")
 
 find_package(CUDAToolkit REQUIRED)
-
-set(cython_lib_dir kvikio)
-
-if(NOT KvikIO_FOUND)
-  add_subdirectory(../../cpp kvikio-cpp)
-  install(TARGETS kvikio DESTINATION ${cython_lib_dir})
-endif()
 
 include(rapids-cython-core)
 rapids_cython_init()
 
 add_subdirectory(cmake)
+
+set(cython_lib_dir kvikio)
 
 # It would be better to factor nvcomp out into its own wheel. Until that is available, we vendor it
 # here.


### PR DESCRIPTION
As of https://github.com/rapidsai/kvikio/pull/439 the `FIND_KVIKIO_CPP` variable is largely superfluous. In principle we could still choose to support users who want to build the Python package without having the C++ library already available somewhere, but that use case is vanishingly small now that we have C++ wheels and it would require the developer to intentionally build without isolation and omit the C++ wheel from the environment. For advanced use cases like that it is reasonable to ask the user to handle building the C++ library separately on their own and making it available for the Python package to find. None of the normal build cases that we support (conda, pip, devcontainers, DLFW) require this any longer.