### PR TITLE
Touch ups to `Array`

### DIFF
--- a/python/kvikio/kvikio/_lib/arr.pxd
+++ b/python/kvikio/kvikio/_lib/arr.pxd
@@ -28,6 +28,9 @@ cdef class Array:
     cpdef Py_ssize_t _nbytes(self)
 
 
+cpdef Array asarray(obj)
+
+
 cdef pair[uintptr_t, size_t] parse_buffer_argument(
     buf, size, bint accept_host_buffer
 ) except *

--- a/python/kvikio/kvikio/_lib/arr.pyi
+++ b/python/kvikio/kvikio/_lib/arr.pyi
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 from typing import Generic, Tuple, TypeVar

--- a/python/kvikio/kvikio/_lib/arr.pyi
+++ b/python/kvikio/kvikio/_lib/arr.pyi
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 from typing import Generic, Tuple, TypeVar

--- a/python/kvikio/kvikio/_lib/arr.pyx
+++ b/python/kvikio/kvikio/_lib/arr.pyx
@@ -289,9 +289,10 @@ cdef inline Py_ssize_t _nbytes(Py_ssize_t itemsize,
         nbytes *= shape_mv[i]
     return nbytes
 
-cpdef asarray(obj):
+
+cpdef Array asarray(obj):
     if isinstance(obj, Array):
-        return obj
+        return <Array>obj
     else:
         return Array(obj)
 

--- a/python/kvikio/kvikio/_lib/arr.pyx
+++ b/python/kvikio/kvikio/_lib/arr.pyx
@@ -291,6 +291,14 @@ cdef inline Py_ssize_t _nbytes(Py_ssize_t itemsize,
 
 
 cpdef Array asarray(obj):
+    """Coerce other objects to ``Array``. No-op for existing ``Array``s.
+
+    Args:
+        obj: Object exposing the Python buffer protocol or ``__cuda_array_interface__``
+
+    Returns:
+        Array: An instance of the ``Array`` class
+    """
     if isinstance(obj, Array):
         return <Array>obj
     else:


### PR DESCRIPTION
* Add return type to `asarray` (makes easy to use with other typed values)
* Include `asarray` in `pxd` for faster access within other Cython modules