### PR TITLE
Visibility of static class methods

### DIFF
--- a/cpp/include/kvikio/bounce_buffer.hpp
+++ b/cpp/include/kvikio/bounce_buffer.hpp
@@ -143,7 +143,7 @@ class AllocRetain {
     return _clear();
   }
 
-  static AllocRetain& instance()
+  KVIKIO_EXPORT static AllocRetain& instance()
   {
     static AllocRetain _instance;
     return _instance;

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -133,7 +133,7 @@ class defaults {
     }
   }
 
-  static defaults* instance()
+  KVIKIO_EXPORT static defaults* instance()
   {
     static defaults _instance;
     return &_instance;

--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -51,7 +51,7 @@ class StreamsByThread {
   // cuDevicePrimaryCtxReset() or cudaDeviceReset() before program termination.
   ~StreamsByThread() = default;
 
-  static CUstream get(CUcontext ctx, std::thread::id thd_id)
+  KVIKIO_EXPORT static CUstream get(CUcontext ctx, std::thread::id thd_id)
   {
     static StreamsByThread _instance;
 

--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -85,7 +85,7 @@ class cudaAPI {
   cudaAPI(cudaAPI const&)        = delete;
   void operator=(cudaAPI const&) = delete;
 
-  static cudaAPI& instance()
+  KVIKIO_EXPORT static cudaAPI& instance()
   {
     static cudaAPI _instance;
     return _instance;

--- a/cpp/include/kvikio/shim/cufile.hpp
+++ b/cpp/include/kvikio/shim/cufile.hpp
@@ -132,7 +132,7 @@ class cuFileAPI {
   cuFileAPI(cuFileAPI const&&)      = delete;
   void operator=(cuFileAPI const&&) = delete;
 
-  static cuFileAPI& instance()
+  KVIKIO_EXPORT static cuFileAPI& instance()
   {
     static cuFileAPI _instance;
     return _instance;

--- a/cpp/include/kvikio/shim/utils.hpp
+++ b/cpp/include/kvikio/shim/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,21 @@
 #include <vector>
 
 namespace kvikio {
+
+// Macros used for defining symbol visibility, only GLIBC is supported.
+// Since KvikIO is header-only, we rely on the linker to disambiguate inline functions
+// and static methods that have (or return) static references. To do this, the relevant
+// function/method must have `__attribute__((visibility("default")))`. If not, then if
+// KvikIO is used in two different DSOs, the function will appear twice, and there will
+// be two static objects.
+// See <https://gcc.gnu.org/wiki/Visibility> and <https://github.com/rapidsai/kvikio/issues/442>.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#define KVIKIO_EXPORT __attribute__((visibility("default")))
+#define KVIKIO_HIDDEN __attribute__((visibility("hidden")))
+#else
+#define KVIKIO_EXPORT
+#define KVIKIO_HIDDEN
+#endif
 
 #define KVIKIO_STRINGIFY_DETAIL(x) #x
 #define KVIKIO_STRINGIFY(x)        KVIKIO_STRINGIFY_DETAIL(x)

--- a/cpp/include/kvikio/shim/utils.hpp
+++ b/cpp/include/kvikio/shim/utils.hpp
@@ -23,7 +23,7 @@
 
 namespace kvikio {
 
-// Macros used for defining symbol visibility, only GLIBC is supported.
+// Macros used for defining symbol visibility.
 // Since KvikIO is header-only, we rely on the linker to disambiguate inline functions
 // and static methods that have (or return) static references. To do this, the relevant
 // function/method must have `__attribute__((visibility("default")))`. If not, then if

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -32,20 +32,6 @@
 #include <kvikio/error.hpp>
 #include <kvikio/shim/cuda.hpp>
 
-// Macros used for defining symbol visibility, only GLIBC is supported.
-// Since KvikIO is header-only, we rely on the linker to disambiguate inline functions
-// that have (or return) static references. To do this, the relevant function must have
-// `__attribute__((visibility("default")))`. If not, then if KvikIO is used in two
-// different DSOs, the function will appear twice, and there will be two static objects.
-// See <https://github.com/rapidsai/kvikio/issues/442>.
-#if (defined(__GNUC__) || defined(__clang__)) && !defined(__MINGW32__) && !defined(__MINGW64__)
-#define KVIKIO_EXPORT __attribute__((visibility("default")))
-#define KVIKIO_HIDDEN __attribute__((visibility("hidden")))
-#else
-#define KVIKIO_EXPORT
-#define KVIKIO_HIDDEN
-#endif
-
 namespace kvikio {
 
 // cuFile defines a page size to 4 KiB


### PR DESCRIPTION
We need to export static class methods that returns a reference to a static variable like we do with inline functions: https://github.com/rapidsai/kvikio/issues/442