### PR TITLE
Simplify `_to_string` encoding of Python `str`s

### DIFF
--- a/python/kvikio/kvikio/_lib/remote_handle.pyx
+++ b/python/kvikio/kvikio/_lib/remote_handle.pyx
@@ -40,11 +40,13 @@ cdef extern from "<kvikio/remote_handle.hpp>" nogil:
             size_t file_offset
         ) except +
 
-cdef string _to_string(str_or_none):
+
+cdef string _to_string(str s):
     """Convert Python object to a C++ string (if None, return the empty string)"""
-    if str_or_none is None:
+    if s is not None:
+        return s.encode()
+    else:
         return string()
-    return str.encode(str(str_or_none))
 
 
 cdef class RemoteFile:


### PR DESCRIPTION
Makes a few improvements to the Cython logic of `_to_string`:

* Types the input as `str`: This allows Cython to use CPython API relevant for the specific type (it will check type on entry)
* Do `is not None` check first: This way when Cython generates additional `None` checks inside the branch, the compiler can optimize them out
* Use `str`'s `encode` method: Cython makes a direct CPython call to generate `bytes` and then extracts the pointer and size for C++ to copy