### PR TITLE
Disabling curl tests doesn't now disable kvikio cpp tests

### DIFF
--- a/cpp/cmake/thirdparty/get_libcurl.cmake
+++ b/cpp/cmake/thirdparty/get_libcurl.cmake
@@ -16,6 +16,11 @@
 function(find_and_configure_libcurl)
   include(${rapids-cmake-dir}/cpm/find.cmake)
 
+  # Work around https://github.com/curl/curl/issues/15351
+  if(DEFINED CACHE{BUILD_TESTING})
+    set(CACHE_HAS_BUILD_TESTING $CACHE{BUILD_TESTING})
+  endif()
+
   rapids_cpm_find(
     CURL 7.87.0
     GLOBAL_TARGETS libcurl
@@ -27,6 +32,11 @@ function(find_and_configure_libcurl)
     OPTIONS "BUILD_CURL_EXE OFF" "BUILD_SHARED_LIBS OFF" "BUILD_TESTING OFF" "CURL_USE_LIBPSL OFF"
             "CURL_DISABLE_LDAP ON" "CMAKE_POSITION_INDEPENDENT_CODE ON"
   )
+  if(DEFINED CACHE_HAS_BUILD_TESTING)
+    set(BUILD_TESTING ${CACHE_HAS_BUILD_TESTING} CACHE BOOL "" FORCE)
+  else()
+    unset(BUILD_TESTING CACHE)
+  endif()
 endfunction()
 
 find_and_configure_libcurl()

--- a/cpp/cmake/thirdparty/get_libcurl.cmake
+++ b/cpp/cmake/thirdparty/get_libcurl.cmake
@@ -35,7 +35,8 @@ function(find_and_configure_libcurl)
   if(DEFINED CACHE_HAS_BUILD_TESTING)
     set(BUILD_TESTING
         ${CACHE_HAS_BUILD_TESTING}
-        CACHE BOOL "" FORCE)
+        CACHE BOOL "" FORCE
+    )
   else()
     unset(BUILD_TESTING CACHE)
   endif()

--- a/cpp/cmake/thirdparty/get_libcurl.cmake
+++ b/cpp/cmake/thirdparty/get_libcurl.cmake
@@ -34,8 +34,8 @@ function(find_and_configure_libcurl)
   )
   if(DEFINED CACHE_HAS_BUILD_TESTING)
     set(BUILD_TESTING
-      ${CACHE_HAS_BUILD_TESTING}
-      CACHE BOOL "" FORCE)
+        ${CACHE_HAS_BUILD_TESTING}
+        CACHE BOOL "" FORCE)
   else()
     unset(BUILD_TESTING CACHE)
   endif()

--- a/cpp/cmake/thirdparty/get_libcurl.cmake
+++ b/cpp/cmake/thirdparty/get_libcurl.cmake
@@ -33,7 +33,9 @@ function(find_and_configure_libcurl)
             "CURL_DISABLE_LDAP ON" "CMAKE_POSITION_INDEPENDENT_CODE ON"
   )
   if(DEFINED CACHE_HAS_BUILD_TESTING)
-    set(BUILD_TESTING ${CACHE_HAS_BUILD_TESTING} CACHE BOOL "" FORCE)
+    set(BUILD_TESTING
+      ${CACHE_HAS_BUILD_TESTING}
+      CACHE BOOL "" FORCE)
   else()
     unset(BUILD_TESTING CACHE)
   endif()


### PR DESCRIPTION
Works around https://github.com/curl/curl/issues/15351 . We cache the `BUILD_TESTING` cache variable when it exists so that our tests are enabled when building curl from source.