### PR TITLE
WIP: [DO NOT MERGE] print sccache stats in builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,7 @@ repos:
               meta[.]yaml$
       - id: verify-alpha-spec
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.13.11
+    rev: v1.16.0
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean"]

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -16,6 +16,10 @@ rapids-print-env
 rapids-logger "Begin cpp build"
 conda config --set path_conflict prevent
 
+sccache --zero-stats
+
 rapids-conda-retry mambabuild conda/recipes/libkvikio
+
+sccache --show-adv-stats
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -18,8 +18,12 @@ rapids-logger "Begin py build"
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 conda config --set path_conflict prevent
 
+sccache --zero-stats
+
 rapids-conda-retry mambabuild \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/kvikio
+
+sccache --show-adv-stats
 
 rapids-upload-conda-to-s3 python

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -13,8 +13,13 @@ rapids-generate-version > ./VERSION
 
 cd "${package_dir}"
 
+sccache --zero-stats
+
 python -m pip install wheel
-python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
+
+sccache --show-adv-stats
+
+python -m pip wheel . -w dist -v --no-deps --disable-pip-version-check
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 cpp dist

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -23,9 +23,13 @@ cd "${package_dir}"
 # are used when creating the isolated build environment
 echo "libkvikio-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${CPP_WHEELHOUSE}/libkvikio_*.whl)" > ./constraints.txt
 
+sccache --zero-stats
+
 PIP_CONSTRAINT="${PWD}/constraints.txt" \
 SKBUILD_CMAKE_ARGS="-DUSE_NVCOMP_RUNTIME_WHEEL=ON" \
-    python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
+    python -m pip wheel . -w dist -v --no-deps --disable-pip-version-check
+
+sccache --show-adv-stats
 
 mkdir -p final_dist
 python -m auditwheel repair \
@@ -33,4 +37,4 @@ python -m auditwheel repair \
     -w final_dist \
     dist/*
 
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 final_dist
+RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python final_dist


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/111

Proposes some small packaging/CI changes, matching similar changes being made across RAPIDS.

* printing `sccache` stats to CI logs
* updating to the latest `rapids-dependency-file-generator` (v1.16.0)
* always explicitly specifying `cpp` / `python` in calls to `rapids-upload-wheels-to-s3`