### PR TITLE
Fix exporting of include directories

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -125,7 +125,8 @@ add_library(kvikio::kvikio ALIAS kvikio)
 
 target_include_directories(
   kvikio
-  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "$<BUILD_INTERFACE:${CUDAToolkit_INCLUDE_DIRS}>"
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+         "$<BUILD_INTERFACE:${CUDAToolkit_INCLUDE_DIRS}>"
          "$<BUILD_INTERFACE:${cuFile_INCLUDE_DIRS}>"
   INTERFACE "$<INSTALL_INTERFACE:include>"
 )

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -132,8 +132,12 @@ target_include_directories(
 # Notice, we do not link to cuda or cufile since KvikIO opens them manually using `dlopen()`.
 target_link_libraries(
   kvikio
-  PUBLIC Threads::Threads BS::thread_pool ${CMAKE_DL_LIBS} $<TARGET_NAME_IF_EXISTS:nvtx3::nvtx3-cpp>
-         $<COMPILE_ONLY:$<TARGET_NAME_IF_EXISTS:CUDA::cudart>> $<COMPILE_ONLY:$<TARGET_NAME_IF_EXISTS:cufile::cufile>>
+  PUBLIC Threads::Threads
+         BS::thread_pool
+         ${CMAKE_DL_LIBS}
+         $<TARGET_NAME_IF_EXISTS:nvtx3::nvtx3-cpp>
+         $<COMPILE_ONLY:$<TARGET_NAME_IF_EXISTS:CUDA::cudart>>
+         $<COMPILE_ONLY:$<TARGET_NAME_IF_EXISTS:cufile::cufile>>
   PRIVATE $<TARGET_NAME_IF_EXISTS:CURL::libcurl>
 )
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -125,8 +125,8 @@ add_library(kvikio::kvikio ALIAS kvikio)
 
 target_include_directories(
   kvikio
-  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "${CUDAToolkit_INCLUDE_DIRS}"
-         "${cuFile_INCLUDE_DIRS}"
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "$<BUILD_INTERFACE:${CUDAToolkit_INCLUDE_DIRS}>"
+         "$<BUILD_INTERFACE:${cuFile_INCLUDE_DIRS}>"
   INTERFACE "$<INSTALL_INTERFACE:include>"
 )
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -126,8 +126,6 @@ add_library(kvikio::kvikio ALIAS kvikio)
 target_include_directories(
   kvikio
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-         "$<BUILD_INTERFACE:${CUDAToolkit_INCLUDE_DIRS}>"
-         "$<BUILD_INTERFACE:${cuFile_INCLUDE_DIRS}>"
   INTERFACE "$<INSTALL_INTERFACE:include>"
 )
 
@@ -135,6 +133,7 @@ target_include_directories(
 target_link_libraries(
   kvikio
   PUBLIC Threads::Threads BS::thread_pool ${CMAKE_DL_LIBS} $<TARGET_NAME_IF_EXISTS:nvtx3::nvtx3-cpp>
+         $<COMPILE_ONLY:$<TARGET_NAME_IF_EXISTS:CUDA::cudart>> $<COMPILE_ONLY:$<TARGET_NAME_IF_EXISTS:cufile::cufile>>
   PRIVATE $<TARGET_NAME_IF_EXISTS:CURL::libcurl>
 )
 


### PR DESCRIPTION
The CUDA and cufile include directories should not be exported as absolute paths when installing, only in the build tree. Add a `$<BUILD_INTERFACE>` generator expression.