### PR TITLE
fix library-loading issues in editable installs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -104,6 +104,7 @@ jobs:
       build_command: |
         sccache -z;
         build-all --verbose;
+        python -c "import kvikio; print(kvikio.__version__)";
         sccache -s;
   wheel-cpp-build:
     secrets: inherit

--- a/python/libkvikio/libkvikio/load.py
+++ b/python/libkvikio/libkvikio/load.py
@@ -63,9 +63,15 @@ def load_library():
         # Prefer the libraries bundled in this package. If they aren't found
         # (which might be the case in builds where the library was prebuilt
         # before packaging the wheel), look for a system installation.
-        libkvikio_lib = _load_wheel_installation(soname)
-        if libkvikio_lib is None:
-            libkvikio_lib = _load_system_installation(soname)
+        try:
+            libkvikio_lib = _load_wheel_installation(soname)
+            if libkvikio_lib is None:
+                libkvikio_lib = _load_system_installation(soname)
+        except OSError:
+            # If none of the searches above succeed, just silently return None
+            # and rely on other mechanisms (like RPATHs on other DSOs) to
+            # help the loader find the library.
+            pass
 
     # The caller almost never needs to do anything with this library, but no
     # harm in offering the option since this object at least provides a handle


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/118

The pattern introduced in #551 breaks editable installs in devcontainers. In that type of build, `libkvikio.so` is built outside of the wheel but **not installed**, so it can't be found by `ld`. Extension modules in `kvikio` are able to find it via RPATHs instead.

This proposes:

* try-catching the entire library-loading attempt, to silently do nothing in cases like that
* adding an import of the `kvikio` Python library in the `devcontainers` CI job, as a smoke test to catch issues like this in the future

## Notes for Reviewers

### How I tested this

Reproduced that with the CUDA 12.5 pip devcontainers today:

```shell
build-all
python -c "import kvikio"
# OSError: libkvikio.so: cannot open shared object file: No such file or directory
```

Confirmed that the changes in this PR fix that.