### PR TITLE
Fix the pytest error for async io

### DIFF
--- a/python/kvikio/tests/test_async_io.py
+++ b/python/kvikio/tests/test_async_io.py
@@ -32,7 +32,9 @@ def test_read_write(tmp_path, size):
     # Try to read file opened in write-only mode
     # POSIX read would yield the error "Operation not permitted"
     # cuFile read would yield the error "unsupported file open flags"
-    with pytest.raises(RuntimeError, match="Operation not permitted|unsupported file open flags"):
+    with pytest.raises(
+        RuntimeError, match="Operation not permitted|unsupported file open flags"
+    ):
         # The exception is raised when we call the raw_read_async API.
         future_stream = f.raw_read_async(a, stream.ptr)
         future_stream.check_bytes_done()

--- a/python/kvikio/tests/test_async_io.py
+++ b/python/kvikio/tests/test_async_io.py
@@ -30,7 +30,9 @@ def test_read_write(tmp_path, size):
     assert f.raw_write_async(a, stream.ptr).check_bytes_done() == a.nbytes
 
     # Try to read file opened in write-only mode
-    with pytest.raises(RuntimeError, match="Operation not permitted"):
+    # POSIX read would yield the error "Operation not permitted"
+    # cuFile read would yield the error "unsupported file open flags"
+    with pytest.raises(RuntimeError, match="Operation not permitted|unsupported file open flags"):
         # The exception is raised when we call the raw_read_async API.
         future_stream = f.raw_read_async(a, stream.ptr)
         future_stream.check_bytes_done()


### PR DESCRIPTION
This PR fixes #558 

The root cause is that POSIX and cuFile report different error messages for the same invalid operation which attempts to read from a write-only file. The unit test needs to take account of these different messages.