### PR TITLE
Remove upper bounds on cuda-python to allow 12.6.2 and 11.8.5

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=3.26.4,!=3.30.0
-- cuda-python>=11.7.1,<12.0a0,<=11.8.3
+- cuda-python>=11.7.1,<12.0a0
 - cuda-version=11.8
 - cudatoolkit
 - cupy>=12.0.0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=3.26.4,!=3.30.0
-- cuda-python>=11.7.1,<12.0a0,<=11.8.3
+- cuda-python>=11.7.1,<12.0a0
 - cuda-version=11.8
 - cudatoolkit
 - cupy>=12.0.0

--- a/conda/environments/all_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-125_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cmake>=3.26.4,!=3.30.0
 - cuda-nvcc
-- cuda-python>=12.0,<13.0a0,<=12.6.0
+- cuda-python>=12.0,<13.0a0
 - cuda-version=12.5
 - cupy>=12.0.0
 - cxx-compiler

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - cmake>=3.26.4,!=3.30.0
 - cuda-nvcc
-- cuda-python>=12.0,<13.0a0,<=12.6.0
+- cuda-python>=12.0,<13.0a0
 - cuda-version=12.5
 - cupy>=12.0.0
 - cxx-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -392,10 +392,10 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cuda-python>=12.0,<13.0a0,<=12.6.0
+              - cuda-python>=12.0,<13.0a0
           - matrix: # All CUDA 11 versions
             packages:
-              - cuda-python>=11.7.1,<12.0a0,<=11.8.3
+              - cuda-python>=11.7.1,<12.0a0
   test_java:
     common:
       - output_types: conda

--- a/python/kvikio/pyproject.toml
+++ b/python/kvikio/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 [project.optional-dependencies]
 test = [
     "boto3>=1.21.21",
-    "cuda-python>=11.7.1,<12.0a0,<=11.8.3",
+    "cuda-python>=11.7.1,<12.0a0",
     "dask>=2022.05.2",
     "moto[server]>=4.0.8",
     "pytest",


### PR DESCRIPTION
Now that some upstream bugs have been fixed, we can allow cuda-python 12.6.2 and 11.8.5.

See https://github.com/NVIDIA/cuda-python/issues/226#issuecomment-2472355738 for more information.
