### PR TITLE
Use curl >=8.5.0 to align with conda-forge and avoid CVEs.

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cython>=3.0.0
 - doxygen=1.9.1
 - gcc_linux-aarch64=11.*
-- libcurl>=8.5.0
+- libcurl>=8.5.0,<9.0a0
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cython>=3.0.0
 - doxygen=1.9.1
 - gcc_linux-aarch64=11.*
-- libcurl>=7.87.0
+- libcurl>=8.5.0
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - gcc_linux-64=11.*
 - libcufile-dev=1.4.0.31
 - libcufile=1.4.0.31
-- libcurl>=8.5.0
+- libcurl>=8.5.0,<9.0a0
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - gcc_linux-64=11.*
 - libcufile-dev=1.4.0.31
 - libcufile=1.4.0.31
-- libcurl>=7.87.0
+- libcurl>=8.5.0
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/environments/all_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-125_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - doxygen=1.9.1
 - gcc_linux-aarch64=11.*
 - libcufile-dev
-- libcurl>=8.5.0
+- libcurl>=8.5.0,<9.0a0
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/environments/all_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-125_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - doxygen=1.9.1
 - gcc_linux-aarch64=11.*
 - libcufile-dev
-- libcurl>=7.87.0
+- libcurl>=8.5.0
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - doxygen=1.9.1
 - gcc_linux-64=11.*
 - libcufile-dev
-- libcurl>=7.87.0
+- libcurl>=8.5.0
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - doxygen=1.9.1
 - gcc_linux-64=11.*
 - libcufile-dev
-- libcurl>=8.5.0
+- libcurl>=8.5.0,<9.0a0
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/recipes/kvikio/conda_build_config.yaml
+++ b/conda/recipes/kvikio/conda_build_config.yaml
@@ -30,7 +30,7 @@ cuda11_libcufile_run_version:
   - ">=1.0.0.82,<=1.4.0.31"
 
 libcurl_version:
-  - "==7.87.0"
+  - "==8.5.0"
 
 nvcomp_version:
   - "=4.1.0.6"

--- a/conda/recipes/libkvikio/conda_build_config.yaml
+++ b/conda/recipes/libkvikio/conda_build_config.yaml
@@ -30,4 +30,4 @@ cuda11_libcufile_run_version:
   - ">=1.0.0.82,<=1.4.0.31"
 
 libcurl_version:
-  - "==7.87.0"
+  - "==8.5.0"

--- a/cpp/cmake/thirdparty/get_libcurl.cmake
+++ b/cpp/cmake/thirdparty/get_libcurl.cmake
@@ -27,7 +27,7 @@ function(find_and_configure_libcurl)
     BUILD_EXPORT_SET kvikio-exports
     INSTALL_EXPORT_SET kvikio-exports
     CPM_ARGS
-   GIT_REPOSITORY https://github.com/curl/curl
+    GIT_REPOSITORY https://github.com/curl/curl
     GIT_TAG curl-8_5_0
     OPTIONS "BUILD_CURL_EXE OFF" "BUILD_SHARED_LIBS OFF" "BUILD_TESTING OFF" "CURL_USE_LIBPSL OFF"
             "CURL_DISABLE_LDAP ON" "CMAKE_POSITION_INDEPENDENT_CODE ON"

--- a/cpp/cmake/thirdparty/get_libcurl.cmake
+++ b/cpp/cmake/thirdparty/get_libcurl.cmake
@@ -22,13 +22,13 @@ function(find_and_configure_libcurl)
   endif()
 
   rapids_cpm_find(
-    CURL 7.87.0
+    CURL 8.5.0
     GLOBAL_TARGETS libcurl
     BUILD_EXPORT_SET kvikio-exports
     INSTALL_EXPORT_SET kvikio-exports
     CPM_ARGS
-    GIT_REPOSITORY https://github.com/curl/curl
-    GIT_TAG curl-7_87_0
+   GIT_REPOSITORY https://github.com/curl/curl
+    GIT_TAG curl-8_5_0
     OPTIONS "BUILD_CURL_EXE OFF" "BUILD_SHARED_LIBS OFF" "BUILD_TESTING OFF" "CURL_USE_LIBPSL OFF"
             "CURL_DISABLE_LDAP ON" "CMAKE_POSITION_INDEPENDENT_CODE ON"
     EXCLUDE_FROM_ALL YES # Don't install libcurl.a (only needed when building libkvikio.so)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -114,7 +114,7 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - libcurl>=7.87.0  # Need CURL_WRITEFUNC_ERROR <https://curl.se/libcurl/c/CURLOPT_WRITEFUNCTION.html>
+          - libcurl>=8.5.0
     specific:
       - output_types: conda
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -114,7 +114,7 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - libcurl>=8.5.0
+          - libcurl>=8.5.0,<9.0a0
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
This PR uses `libcurl` 8.5.0 at build time, and should permit `>=8.5.0,<9.0a0` at runtime. This is needed to align with conda-forge which uses `libcurl` 8, and also gets a new enough minor version to avoid some known CVEs.
