### PR TITLE
Use GCC 13 in CUDA 12 conda builds.

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -37,6 +37,6 @@ dependencies:
 - sphinx
 - sphinx-click
 - sphinx_rtd_theme
-- sysroot_linux-aarch64=2.17
+- sysroot_linux-aarch64=2.28
 - zarr>=2.0.0,<3.0.0a0
 name: all_cuda-118_arch-aarch64

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -39,6 +39,6 @@ dependencies:
 - sphinx
 - sphinx-click
 - sphinx_rtd_theme
-- sysroot_linux-64=2.17
+- sysroot_linux-64=2.28
 - zarr>=2.0.0,<3.0.0a0
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-125_arch-aarch64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cxx-compiler
 - cython>=3.0.0
 - doxygen=1.9.1
-- gcc_linux-aarch64=11.*
+- gcc_linux-aarch64=13.*
 - libcufile-dev
 - libcurl>=8.5.0,<9.0a0
 - moto>=4.0.8
@@ -37,6 +37,6 @@ dependencies:
 - sphinx
 - sphinx-click
 - sphinx_rtd_theme
-- sysroot_linux-aarch64=2.17
+- sysroot_linux-aarch64=2.28
 - zarr>=2.0.0,<3.0.0a0
 name: all_cuda-125_arch-aarch64

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cxx-compiler
 - cython>=3.0.0
 - doxygen=1.9.1
-- gcc_linux-64=11.*
+- gcc_linux-64=13.*
 - libcufile-dev
 - libcurl>=8.5.0,<9.0a0
 - moto>=4.0.8
@@ -37,6 +37,6 @@ dependencies:
 - sphinx
 - sphinx-click
 - sphinx_rtd_theme
-- sysroot_linux-64=2.17
+- sysroot_linux-64=2.28
 - zarr>=2.0.0,<3.0.0a0
 name: all_cuda-125_arch-x86_64

--- a/conda/recipes/kvikio/conda_build_config.yaml
+++ b/conda/recipes/kvikio/conda_build_config.yaml
@@ -1,23 +1,23 @@
 c_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cxx_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cmake_version:
   - ">=3.26.4,!=3.30.0"
 
 cuda_compiler:
-  - cuda-nvcc
-
-cuda11_compiler:
-  - nvcc
+  - cuda-nvcc  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - nvcc  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 c_stdlib:
   - sysroot
 
 c_stdlib_version:
-  - "2.17"
+  - "2.28"
 
 # The CTK libraries below are missing from the conda-forge::cudatoolkit package
 # for CUDA 11. The "*_host_*" version specifiers correspond to `11.8` packages

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -33,10 +33,8 @@ build:
     - SCCACHE_S3_USE_SSL
     - SCCACHE_S3_NO_CREDENTIALS
   ignore_run_exports_from:
-    {% if cuda_major == "11" %}
     - {{ compiler('cuda') }}
-    {% else %}
-    - {{ compiler('cuda') }}
+    {% if cuda_major != "11" %}
     - cuda-cudart-dev
     - libcufile-dev  # [linux]
     {% endif %}

--- a/conda/recipes/kvikio/meta.yaml
+++ b/conda/recipes/kvikio/meta.yaml
@@ -34,7 +34,7 @@ build:
     - SCCACHE_S3_NO_CREDENTIALS
   ignore_run_exports_from:
     {% if cuda_major == "11" %}
-    - {{ compiler('cuda11') }}
+    - {{ compiler('cuda') }}
     {% else %}
     - {{ compiler('cuda') }}
     - cuda-cudart-dev
@@ -49,7 +49,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}
-    - {{ compiler('cuda11') }} ={{ cuda_version }}
+    - {{ compiler('cuda') }} ={{ cuda_version }}
     {% else %}
     - {{ compiler('cuda') }}
     {% endif %}

--- a/conda/recipes/libkvikio/conda_build_config.yaml
+++ b/conda/recipes/libkvikio/conda_build_config.yaml
@@ -1,23 +1,23 @@
 c_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cxx_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cmake_version:
   - ">=3.26.4,!=3.30.0"
 
 cuda_compiler:
-  - cuda-nvcc
-
-cuda11_compiler:
-  - nvcc
+  - cuda-nvcc  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - nvcc  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 c_stdlib:
   - sysroot
 
 c_stdlib_version:
-  - "2.17"
+  - "2.28"
 
 # The CTK libraries below are missing from the conda-forge::cudatoolkit package
 # for CUDA 11. The "*_host_*" version specifiers correspond to `11.8` packages

--- a/conda/recipes/libkvikio/meta.yaml
+++ b/conda/recipes/libkvikio/meta.yaml
@@ -64,10 +64,8 @@ outputs:
       run_exports:
         - {{ pin_subpackage("libkvikio", max_pin="x.x") }}
       ignore_run_exports_from:
-        {% if cuda_major == "11" %}
         - {{ compiler('cuda') }}
-        {% else %}
-        - {{ compiler('cuda') }}
+        {% if cuda_major != "11" %}
         - libcufile-dev  # [linux]
         {% endif %}
     requirements:
@@ -101,10 +99,8 @@ outputs:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
-        {% if cuda_major == "11" %}
         - {{ compiler('cuda') }}
-        {% else %}
-        - {{ compiler('cuda') }}
+        {% if cuda_major != "11" %}
         - cuda-cudart-dev
         - libcufile-dev  # [linux]
         {% endif %}

--- a/conda/recipes/libkvikio/meta.yaml
+++ b/conda/recipes/libkvikio/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
 {% set cuda_version = '.'.join(environ['RAPIDS_CUDA_VERSION'].split('.')[:2]) %}
@@ -37,7 +37,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}
-    - {{ compiler('cuda11') }} ={{ cuda_version }}
+    - {{ compiler('cuda') }} ={{ cuda_version }}
     {% else %}
     - {{ compiler('cuda') }}
     {% endif %}
@@ -65,7 +65,7 @@ outputs:
         - {{ pin_subpackage("libkvikio", max_pin="x.x") }}
       ignore_run_exports_from:
         {% if cuda_major == "11" %}
-        - {{ compiler('cuda11') }}
+        - {{ compiler('cuda') }}
         {% else %}
         - {{ compiler('cuda') }}
         - libcufile-dev  # [linux]
@@ -102,7 +102,7 @@ outputs:
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
         {% if cuda_major == "11" %}
-        - {{ compiler('cuda11') }}
+        - {{ compiler('cuda') }}
         {% else %}
         - {{ compiler('cuda') }}
         - cuda-cudart-dev

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -128,14 +128,28 @@ dependencies:
         matrices:
           - matrix:
               arch: x86_64
+              cuda: "11.8"
             packages:
               - gcc_linux-64=11.*
-              - sysroot_linux-64=2.17
+              - sysroot_linux-64=2.28
           - matrix:
               arch: aarch64
+              cuda: "11.8"
             packages:
               - gcc_linux-aarch64=11.*
-              - sysroot_linux-aarch64=2.17
+              - sysroot_linux-aarch64=2.28
+          - matrix:
+              arch: x86_64
+              cuda: "12.*"
+            packages:
+              - gcc_linux-64=13.*
+              - sysroot_linux-64=2.28
+          - matrix:
+              arch: aarch64
+              cuda: "12.*"
+            packages:
+              - gcc_linux-aarch64=13.*
+              - sysroot_linux-aarch64=2.28
       - output_types: conda
         matrices:
           - matrix:


### PR DESCRIPTION
## Description
conda-forge is using GCC 13 for CUDA 12 builds. This PR updates CUDA 12 conda builds to use GCC 13, for alignment.

These PRs should be merged in a specific order, see https://github.com/rapidsai/build-planning/issues/129 for details.
