### PR TITLE
allow deselecting nvcomp wheels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
           )
       - id: verify-alpha-spec
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.16.0
+    rev: v1.17.0
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -295,16 +295,25 @@ dependencies:
         packages:
           - nvcomp==4.1.0.6
     specific:
-      - output_types: [requirements, pyproject]
+      - output_types: [pyproject, requirements]
         matrices:
           - matrix:
               cuda: "12.*"
+              use_cuda_wheels: "true"
             packages:
               - nvidia-nvcomp-cu12==4.1.0.6
           - matrix:
               cuda: "11.*"
+              use_cuda_wheels: "true"
             packages:
               - nvidia-nvcomp-cu11==4.1.0.6
+          # if use_cuda_wheels=false is provided, do not add dependencies on any CUDA wheels
+          # (e.g. for DLFW and pip devcontainers)
+          - matrix:
+              use_cuda_wheels: "false"
+            packages:
+          # if no matching matrix selectors passed, list the unsuffixed packages
+          # (just as a source of documentation, as this populates pyproject.toml in source control)
           - matrix:
             packages:
               - nvidia-nvcomp==4.1.0.6

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -295,7 +295,7 @@ dependencies:
         packages:
           - nvcomp==4.1.0.6
     specific:
-      - output_types: pyproject
+      - output_types: [requirements, pyproject]
         matrices:
           - matrix:
               cuda: "12.*"

--- a/python/kvikio/pyproject.toml
+++ b/python/kvikio/pyproject.toml
@@ -115,7 +115,7 @@ nvcomp_batch = "kvikio.nvcomp_codec:NvCompBatchCodec"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
-matrix-entry = "cuda_suffixed=true"
+matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "cython>=3.0.0",

--- a/python/libkvikio/pyproject.toml
+++ b/python/libkvikio/pyproject.toml
@@ -51,7 +51,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
-matrix-entry = "cuda_suffixed=true"
+matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "ninja",

--- a/python/libkvikio/pyproject.toml
+++ b/python/libkvikio/pyproject.toml
@@ -51,7 +51,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
-matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
+matrix-entry = "cuda_suffixed=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "ninja",


### PR DESCRIPTION
## Description

Follow-up to #478

Adds a matrix filter `use_cuda_wheels` in the `dependencies.yaml` list used for `libkvikio`'s `nvcomp` dependency. Some types of builds (like RAPIDS devcontainers) prefer to use the system-installed nvCOMP to one provided by wheels.

This ensures that preference is respected, because those builds pass matrix selector `use_cuda_wheels=false` through `rapids-dependency-file-generator` (https://github.com/rapidsai/devcontainers/pull/382).

## Notes for Reviewers

Similar changes in cuDF: https://github.com/rapidsai/cudf/pull/17774