### PR TITLE
Apply east const using clang-format. Fix header issues reported by clang-tidy

### DIFF
--- a/cpp/include/kvikio/batch.hpp
+++ b/cpp/include/kvikio/batch.hpp
@@ -78,7 +78,7 @@ class BatchHandle {
   /**
    * @brief BatchHandle support move semantic but isn't copyable
    */
-  BatchHandle(const BatchHandle&)            = delete;
+  BatchHandle(BatchHandle const&)            = delete;
   BatchHandle& operator=(BatchHandle const&) = delete;
   BatchHandle(BatchHandle&& o) noexcept;
   ~BatchHandle() noexcept;
@@ -96,7 +96,7 @@ class BatchHandle {
    * @param operations The vector of batch operations, which must not exceed the
    * `max_num_events`.
    */
-  void submit(const std::vector<BatchOp>& operations);
+  void submit(std::vector<BatchOp> const& operations);
 
   /**
    * @brief Get status of submitted operations
@@ -127,7 +127,7 @@ class BatchHandle {
 
   void close() noexcept;
 
-  void submit(const std::vector<BatchOp>& operations);
+  void submit(std::vector<BatchOp> const& operations);
 
   std::vector<CUfileIOEvents_t> status(unsigned min_nr,
                                        unsigned max_nr,

--- a/cpp/include/kvikio/buffer.hpp
+++ b/cpp/include/kvikio/buffer.hpp
@@ -35,17 +35,17 @@ namespace kvikio {
  * streaming buffer that is reused across multiple cuFile IO operations.
  */
 /*NOLINTNEXTLINE(readability-function-cognitive-complexity)*/
-void buffer_register(const void* devPtr_base,
+void buffer_register(void const* devPtr_base,
                      std::size_t size,
                      int flags                                = 0,
-                     const std::vector<int>& errors_to_ignore = std::vector<int>());
+                     std::vector<int> const& errors_to_ignore = std::vector<int>());
 
 /**
  * @brief deregister an already registered device memory from cuFile
  *
  * @param devPtr_base  device pointer to deregister
  */
-void buffer_deregister(const void* devPtr_base);
+void buffer_deregister(void const* devPtr_base);
 
 /**
  * @brief Register device memory allocation which is part of devPtr. Use this
@@ -61,15 +61,15 @@ void buffer_deregister(const void* devPtr_base);
  * @warning This API is intended for usecases where the memory is used as
  * streaming buffer that is reused across multiple cuFile IO operations.
  */
-void memory_register(const void* devPtr,
+void memory_register(void const* devPtr,
                      int flags                                = 0,
-                     const std::vector<int>& errors_to_ignore = {});
+                     std::vector<int> const& errors_to_ignore = {});
 
 /**
  * @brief  deregister an already registered device memory from cuFile.
  *
  * @param devPtr device pointer to deregister
  */
-void memory_deregister(const void* devPtr);
+void memory_deregister(void const* devPtr);
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/cufile/config.hpp
+++ b/cpp/include/kvikio/cufile/config.hpp
@@ -26,6 +26,6 @@ namespace kvikio {
  *
  * @return The filepath to the cufile.json file or the empty string if it isn't found.
  */
-[[nodiscard]] KVIKIO_EXPORT const std::string& config_path();
+[[nodiscard]] KVIKIO_EXPORT std::string const& config_path();
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -62,7 +62,7 @@ CompatMode parse_compat_mode_str(std::string_view compat_mode_str);
 template <typename T>
 T getenv_or(std::string_view env_var_name, T default_val)
 {
-  const auto* env_val = std::getenv(env_var_name.data());
+  auto const* env_val = std::getenv(env_var_name.data());
   if (env_val == nullptr) { return default_val; }
 
   std::stringstream sstream(env_val);

--- a/cpp/include/kvikio/error.hpp
+++ b/cpp/include/kvikio/error.hpp
@@ -67,7 +67,7 @@ struct CUfileException : public std::runtime_error {
 
 namespace detail {
 template <typename Exception>
-void cuda_driver_try_2(CUresult error, int line_number, const char* filename)
+void cuda_driver_try_2(CUresult error, int line_number, char const* filename)
 {
   if (error == CUDA_ERROR_STUB_LIBRARY) {
     throw Exception{std::string{"CUDA error at: "} + std::string(filename) + ":" +
@@ -76,8 +76,8 @@ void cuda_driver_try_2(CUresult error, int line_number, const char* filename)
                     "The CUDA driver loaded is a stub library)"};
   }
   if (error != CUDA_SUCCESS) {
-    const char* err_name     = nullptr;
-    const char* err_str      = nullptr;
+    char const* err_name     = nullptr;
+    char const* err_str      = nullptr;
     CUresult err_name_status = cudaAPI::instance().GetErrorName(error, &err_name);
     CUresult err_str_status  = cudaAPI::instance().GetErrorString(error, &err_str);
     if (err_name_status == CUDA_ERROR_INVALID_VALUE) { err_name = "unknown"; }
@@ -89,7 +89,7 @@ void cuda_driver_try_2(CUresult error, int line_number, const char* filename)
 }
 
 template <typename Exception>
-void cufile_try_2(CUfileError_t error, int line_number, const char* filename)
+void cufile_try_2(CUfileError_t error, int line_number, char const* filename)
 {
   if (error.err != CU_FILE_SUCCESS) {
     if (error.err == CU_FILE_CUDA_DRIVER_ERROR) {
@@ -103,7 +103,7 @@ void cufile_try_2(CUfileError_t error, int line_number, const char* filename)
 }
 
 template <typename Exception>
-void cufile_check_bytes_done_2(ssize_t nbytes_done, int line_number, const char* filename)
+void cufile_check_bytes_done_2(ssize_t nbytes_done, int line_number, char const* filename)
 {
   if (nbytes_done < 0) {
     auto const err = std::abs(nbytes_done);

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -82,15 +82,15 @@ class FileHandle {
    * @param mode Access modes (see `open(2)`).
    * @param compat_mode Set KvikIO's compatibility mode for this file.
    */
-  FileHandle(const std::string& file_path,
-             const std::string& flags = "r",
+  FileHandle(std::string const& file_path,
+             std::string const& flags = "r",
              mode_t mode              = m644,
              CompatMode compat_mode   = defaults::compat_mode());
 
   /**
    * @brief FileHandle support move semantic but isn't copyable
    */
-  FileHandle(const FileHandle&)            = delete;
+  FileHandle(FileHandle const&)            = delete;
   FileHandle& operator=(FileHandle const&) = delete;
   FileHandle(FileHandle&& o) noexcept;
   FileHandle& operator=(FileHandle&& o) noexcept;
@@ -216,7 +216,7 @@ class FileHandle {
    * case, the value of `sync_default_stream` is ignored.
    * @return Size of bytes that were successfully written.
    */
-  std::size_t write(const void* devPtr_base,
+  std::size_t write(void const* devPtr_base,
                     std::size_t size,
                     std::size_t file_offset,
                     std::size_t devPtr_offset,
@@ -289,7 +289,7 @@ class FileHandle {
    * @note The `std::future` object's `wait()` or `get()` should not be called after the lifetime of
    * the FileHandle object ends. Otherwise, the behavior is undefined.
    */
-  std::future<std::size_t> pwrite(const void* buf,
+  std::future<std::size_t> pwrite(void const* buf,
                                   std::size_t size,
                                   std::size_t file_offset   = 0,
                                   std::size_t task_size     = defaults::task_size(),

--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -69,7 +69,7 @@ class StreamsByThread {
 
   static CUstream get();
 
-  StreamsByThread(const StreamsByThread&)            = delete;
+  StreamsByThread(StreamsByThread const&)            = delete;
   StreamsByThread& operator=(StreamsByThread const&) = delete;
   StreamsByThread(StreamsByThread&& o)               = delete;
   StreamsByThread& operator=(StreamsByThread&& o)    = delete;
@@ -88,11 +88,11 @@ class StreamsByThread {
  * @return The number of bytes read or written (always gather than zero)
  */
 template <IOOperationType Operation, PartialIO PartialIOStatus>
-ssize_t posix_host_io(int fd, const void* buf, size_t count, off_t offset)
+ssize_t posix_host_io(int fd, void const* buf, size_t count, off_t offset)
 {
   off_t cur_offset      = offset;
   size_t byte_remaining = count;
-  char* buffer          = const_cast<char*>(static_cast<const char*>(buf));
+  char* buffer          = const_cast<char*>(static_cast<char const*>(buf));
   while (byte_remaining > 0) {
     ssize_t nbytes = 0;
     if constexpr (Operation == IOOperationType::READ) {
@@ -101,7 +101,7 @@ ssize_t posix_host_io(int fd, const void* buf, size_t count, off_t offset)
       nbytes = ::pwrite(fd, buffer, byte_remaining, cur_offset);
     }
     if (nbytes == -1) {
-      const std::string name = Operation == IOOperationType::READ ? "pread" : "pwrite";
+      std::string const name = Operation == IOOperationType::READ ? "pread" : "pwrite";
       if (errno == EBADF) {
         throw CUfileException{std::string{"POSIX error on " + name + " at: "} + __FILE__ + ":" +
                               KVIKIO_STRINGIFY(__LINE__) + ": Operation not permitted"};
@@ -136,7 +136,7 @@ ssize_t posix_host_io(int fd, const void* buf, size_t count, off_t offset)
  */
 template <IOOperationType Operation>
 std::size_t posix_device_io(int fd,
-                            const void* devPtr_base,
+                            void const* devPtr_base,
                             std::size_t size,
                             std::size_t file_offset,
                             std::size_t devPtr_offset)
@@ -145,13 +145,13 @@ std::size_t posix_device_io(int fd,
   CUdeviceptr devPtr      = convert_void2deviceptr(devPtr_base) + devPtr_offset;
   off_t cur_file_offset   = convert_size2off(file_offset);
   off_t byte_remaining    = convert_size2off(size);
-  const off_t chunk_size2 = convert_size2off(alloc.size());
+  off_t const chunk_size2 = convert_size2off(alloc.size());
 
   // Get a stream for the current CUDA context and thread
   CUstream stream = StreamsByThread::get();
 
   while (byte_remaining > 0) {
-    const off_t nbytes_requested = std::min(chunk_size2, byte_remaining);
+    off_t const nbytes_requested = std::min(chunk_size2, byte_remaining);
     ssize_t nbytes_got           = nbytes_requested;
     if constexpr (Operation == IOOperationType::READ) {
       nbytes_got = posix_host_io<IOOperationType::READ, PartialIO::YES>(
@@ -209,7 +209,7 @@ std::size_t posix_host_read(int fd, void* buf, std::size_t size, std::size_t fil
  * @return Size of bytes that were successfully read.
  */
 template <PartialIO PartialIOStatus>
-std::size_t posix_host_write(int fd, const void* buf, std::size_t size, std::size_t file_offset)
+std::size_t posix_host_write(int fd, void const* buf, std::size_t size, std::size_t file_offset)
 {
   KVIKIO_NVTX_SCOPED_RANGE("posix_host_write()", size);
   return detail::posix_host_io<IOOperationType::WRITE, PartialIOStatus>(
@@ -230,7 +230,7 @@ std::size_t posix_host_write(int fd, const void* buf, std::size_t size, std::siz
  * @return Size of bytes that were successfully read.
  */
 std::size_t posix_device_read(int fd,
-                              const void* devPtr_base,
+                              void const* devPtr_base,
                               std::size_t size,
                               std::size_t file_offset,
                               std::size_t devPtr_offset);
@@ -249,7 +249,7 @@ std::size_t posix_device_read(int fd,
  * @return Size of bytes that were successfully written.
  */
 std::size_t posix_device_write(int fd,
-                               const void* devPtr_base,
+                               void const* devPtr_base,
                                std::size_t size,
                                std::size_t file_offset,
                                std::size_t devPtr_offset);

--- a/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cufile_h_wrapper.hpp
@@ -59,7 +59,7 @@ struct CUfileDescr_t {
   } handle;
 };
 
-static inline const char* cufileop_status_error(CUfileOpError err) { return CUFILE_ERRSTR(err); };
+inline static char const* cufileop_status_error(CUfileOpError err) { return CUFILE_ERRSTR(err); };
 CUfileError_t cuFileHandleRegister(...);
 CUfileError_t cuFileHandleDeregister(...);
 ssize_t cuFileRead(...);

--- a/cpp/include/kvikio/shim/libcurl.hpp
+++ b/cpp/include/kvikio/shim/libcurl.hpp
@@ -20,13 +20,13 @@
   "cannot include the remote IO API, please build KvikIO with libcurl (-DKvikIO_REMOTE_SUPPORT=ON)"
 #endif
 
+#include <curl/curl.h>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
-
-#include <curl/curl.h>
 
 namespace kvikio {
 

--- a/cpp/include/kvikio/shim/libcurl.hpp
+++ b/cpp/include/kvikio/shim/libcurl.hpp
@@ -20,13 +20,14 @@
   "cannot include the remote IO API, please build KvikIO with libcurl (-DKvikIO_REMOTE_SUPPORT=ON)"
 #endif
 
-#include <curl/curl.h>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include <curl/curl.h>
 
 namespace kvikio {
 

--- a/cpp/include/kvikio/shim/utils.hpp
+++ b/cpp/include/kvikio/shim/utils.hpp
@@ -17,6 +17,7 @@
 
 #include <dlfcn.h>
 #include <sys/utsname.h>
+#include <stdexcept>
 #include <vector>
 
 namespace kvikio {
@@ -44,7 +45,7 @@ namespace kvikio {
  * @param name Name of the library to load.
  * @return The library handle.
  */
-void* load_library(const char* name, int mode = RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
+void* load_library(char const* name, int mode = RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
 
 /**
  * @brief Load shared library
@@ -52,7 +53,7 @@ void* load_library(const char* name, int mode = RTLD_LAZY | RTLD_LOCAL | RTLD_NO
  * @param names Vector of names to try when loading shared library.
  * @return The library handle.
  */
-void* load_library(const std::vector<const char*>& names,
+void* load_library(std::vector<char const*> const& names,
                    int mode = RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
 
 /**
@@ -64,12 +65,12 @@ void* load_library(const std::vector<const char*>& names,
  * @param name Name of the symbol/function to load.
  */
 template <typename T>
-void get_symbol(T& handle, void* lib, const char* name)
+void get_symbol(T& handle, void* lib, char const* name)
 {
   ::dlerror();  // Clear old errors
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   handle          = reinterpret_cast<T>(::dlsym(lib, name));
-  const char* err = ::dlerror();
+  char const* err = ::dlerror();
   if (err != nullptr) { throw std::runtime_error(err); }
 }
 

--- a/cpp/include/kvikio/stream.hpp
+++ b/cpp/include/kvikio/stream.hpp
@@ -66,7 +66,7 @@ class StreamFuture {
   /**
    * @brief StreamFuture support move semantic but isn't copyable
    */
-  StreamFuture(const StreamFuture&)        = delete;
+  StreamFuture(StreamFuture const&)        = delete;
   StreamFuture& operator=(StreamFuture& o) = delete;
   StreamFuture(StreamFuture&& o) noexcept;
   StreamFuture& operator=(StreamFuture&& o) noexcept;

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -38,7 +38,7 @@ inline constexpr std::size_t page_size = 4096;
 
 [[nodiscard]] ssize_t convert_size2ssize(std::size_t x);
 
-[[nodiscard]] CUdeviceptr convert_void2deviceptr(const void* devPtr);
+[[nodiscard]] CUdeviceptr convert_void2deviceptr(void const* devPtr);
 
 /**
  * @brief Help function to convert value to 64 bit signed integer
@@ -127,7 +127,7 @@ constexpr bool is_host_memory(const void* ptr) { return true; }
  * @param devPtr Device pointer to query
  * @return Usable CUDA context
  */
-[[nodiscard]] CUcontext get_context_from_pointer(const void* devPtr);
+[[nodiscard]] CUcontext get_context_from_pointer(void const* devPtr);
 
 /**
  * @brief Push CUDA context on creation and pop it on destruction
@@ -138,7 +138,7 @@ class PushAndPopContext {
 
  public:
   PushAndPopContext(CUcontext ctx);
-  PushAndPopContext(const PushAndPopContext&)            = delete;
+  PushAndPopContext(PushAndPopContext const&)            = delete;
   PushAndPopContext& operator=(PushAndPopContext const&) = delete;
   PushAndPopContext(PushAndPopContext&&)                 = delete;
   PushAndPopContext&& operator=(PushAndPopContext&&)     = delete;
@@ -146,11 +146,11 @@ class PushAndPopContext {
 };
 
 // Find the base and offset of the memory allocation `devPtr` is in
-std::tuple<void*, std::size_t, std::size_t> get_alloc_info(const void* devPtr,
+std::tuple<void*, std::size_t, std::size_t> get_alloc_info(void const* devPtr,
                                                            CUcontext* ctx = nullptr);
 
 template <typename T>
-bool is_future_done(const T& future)
+bool is_future_done(T const& future)
 {
   return future.wait_for(std::chrono::seconds(0)) != std::future_status::timeout;
 }

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -72,9 +72,9 @@ template <typename T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
  * @return The boolean answer
  */
 #ifdef KVIKIO_CUDA_FOUND
-bool is_host_memory(const void* ptr);
+bool is_host_memory(void const* ptr);
 #else
-constexpr bool is_host_memory(const void* ptr) { return true; }
+constexpr bool is_host_memory(void const* ptr) { return true; }
 #endif
 
 /**

--- a/cpp/src/batch.cpp
+++ b/cpp/src/batch.cpp
@@ -52,14 +52,14 @@ void BatchHandle::close() noexcept
   cuFileAPI::instance().BatchIODestroy(_handle);
 }
 
-void BatchHandle::submit(const std::vector<BatchOp>& operations)
+void BatchHandle::submit(std::vector<BatchOp> const& operations)
 {
   if (convert_size2ssize(operations.size()) > _max_num_events) {
     throw CUfileException("Cannot submit more than the max_num_events)");
   }
   std::vector<CUfileIOParams_t> io_batch_params;
   io_batch_params.reserve(operations.size());
-  for (const auto& op : operations) {
+  for (auto const& op : operations) {
     if (op.file_handle.is_compat_mode_preferred()) {
       throw CUfileException("Cannot submit a FileHandle opened in compatibility mode");
     }
@@ -102,7 +102,7 @@ bool BatchHandle::closed() const noexcept { return true; }
 
 void BatchHandle::close() noexcept {}
 
-void BatchHandle::submit(const std::vector<BatchOp>& operations) {}
+void BatchHandle::submit(std::vector<BatchOp> const& operations) {}
 
 std::vector<CUfileIOEvents_t> BatchHandle::status(unsigned min_nr,
                                                   unsigned max_nr,

--- a/cpp/src/buffer.cpp
+++ b/cpp/src/buffer.cpp
@@ -27,10 +27,10 @@
 
 namespace kvikio {
 
-void buffer_register(const void* devPtr_base,
+void buffer_register(void const* devPtr_base,
                      std::size_t size,
                      int flags,
-                     const std::vector<int>& errors_to_ignore)
+                     std::vector<int> const& errors_to_ignore)
 {
   if (defaults::is_compat_mode_preferred()) { return; }
   CUfileError_t status = cuFileAPI::instance().BufRegister(devPtr_base, size, flags);
@@ -43,19 +43,19 @@ void buffer_register(const void* devPtr_base,
   }
 }
 
-void buffer_deregister(const void* devPtr_base)
+void buffer_deregister(void const* devPtr_base)
 {
   if (defaults::is_compat_mode_preferred()) { return; }
   CUFILE_TRY(cuFileAPI::instance().BufDeregister(devPtr_base));
 }
 
-void memory_register(const void* devPtr, int flags, const std::vector<int>& errors_to_ignore)
+void memory_register(void const* devPtr, int flags, std::vector<int> const& errors_to_ignore)
 {
   auto [base, nbytes, offset] = get_alloc_info(devPtr);
   buffer_register(base, nbytes, flags, errors_to_ignore);
 }
 
-void memory_deregister(const void* devPtr)
+void memory_deregister(void const* devPtr)
 {
   auto [base, nbytes, offset] = get_alloc_info(devPtr);
   buffer_deregister(base);

--- a/cpp/src/cufile/config.cpp
+++ b/cpp/src/cufile/config.cpp
@@ -23,9 +23,9 @@
 namespace kvikio {
 namespace {
 
-[[nodiscard]] const char* lookup_config_path()
+[[nodiscard]] char const* lookup_config_path()
 {
-  const char* env = std::getenv("CUFILE_ENV_PATH_JSON");
+  char const* env = std::getenv("CUFILE_ENV_PATH_JSON");
   if (env != nullptr && std::filesystem::exists(env)) { return env; }
   if (std::filesystem::exists("/etc/cufile.json")) { return "/etc/cufile.json"; }
   return "";
@@ -33,9 +33,9 @@ namespace {
 
 }  // namespace
 
-const std::string& config_path()
+std::string const& config_path()
 {
-  static const std::string ret = lookup_config_path();
+  static std::string const ret = lookup_config_path();
   return ret;
 }
 

--- a/cpp/src/cufile/driver.cpp
+++ b/cpp/src/cufile/driver.cpp
@@ -48,7 +48,7 @@ DriverInitializer::~DriverInitializer() noexcept
 {
   try {
     cuFileAPI::instance().driver_close();
-  } catch (const CUfileException& e) {
+  } catch (CUfileException const& e) {
     std::cerr << "Unable to close GDS file driver: ";
     std::cerr << e.what();
     std::cerr << std::endl;

--- a/cpp/src/defaults.cpp
+++ b/cpp/src/defaults.cpp
@@ -54,12 +54,12 @@ CompatMode parse_compat_mode_str(std::string_view compat_mode_str)
 template <>
 bool getenv_or(std::string_view env_var_name, bool default_val)
 {
-  const auto* env_val = std::getenv(env_var_name.data());
+  auto const* env_val = std::getenv(env_var_name.data());
   if (env_val == nullptr) { return default_val; }
   try {
     // Try parsing `env_var_name` as a integer
     return static_cast<bool>(std::stoi(env_val));
-  } catch (const std::invalid_argument&) {
+  } catch (std::invalid_argument const&) {
   }
   // Convert to lowercase
   std::string str{env_val};
@@ -93,7 +93,7 @@ CompatMode getenv_or(std::string_view env_var_name, CompatMode default_val)
 
 unsigned int defaults::get_num_threads_from_env()
 {
-  const int ret = getenv_or("KVIKIO_NTHREADS", 1);
+  int const ret = getenv_or("KVIKIO_NTHREADS", 1);
   if (ret <= 0) {
     throw std::invalid_argument("KVIKIO_NTHREADS has to be a positive integer greater than zero");
   }
@@ -108,7 +108,7 @@ defaults::defaults()
   }
   // Determine the default value of `task_size`
   {
-    const ssize_t env = getenv_or("KVIKIO_TASK_SIZE", 4 * 1024 * 1024);
+    ssize_t const env = getenv_or("KVIKIO_TASK_SIZE", 4 * 1024 * 1024);
     if (env <= 0) {
       throw std::invalid_argument(
         "KVIKIO_TASK_SIZE has to be a positive integer greater than zero");
@@ -117,7 +117,7 @@ defaults::defaults()
   }
   // Determine the default value of `gds_threshold`
   {
-    const ssize_t env = getenv_or("KVIKIO_GDS_THRESHOLD", 1024 * 1024);
+    ssize_t const env = getenv_or("KVIKIO_GDS_THRESHOLD", 1024 * 1024);
     if (env < 0) {
       throw std::invalid_argument("KVIKIO_GDS_THRESHOLD has to be a positive integer");
     }
@@ -125,7 +125,7 @@ defaults::defaults()
   }
   // Determine the default value of `bounce_buffer_size`
   {
-    const ssize_t env = getenv_or("KVIKIO_BOUNCE_BUFFER_SIZE", 16 * 1024 * 1024);
+    ssize_t const env = getenv_or("KVIKIO_BOUNCE_BUFFER_SIZE", 16 * 1024 * 1024);
     if (env <= 0) {
       throw std::invalid_argument(
         "KVIKIO_BOUNCE_BUFFER_SIZE has to be a positive integer greater than zero");

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -106,7 +106,7 @@ int open_fd(std::string const& file_path, std::string const& flags, bool o_direc
  */
 [[nodiscard]] std::size_t get_file_size(int file_descriptor)
 {
-  struct stat st{};
+  struct stat st {};
   int ret = fstat(file_descriptor, &st);
   if (ret == -1) {
     throw std::system_error(errno, std::generic_category(), "Unable to query file size");

--- a/cpp/src/posix_io.cpp
+++ b/cpp/src/posix_io.cpp
@@ -55,7 +55,7 @@ CUstream StreamsByThread::get()
 }
 
 std::size_t posix_device_read(int fd,
-                              const void* devPtr_base,
+                              void const* devPtr_base,
                               std::size_t size,
                               std::size_t file_offset,
                               std::size_t devPtr_offset)
@@ -66,7 +66,7 @@ std::size_t posix_device_read(int fd,
 }
 
 std::size_t posix_device_write(int fd,
-                               const void* devPtr_base,
+                               void const* devPtr_base,
                                std::size_t size,
                                std::size_t file_offset,
                                std::size_t devPtr_offset)

--- a/cpp/src/shim/cuda.cpp
+++ b/cpp/src/shim/cuda.cpp
@@ -62,7 +62,7 @@ bool is_cuda_available()
 {
   try {
     cudaAPI::instance();
-  } catch (const std::runtime_error&) {
+  } catch (std::runtime_error const&) {
     return false;
   }
   return true;

--- a/cpp/src/shim/utils.cpp
+++ b/cpp/src/shim/utils.cpp
@@ -48,7 +48,7 @@ void* load_library(std::vector<char const*> const& names, int mode)
 bool is_running_in_wsl() noexcept
 {
   try {
-    struct utsname buf{};
+    struct utsname buf {};
     int err = ::uname(&buf);
     if (err == 0) {
       std::string const name(static_cast<char*>(buf.release));

--- a/cpp/src/shim/utils.cpp
+++ b/cpp/src/shim/utils.cpp
@@ -24,7 +24,7 @@
 
 namespace kvikio {
 
-void* load_library(const char* name, int mode)
+void* load_library(char const* name, int mode)
 {
   ::dlerror();  // Clear old errors
   void* ret = ::dlopen(name, mode);
@@ -32,14 +32,14 @@ void* load_library(const char* name, int mode)
   return ret;
 }
 
-void* load_library(const std::vector<const char*>& names, int mode)
+void* load_library(std::vector<char const*> const& names, int mode)
 {
   std::stringstream ss;
-  for (const char* name : names) {
+  for (char const* name : names) {
     ss << name << " ";
     try {
       return load_library(name, mode);
-    } catch (const std::runtime_error&) {
+    } catch (std::runtime_error const&) {
     }
   }
   throw std::runtime_error("cannot open shared object file, tried: " + ss.str());
@@ -48,10 +48,10 @@ void* load_library(const std::vector<const char*>& names, int mode)
 bool is_running_in_wsl() noexcept
 {
   try {
-    struct utsname buf {};
+    struct utsname buf{};
     int err = ::uname(&buf);
     if (err == 0) {
-      const std::string name(static_cast<char*>(buf.release));
+      std::string const name(static_cast<char*>(buf.release));
       // 'Microsoft' for WSL1 and 'microsoft' for WSL2
       return name.find("icrosoft") != std::string::npos;
     }

--- a/cpp/src/stream.cpp
+++ b/cpp/src/stream.cpp
@@ -92,7 +92,7 @@ StreamFuture::~StreamFuture() noexcept
   if (_val != nullptr) {
     try {
       check_bytes_done();
-    } catch (const kvikio::CUfileException& e) {
+    } catch (kvikio::CUfileException const& e) {
       std::cerr << e.what() << std::endl;
     }
     std::free(_val);

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -49,7 +49,7 @@ ssize_t convert_size2ssize(std::size_t x)
   return static_cast<ssize_t>(x);
 }
 
-CUdeviceptr convert_void2deviceptr(const void* devPtr)
+CUdeviceptr convert_void2deviceptr(void const* devPtr)
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   return reinterpret_cast<CUdeviceptr>(devPtr);
@@ -108,7 +108,7 @@ CUcontext get_primary_cuda_context(int ordinal)
 std::optional<CUcontext> get_context_associated_pointer(CUdeviceptr dev_ptr)
 {
   CUcontext ctx = nullptr;
-  const CUresult err =
+  CUresult const err =
     cudaAPI::instance().PointerGetAttribute(&ctx, CU_POINTER_ATTRIBUTE_CONTEXT, dev_ptr);
   if (err == CUDA_SUCCESS && ctx != nullptr) { return ctx; }
   if (err != CUDA_ERROR_INVALID_VALUE) { CUDA_DRIVER_TRY(err); }
@@ -118,14 +118,14 @@ std::optional<CUcontext> get_context_associated_pointer(CUdeviceptr dev_ptr)
 bool current_context_can_access_pointer(CUdeviceptr dev_ptr)
 {
   CUdeviceptr current_ctx_dev_ptr{};
-  const CUresult err = cudaAPI::instance().PointerGetAttribute(
+  CUresult const err = cudaAPI::instance().PointerGetAttribute(
     &current_ctx_dev_ptr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, dev_ptr);
   if (err == CUDA_SUCCESS && current_ctx_dev_ptr == dev_ptr) { return true; }
   if (err != CUDA_ERROR_INVALID_VALUE) { CUDA_DRIVER_TRY(err); }
   return false;
 }
 
-CUcontext get_context_from_pointer(const void* devPtr)
+CUcontext get_context_from_pointer(void const* devPtr)
 {
   CUdeviceptr dev_ptr = convert_void2deviceptr(devPtr);
 
@@ -157,12 +157,12 @@ PushAndPopContext::~PushAndPopContext()
 {
   try {
     CUDA_DRIVER_TRY(cudaAPI::instance().CtxPopCurrent(&_ctx), CUfileException);
-  } catch (const CUfileException& e) {
+  } catch (CUfileException const& e) {
     std::cerr << e.what() << std::endl;
   }
 }
 
-std::tuple<void*, std::size_t, std::size_t> get_alloc_info(const void* devPtr, CUcontext* ctx)
+std::tuple<void*, std::size_t, std::size_t> get_alloc_info(void const* devPtr, CUcontext* ctx)
 {
   auto dev = convert_void2deviceptr(devPtr);
   CUdeviceptr base_ptr{};

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -56,7 +56,7 @@ CUdeviceptr convert_void2deviceptr(void const* devPtr)
 }
 
 #ifdef KVIKIO_CUDA_FOUND
-bool is_host_memory(const void* ptr)
+bool is_host_memory(void const* ptr)
 {
   CUpointer_attribute attrs[1] = {
     CU_POINTER_ATTRIBUTE_MEMORY_TYPE,

--- a/cpp/tests/test_basic_io.cpp
+++ b/cpp/tests/test_basic_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ TEST_F(BasicIOTest, write_read_async)
 
   // Explicitly set compatibility mode
   std::array<kvikio::CompatMode, 2> compat_modes{kvikio::CompatMode::AUTO, kvikio::CompatMode::ON};
-  for (const auto& compat_mode : compat_modes) {
+  for (auto const& compat_mode : compat_modes) {
     {
       kvikio::FileHandle f(_filepath, "w", kvikio::FileHandle::m644, compat_mode);
       auto stream_future = f.write_async(_dev_a.ptr, _dev_a.nbytes, 0, 0, stream);

--- a/cpp/tests/test_defaults.cpp
+++ b/cpp/tests/test_defaults.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ TEST(Defaults, parse_compat_mode_str)
   {
     std::vector<std::string> inputs{
       "ON", "on", "On", "TRUE", "true", "True", "YES", "yes", "Yes", "1"};
-    for (const auto& input : inputs) {
+    for (auto const& input : inputs) {
       EXPECT_EQ(kvikio::detail::parse_compat_mode_str(input), kvikio::CompatMode::ON);
     }
   }
@@ -32,21 +32,21 @@ TEST(Defaults, parse_compat_mode_str)
   {
     std::vector<std::string> inputs{
       "OFF", "off", "oFf", "FALSE", "false", "False", "NO", "no", "No", "0"};
-    for (const auto& input : inputs) {
+    for (auto const& input : inputs) {
       EXPECT_EQ(kvikio::detail::parse_compat_mode_str(input), kvikio::CompatMode::OFF);
     }
   }
 
   {
     std::vector<std::string> inputs{"AUTO", "auto", "aUtO"};
-    for (const auto& input : inputs) {
+    for (auto const& input : inputs) {
       EXPECT_EQ(kvikio::detail::parse_compat_mode_str(input), kvikio::CompatMode::AUTO);
     }
   }
 
   {
     std::vector<std::string> inputs{"", "invalidOption", "11", "*&^Yes"};
-    for (const auto& input : inputs) {
+    for (auto const& input : inputs) {
       EXPECT_THROW(kvikio::detail::parse_compat_mode_str(input), std::invalid_argument);
     }
   }

--- a/cpp/tests/utils.hpp
+++ b/cpp/tests/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ namespace kvikio::test {
  */
 class TempDir {
  public:
-  TempDir(const bool cleanup = true) : _cleanup{cleanup}
+  TempDir(bool const cleanup = true) : _cleanup{cleanup}
   {
     std::string tpl{std::filesystem::temp_directory_path() / "kvikio.XXXXXX"};
     if (mkdtemp(tpl.data()) == nullptr) {
@@ -91,17 +91,17 @@ class TempDir {
     }
   }
 
-  TempDir(const TempDir&)              = delete;
+  TempDir(TempDir const&)              = delete;
   TempDir& operator=(TempDir const&)   = delete;
-  TempDir(const TempDir&&)             = delete;
+  TempDir(TempDir const&&)             = delete;
   TempDir&& operator=(TempDir const&&) = delete;
 
-  const std::filesystem::path& path() { return _dir_path; }
+  std::filesystem::path const& path() { return _dir_path; }
 
   operator std::string() { return path(); }
 
  private:
-  const bool _cleanup;
+  bool const _cleanup;
   std::filesystem::path _dir_path{};
 };
 
@@ -120,7 +120,7 @@ class DevBuffer {
   {
     KVIKIO_CHECK_CUDA(cudaMalloc(&ptr, nbytes));
   }
-  DevBuffer(const std::vector<std::int64_t>& host_buffer) : DevBuffer{host_buffer.size()}
+  DevBuffer(std::vector<std::int64_t> const& host_buffer) : DevBuffer{host_buffer.size()}
   {
     KVIKIO_CHECK_CUDA(cudaMemcpy(ptr, host_buffer.data(), nbytes, cudaMemcpyHostToDevice));
   }
@@ -149,7 +149,7 @@ class DevBuffer {
     return DevBuffer{host_buffer};
   }
 
-  [[nodiscard]] static DevBuffer zero_like(const DevBuffer& prototype)
+  [[nodiscard]] static DevBuffer zero_like(DevBuffer const& prototype)
   {
     DevBuffer ret{prototype.nelem};
     KVIKIO_CHECK_CUDA(cudaMemset(ret.ptr, 0, ret.nbytes));
@@ -176,7 +176,7 @@ class DevBuffer {
 /**
  * @brief Check that two buffers are equal
  */
-inline void expect_equal(const DevBuffer& a, const DevBuffer& b)
+inline void expect_equal(DevBuffer const& a, DevBuffer const& b)
 {
   EXPECT_EQ(a.nbytes, b.nbytes);
   auto a_vec = a.to_vector();

--- a/java/src/main/native/src/CuFileJni.cpp
+++ b/java/src/main/native/src/CuFileJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_kvikio_cufile_CuFileDriver_create(JNIEnv*
 {
   try {
     return reinterpret_cast<jlong>(new cufile_driver());
-  } catch (const std::exception& e) {
+  } catch (std::exception const& e) {
     jlong default_ret_val = 0;
     if (env->ExceptionOccurred()) { return default_ret_val; }
 


### PR DESCRIPTION
This small PR applies east const style using `clang-format`. This makes KvikIO consistent with cuDF in coding style. The following parameters were applied to `.clang-format` for auto-reformatting. The file `.clang-format` itself is not updated in this PR.
```
QualifierAlignment: Custom
QualifierOrder: [inline, static, type, const, volatile]
```
In addition, this PR fixes minor "missing header" issues reported by `clang-tidy`. 