### PR TITLE
Adjust the way of determining FileHandle's compatibility mode for sync and async I/O to improve code readability

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -138,6 +138,7 @@ set(SOURCES
     "src/batch.cpp"
     "src/bounce_buffer.cpp"
     "src/buffer.cpp"
+    "src/compat_mode.cpp"
     "src/cufile/config.cpp"
     "src/cufile/driver.cpp"
     "src/defaults.cpp"

--- a/cpp/doxygen/main_page.md
+++ b/cpp/doxygen/main_page.md
@@ -80,7 +80,7 @@ When KvikIO is running in compatibility mode, it doesn't load `libcufile.so`. In
 
 The environment variable `KVIKIO_COMPAT_MODE` has three options (case-insensitive):
   - `ON` (aliases: `TRUE`, `YES`, `1`): Enable the compatibility mode.
-  - `OFF` (aliases: `FALSE`, `NO`, `0`): Disable the compatibility mode, and enforce cuFile I/O. GDS will be activated if the system requirements for cuFile are met and cuFile is properly configured. However, if the system is not suited for cuFile, I/O operations under the `OFF` option may error out, crash or hang.
+  - `OFF` (aliases: `FALSE`, `NO`, `0`): Disable the compatibility mode, and enforce cuFile I/O. GDS will be activated if the system requirements for cuFile are met and cuFile is properly configured. However, if the system is not suited for cuFile, I/O operations under the `OFF` option may error out.
   - `AUTO`: Try cuFile I/O first, and fall back to POSIX I/O if the system requirements for cuFile are not met.
 
 Under `AUTO`, KvikIO falls back to the compatibility mode:

--- a/cpp/include/kvikio/compat_mode.hpp
+++ b/cpp/include/kvikio/compat_mode.hpp
@@ -49,9 +49,11 @@ CompatMode parse_compat_mode_str(std::string_view compat_mode_str);
 
 }  // namespace detail
 
+// Forward declaration.
+class FileHandle;
+
 /**
- * @brief
- *
+ * @brief Store and manage the compatibility mode data associated with a FileHandle.
  */
 class CompatModeManager {
  private:
@@ -60,36 +62,87 @@ class CompatModeManager {
   bool _is_compat_mode_preferred_for_async{true};
 
  public:
+  /**
+   * @brief Construct an empty compatibility mode manager.
+   */
   CompatModeManager() noexcept = default;
+
+  /**
+   * @brief Construct a compatibility mode manager associated with a FileHandle.
+   *
+   * According to the file path, requested compatibility mode, and the system configuration, the
+   * compatibility manager:
+   * - Infers the final compatibility modes for synchronous and asynchronous I/O paths,
+   * respectively.
+   * - Initializes the file wrappers and cuFile handle associated with a FileHandle.
+   *
+   * @param file_path Refer to
+   * FileHandle::FileHandle(std::string const&, std::string const&, mode_t, CompatMode).
+   * @param flags Same as above.
+   * @param mode Same as above.
+   * @param compat_mode_requested Same as above.
+   * @param file_handle Point to the FileHandle object that owns this compatibility mode manager.
+   */
   CompatModeManager(std::string const& file_path,
                     std::string const& flags,
                     mode_t mode,
                     CompatMode compat_mode_requested,
-                    FileWrapper& file_direct_on,
-                    FileWrapper& file_direct_off,
-                    CUFileHandleWrapper& cufile_handle);
+                    FileHandle* file_handle);
+
   ~CompatModeManager() noexcept                              = default;
   CompatModeManager(const CompatModeManager&)                = default;
   CompatModeManager& operator=(const CompatModeManager&)     = default;
   CompatModeManager(CompatModeManager&&) noexcept            = default;
   CompatModeManager& operator=(CompatModeManager&&) noexcept = default;
 
-  void compat_mode_reset(CompatMode compat_mode_requested);
-
+  /**
+   * @brief Functionally identical to `defaults::infer_compat_mode_if_auto(CompatMode)`.
+   *
+   * @param compat_mode Compatibility mode.
+   * @return If the given compatibility mode is CompatMode::AUTO, infer the final compatibility
+   * mode.
+   */
   CompatMode infer_compat_mode_if_auto(CompatMode compat_mode) noexcept;
 
+  /**
+   * @brief Functionally identical to `defaults::is_compat_mode_preferred(CompatMode)`.
+   *
+   * @param compat_mode Compatibility mode.
+   * @return Boolean answer.
+   */
   bool is_compat_mode_preferred(CompatMode compat_mode) noexcept;
 
+  /**
+   * @brief Check if the compatibility mode for synchronous I/O of the associated FileHandle is
+   * expected to be CompatMode::ON.
+   *
+   * @return Boolean answer.
+   */
   bool is_compat_mode_preferred() const noexcept;
 
+  /**
+   * @brief Check if the compatibility mode for asynchronous I/O of the associated FileHandle is
+   * expected to be CompatMode::ON.
+   *
+   * @return Boolean answer.
+   */
   bool is_compat_mode_preferred_for_async() const noexcept;
 
+  /**
+   * @brief Retrieve the original compatibility mode requested.
+   *
+   * @return The original compatibility mode requested.
+   */
   CompatMode compat_mode_requested() const noexcept;
 
   /**
    * @brief Determine if the asynchronous I/O should be performed or not (throw exceptions)
-   * according to `_compat_mode_requested`, `_is_compat_mode_preferred`, and
-   * `_is_compat_mode_preferred_for_async`.
+   * according to the existing compatibility mode data in the manager.
+   *
+   * The asynchronous I/O should not be performed, for instance, when compat_mode_requested() is
+   * CompatMode::OFF, is_compat_mode_preferred() is CompatMode::OFF, but
+   * is_compat_mode_preferred_for_async() is CompatMode::ON (due to missing cuFile stream API or
+   * cuFile configuration file).
    */
   void validate_compat_mode_for_async();
 };

--- a/cpp/include/kvikio/compat_mode.hpp
+++ b/cpp/include/kvikio/compat_mode.hpp
@@ -60,12 +60,18 @@ class CompatModeManager {
   bool _is_compat_mode_preferred_for_async{true};
 
  public:
-  CompatModeManager()                                    = default;
-  ~CompatModeManager() noexcept                          = default;
-  CompatModeManager(const CompatModeManager&)            = default;
-  CompatModeManager& operator=(const CompatModeManager&) = default;
-  CompatModeManager(CompatModeManager&&) noexcept;
-  CompatModeManager& operator=(CompatModeManager&&) noexcept;
+  CompatModeManager(std::string const& file_path,
+                    std::string const& flags,
+                    mode_t mode,
+                    CompatMode compat_mode_requested,
+                    FileWrapper& file_direct_on,
+                    FileWrapper& file_direct_off,
+                    CUFileHandleWrapper& cufile_handle);
+  ~CompatModeManager() noexcept                              = default;
+  CompatModeManager(const CompatModeManager&)                = default;
+  CompatModeManager& operator=(const CompatModeManager&)     = default;
+  CompatModeManager(CompatModeManager&&) noexcept            = default;
+  CompatModeManager& operator=(CompatModeManager&&) noexcept = default;
 
   void compat_mode_reset(CompatMode compat_mode_requested);
 
@@ -78,9 +84,6 @@ class CompatModeManager {
   bool is_compat_mode_preferred_for_async() const noexcept;
 
   CompatMode compat_mode_requested() const noexcept;
-
-  std::tuple<FileWrapper, FileWrapper, CUFileHandleWrapper> resolve_compat_mode_for_file(
-    std::string const& file_path, std::string const& flags, mode_t mode, CompatMode compat_mode);
 
   /**
    * @brief Determine if the asynchronous I/O should be performed or not (throw exceptions)

--- a/cpp/include/kvikio/compat_mode.hpp
+++ b/cpp/include/kvikio/compat_mode.hpp
@@ -96,7 +96,7 @@ class CompatModeManager {
   CompatModeManager& operator=(CompatModeManager&&) noexcept = default;
 
   /**
-   * @brief Functionally identical to `defaults::infer_compat_mode_if_auto(CompatMode)`.
+   * @brief Functionally identical to defaults::infer_compat_mode_if_auto(CompatMode).
    *
    * @param compat_mode Compatibility mode.
    * @return If the given compatibility mode is CompatMode::AUTO, infer the final compatibility
@@ -105,7 +105,7 @@ class CompatModeManager {
   CompatMode infer_compat_mode_if_auto(CompatMode compat_mode) noexcept;
 
   /**
-   * @brief Functionally identical to `defaults::is_compat_mode_preferred(CompatMode)`.
+   * @brief Functionally identical to defaults::is_compat_mode_preferred(CompatMode).
    *
    * @param compat_mode Compatibility mode.
    * @return Boolean answer.
@@ -136,10 +136,10 @@ class CompatModeManager {
   CompatMode compat_mode_requested() const noexcept;
 
   /**
-   * @brief Determine if the asynchronous I/O should be performed or not (throw exceptions)
+   * @brief Determine if the asynchronous I/O can be performed or not (throw exceptions)
    * according to the existing compatibility mode data in the manager.
    *
-   * The asynchronous I/O should not be performed, for instance, when compat_mode_requested() is
+   * The asynchronous I/O  cannot be performed, for instance, when compat_mode_requested() is
    * CompatMode::OFF, is_compat_mode_preferred() is CompatMode::OFF, but
    * is_compat_mode_preferred_for_async() is CompatMode::ON (due to missing cuFile stream API or
    * cuFile configuration file).

--- a/cpp/include/kvikio/compat_mode.hpp
+++ b/cpp/include/kvikio/compat_mode.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <kvikio/file_utils.hpp>
+
+namespace kvikio {
+/**
+ * @brief I/O compatibility mode.
+ */
+enum class CompatMode : uint8_t {
+  OFF,  ///< Enforce cuFile I/O. GDS will be activated if the system requirements for cuFile are met
+        ///< and cuFile is properly configured. However, if the system is not suited for cuFile, I/O
+        ///< operations under the OFF option may error out.
+  ON,   ///< Enforce POSIX I/O.
+  AUTO,  ///< Try cuFile I/O first, and fall back to POSIX I/O if the system requirements for cuFile
+         ///< are not met.
+};
+
+namespace detail {
+/**
+ * @brief Parse a string into a CompatMode enum.
+ *
+ * @param compat_mode_str Compatibility mode in string format (case-insensitive). Valid values
+ * include:
+ *   - `ON` (alias: `TRUE`, `YES`, `1`)
+ *   - `OFF` (alias: `FALSE`, `NO`, `0`)
+ *   - `AUTO`
+ * @return A CompatMode enum.
+ */
+CompatMode parse_compat_mode_str(std::string_view compat_mode_str);
+
+}  // namespace detail
+
+/**
+ * @brief
+ *
+ */
+class CompatModeManager {
+ private:
+  CompatMode _compat_mode_requested{CompatMode::AUTO};
+  bool _is_compat_mode_preferred{true};
+  bool _is_compat_mode_preferred_for_async{true};
+
+ public:
+  CompatModeManager()                                    = default;
+  ~CompatModeManager() noexcept                          = default;
+  CompatModeManager(const CompatModeManager&)            = delete;
+  CompatModeManager& operator=(const CompatModeManager&) = delete;
+  CompatModeManager(CompatModeManager&&) noexcept;
+  CompatModeManager& operator=(CompatModeManager&&) noexcept;
+
+  void compat_mode_reset(CompatMode compat_mode_requested);
+
+  CompatMode infer_compat_mode_if_auto(CompatMode compat_mode) noexcept;
+
+  bool is_compat_mode_preferred(CompatMode compat_mode) noexcept;
+
+  bool is_compat_mode_preferred() const noexcept;
+
+  bool is_compat_mode_preferred_for_async() const noexcept;
+
+  CompatMode compat_mode_requested() const noexcept;
+
+  std::tuple<FileWrapper, FileWrapper, CUFileHandleWrapper> resolve_compat_mode_for_file(
+    std::string const& file_path, std::string const& flags, mode_t mode, CompatMode compat_mode);
+
+  /**
+   * @brief Determine if the asynchronous I/O should be performed or not (throw exceptions)
+   * according to `_compat_mode_requested`, `_is_compat_mode_preferred`, and
+   * `_is_compat_mode_preferred_for_async`.
+   */
+  void validate_compat_mode_for_async();
+};
+
+}  // namespace kvikio

--- a/cpp/include/kvikio/compat_mode.hpp
+++ b/cpp/include/kvikio/compat_mode.hpp
@@ -62,8 +62,8 @@ class CompatModeManager {
  public:
   CompatModeManager()                                    = default;
   ~CompatModeManager() noexcept                          = default;
-  CompatModeManager(const CompatModeManager&)            = delete;
-  CompatModeManager& operator=(const CompatModeManager&) = delete;
+  CompatModeManager(const CompatModeManager&)            = default;
+  CompatModeManager& operator=(const CompatModeManager&) = default;
   CompatModeManager(CompatModeManager&&) noexcept;
   CompatModeManager& operator=(CompatModeManager&&) noexcept;
 

--- a/cpp/include/kvikio/compat_mode.hpp
+++ b/cpp/include/kvikio/compat_mode.hpp
@@ -39,7 +39,7 @@ namespace detail {
  * @brief Parse a string into a CompatMode enum.
  *
  * @param compat_mode_str Compatibility mode in string format (case-insensitive). Valid values
- * include:
+ * are:
  *   - `ON` (alias: `TRUE`, `YES`, `1`)
  *   - `OFF` (alias: `FALSE`, `NO`, `0`)
  *   - `AUTO`
@@ -81,7 +81,7 @@ class CompatModeManager {
    * @param flags Same as above.
    * @param mode Same as above.
    * @param compat_mode_requested Same as above.
-   * @param file_handle Point to the FileHandle object that owns this compatibility mode manager.
+   * @param file_handle Pointer to the FileHandle object that owns this compatibility mode manager.
    */
   CompatModeManager(std::string const& file_path,
                     std::string const& flags,
@@ -136,10 +136,10 @@ class CompatModeManager {
   CompatMode compat_mode_requested() const noexcept;
 
   /**
-   * @brief Determine if the asynchronous I/O can be performed or not (throw exceptions)
+   * @brief Determine if asynchronous I/O can be performed or not (throw exceptions)
    * according to the existing compatibility mode data in the manager.
    *
-   * The asynchronous I/O cannot be performed, for instance, when compat_mode_requested() is
+   * Asynchronous I/O cannot be performed, for instance, when compat_mode_requested() is
    * CompatMode::OFF, is_compat_mode_preferred() is CompatMode::OFF, but
    * is_compat_mode_preferred_for_async() is CompatMode::ON (due to missing cuFile stream API or
    * cuFile configuration file).

--- a/cpp/include/kvikio/compat_mode.hpp
+++ b/cpp/include/kvikio/compat_mode.hpp
@@ -60,6 +60,7 @@ class CompatModeManager {
   bool _is_compat_mode_preferred_for_async{true};
 
  public:
+  CompatModeManager() noexcept = default;
   CompatModeManager(std::string const& file_path,
                     std::string const& flags,
                     mode_t mode,

--- a/cpp/include/kvikio/compat_mode.hpp
+++ b/cpp/include/kvikio/compat_mode.hpp
@@ -139,12 +139,12 @@ class CompatModeManager {
    * @brief Determine if the asynchronous I/O can be performed or not (throw exceptions)
    * according to the existing compatibility mode data in the manager.
    *
-   * The asynchronous I/O  cannot be performed, for instance, when compat_mode_requested() is
+   * The asynchronous I/O cannot be performed, for instance, when compat_mode_requested() is
    * CompatMode::OFF, is_compat_mode_preferred() is CompatMode::OFF, but
    * is_compat_mode_preferred_for_async() is CompatMode::ON (due to missing cuFile stream API or
    * cuFile configuration file).
    */
-  void validate_compat_mode_for_async();
+  void validate_compat_mode_for_async() const;
 };
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-// Enable documentation of the enum.
-/**
- * @file
- */
-
 #pragma once
 
 #include <cstddef>
@@ -29,35 +24,13 @@
 
 #include <BS_thread_pool.hpp>
 
+#include <kvikio/compat_mode.hpp>
 #include <kvikio/shim/cufile.hpp>
 
+/**
+ * @brief KvikIO namespace.
+ */
 namespace kvikio {
-/**
- * @brief I/O compatibility mode.
- */
-enum class CompatMode : uint8_t {
-  OFF,  ///< Enforce cuFile I/O. GDS will be activated if the system requirements for cuFile are met
-        ///< and cuFile is properly configured. However, if the system is not suited for cuFile, I/O
-        ///< operations under the OFF option may error out, crash or hang.
-  ON,   ///< Enforce POSIX I/O.
-  AUTO,  ///< Try cuFile I/O first, and fall back to POSIX I/O if the system requirements for cuFile
-         ///< are not met.
-};
-
-namespace detail {
-/**
- * @brief Parse a string into a CompatMode enum.
- *
- * @param compat_mode_str Compatibility mode in string format(case-insensitive). Valid values
- * include:
- *   - `ON` (alias: `TRUE`, `YES`, `1`)
- *   - `OFF` (alias: `FALSE`, `NO`, `0`)
- *   - `AUTO`
- * @return A CompatMode enum.
- */
-CompatMode parse_compat_mode_str(std::string_view compat_mode_str);
-
-}  // namespace detail
 
 template <typename T>
 T getenv_or(std::string_view env_var_name, T default_val)
@@ -88,10 +61,10 @@ CompatMode getenv_or(std::string_view env_var_name, CompatMode default_val);
 class defaults {
  private:
   BS::thread_pool _thread_pool{get_num_threads_from_env()};
-  CompatMode _compat_mode;
   std::size_t _task_size;
   std::size_t _gds_threshold;
   std::size_t _bounce_buffer_size;
+  CompatModeManager _compat_mode_manager{};
 
   static unsigned int get_num_threads_from_env();
 

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -61,10 +61,10 @@ CompatMode getenv_or(std::string_view env_var_name, CompatMode default_val);
 class defaults {
  private:
   BS::thread_pool _thread_pool{get_num_threads_from_env()};
+  CompatMode _compat_mode;
   std::size_t _task_size;
   std::size_t _gds_threshold;
   std::size_t _bounce_buffer_size;
-  CompatModeManager _compat_mode_manager{};
 
   static unsigned int get_num_threads_from_env();
 

--- a/cpp/include/kvikio/error.hpp
+++ b/cpp/include/kvikio/error.hpp
@@ -17,6 +17,7 @@
 
 #include <cstring>
 #include <exception>
+#include <string>
 #include <system_error>
 
 #include <kvikio/shim/cuda.hpp>
@@ -71,7 +72,7 @@ void cuda_driver_try_2(CUresult error, int line_number, char const* filename)
 {
   if (error == CUDA_ERROR_STUB_LIBRARY) {
     throw Exception{std::string{"CUDA error at: "} + std::string(filename) + ":" +
-                    KVIKIO_STRINGIFY(line_number) +
+                    std::to_string(line_number) +
                     ": CUDA_ERROR_STUB_LIBRARY("
                     "The CUDA driver loaded is a stub library)"};
   }
@@ -82,9 +83,8 @@ void cuda_driver_try_2(CUresult error, int line_number, char const* filename)
     CUresult err_str_status  = cudaAPI::instance().GetErrorString(error, &err_str);
     if (err_name_status == CUDA_ERROR_INVALID_VALUE) { err_name = "unknown"; }
     if (err_str_status == CUDA_ERROR_INVALID_VALUE) { err_str = "unknown"; }
-    throw Exception{std::string{"CUDA error at: "} + filename + ":" +
-                    KVIKIO_STRINGIFY(line_number) + ": " + std::string(err_name) + "(" +
-                    std::string(err_str) + ")"};
+    throw Exception{std::string{"CUDA error at: "} + filename + ":" + std::to_string(line_number) +
+                    ": " + std::string(err_name) + "(" + std::string(err_str) + ")"};
   }
 }
 
@@ -97,7 +97,7 @@ void cufile_try_2(CUfileError_t error, int line_number, char const* filename)
       CUDA_DRIVER_TRY(cuda_error);
     }
     throw Exception{std::string{"cuFile error at: "} + filename + ":" +
-                    KVIKIO_STRINGIFY(line_number) + ": " +
+                    std::to_string(line_number) + ": " +
                     cufileop_status_error((CUfileOpError)std::abs(error.err))};
   }
 }
@@ -111,7 +111,7 @@ void cufile_check_bytes_done_2(ssize_t nbytes_done, int line_number, char const*
                        ? std::string(cufileop_status_error((CUfileOpError)err))
                        : std::string(std::strerror(err));
     throw Exception{std::string{"cuFile error at: "} + filename + ":" +
-                    KVIKIO_STRINGIFY(line_number) + ": " + msg};
+                    std::to_string(line_number) + ": " + msg};
   }
 }
 

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -49,10 +49,11 @@ class FileHandle {
   // We use two file descriptors, one opened with the O_DIRECT flag and one without.
   FileWrapper _file_direct_on{};
   FileWrapper _file_direct_off{};
-  CUFileHandleWrapper _cufile_handle{};
   bool _initialized{false};
   mutable std::size_t _nbytes{0};  // The size of the underlying file, zero means unknown.
+  CUFileHandleWrapper _cufile_handle{};
   CompatModeManager _compat_mode_manager;
+  friend class CompatModeManager;
 
  public:
   static constexpr mode_t m644 = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH;

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -47,12 +47,12 @@ namespace kvikio {
 class FileHandle {
  private:
   // We use two file descriptors, one opened with the O_DIRECT flag and one without.
-  FileWrapper _fd_direct_on{};
-  FileWrapper _fd_direct_off{};
+  FileWrapper _file_direct_on{};
+  FileWrapper _file_direct_off{};
+  CUFileHandleWrapper _cufile_handle{};
   bool _initialized{false};
   mutable std::size_t _nbytes{0};  // The size of the underlying file, zero means unknown.
-  CUFileHandleWrapper _cufile_handle{};
-  CompatModeManager _compat_mode_manager{};
+  CompatModeManager _compat_mode_manager;
 
  public:
   static constexpr mode_t m644 = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH;

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -436,34 +436,13 @@ class FileHandle {
                                          CUstream stream     = nullptr);
 
   /**
-   * @brief Returns `true` if the compatibility mode is expected to be `ON` for this file.
+   * @brief Get the associated compatibility mode manager, which can be used to query the original
+   * requested compatibility mode or the expected compatibility modes for synchronous and
+   * asynchronous I/O.
    *
-   * Compatibility mode can be explicitly enabled in object creation. The mode is also enabled
-   * automatically, if file cannot be opened with the `O_DIRECT` flag, or if the system does not
-   * meet the requirements for the cuFile library under the `AUTO` compatibility mode.
-   *
-   * @return Boolean answer.
+   * @return The associated compatibility mode manager.
    */
-  [[nodiscard]] bool is_compat_mode_preferred() const noexcept;
-
-  /**
-   * @brief Returns `true` if the compatibility mode is expected to be `ON` for the asynchronous I/O
-   * on this file.
-   *
-   * For asynchronous I/O, the compatibility mode can be automatically enabled if the cuFile batch
-   * and stream symbols are missing, or if the cuFile configuration file is missing, or if
-   * `is_compat_mode_preferred()` returns true.
-   *
-   * @return Boolean answer.
-   */
-  [[nodiscard]] bool is_compat_mode_preferred_for_async() const noexcept;
-
-  /**
-   * @brief Returns the initially requested compatibility mode.
-   *
-   * @return The compatibility mode initially requested.
-   */
-  CompatMode compat_mode_requested() const noexcept;
+  const CompatModeManager& get_compat_mode_manager() const noexcept;
 };
 
 }  // namespace kvikio

--- a/cpp/src/batch.cpp
+++ b/cpp/src/batch.cpp
@@ -60,7 +60,7 @@ void BatchHandle::submit(std::vector<BatchOp> const& operations)
   std::vector<CUfileIOParams_t> io_batch_params;
   io_batch_params.reserve(operations.size());
   for (auto const& op : operations) {
-    if (op.file_handle.is_compat_mode_preferred()) {
+    if (op.file_handle.get_compat_mode_manager().is_compat_mode_preferred()) {
       throw CUfileException("Cannot submit a FileHandle opened in compatibility mode");
     }
 

--- a/cpp/src/compat_mode.cpp
+++ b/cpp/src/compat_mode.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cassert>
+#include <stdexcept>
+#include <utility>
+
+#include <kvikio/compat_mode.hpp>
+#include <kvikio/cufile/config.hpp>
+#include <kvikio/error.hpp>
+#include <kvikio/shim/cufile.hpp>
+
+namespace kvikio {
+
+namespace detail {
+CompatMode parse_compat_mode_str(std::string_view compat_mode_str)
+{
+  // Convert to lowercase
+  std::string tmp{compat_mode_str};
+  std::transform(
+    tmp.begin(), tmp.end(), tmp.begin(), [](unsigned char c) { return std::tolower(c); });
+
+  CompatMode res{};
+  if (tmp == "on" || tmp == "true" || tmp == "yes" || tmp == "1") {
+    res = CompatMode::ON;
+  } else if (tmp == "off" || tmp == "false" || tmp == "no" || tmp == "0") {
+    res = CompatMode::OFF;
+  } else if (tmp == "auto") {
+    res = CompatMode::AUTO;
+  } else {
+    throw std::invalid_argument("Unknown compatibility mode: " + std::string{tmp});
+  }
+  return res;
+}
+
+}  // namespace detail
+
+CompatModeManager::CompatModeManager(CompatModeManager&& o) noexcept
+  : _compat_mode_requested{std::exchange(o._compat_mode_requested, CompatMode::AUTO)},
+    _is_compat_mode_preferred{std::exchange(o._is_compat_mode_preferred, true)},
+    _is_compat_mode_preferred_for_async{std::exchange(o._is_compat_mode_preferred_for_async, true)}
+{
+}
+
+CompatModeManager& CompatModeManager::operator=(CompatModeManager&& o) noexcept
+{
+  _compat_mode_requested              = std::exchange(o._compat_mode_requested, CompatMode::AUTO);
+  _is_compat_mode_preferred           = std::exchange(o._is_compat_mode_preferred, true);
+  _is_compat_mode_preferred_for_async = std::exchange(o._is_compat_mode_preferred_for_async, true);
+  return *this;
+}
+
+void CompatModeManager::compat_mode_reset(CompatMode compat_mode_requested)
+{
+  _compat_mode_requested    = compat_mode_requested;
+  _is_compat_mode_preferred = (infer_compat_mode_if_auto(_compat_mode_requested) == CompatMode::ON);
+}
+
+CompatMode CompatModeManager::infer_compat_mode_if_auto(CompatMode compat_mode) noexcept
+{
+  if (compat_mode == CompatMode::AUTO) {
+    static auto inferred_compat_mode_for_auto = []() -> CompatMode {
+      return is_cufile_available() ? CompatMode::OFF : CompatMode::ON;
+    }();
+    return inferred_compat_mode_for_auto;
+  }
+  return compat_mode;
+}
+
+bool CompatModeManager::is_compat_mode_preferred(CompatMode compat_mode) noexcept
+{
+  return compat_mode == CompatMode::ON ||
+         (compat_mode == CompatMode::AUTO &&
+          infer_compat_mode_if_auto(compat_mode) == CompatMode::ON);
+}
+
+bool CompatModeManager::is_compat_mode_preferred() const noexcept
+{
+  return _is_compat_mode_preferred;
+}
+
+bool CompatModeManager::is_compat_mode_preferred_for_async() const noexcept
+{
+  return _is_compat_mode_preferred_for_async;
+}
+
+CompatMode CompatModeManager::compat_mode_requested() const noexcept
+{
+  return _compat_mode_requested;
+}
+
+std::tuple<FileWrapper, FileWrapper, CUFileHandleWrapper>
+CompatModeManager::resolve_compat_mode_for_file(std::string const& file_path,
+                                                std::string const& flags,
+                                                mode_t mode,
+                                                CompatMode compat_mode_requested_v)
+{
+  FileWrapper file_direct_off{file_path, flags, false, mode};
+  _is_compat_mode_preferred = is_compat_mode_preferred(compat_mode_requested_v);
+
+  // Nothing to do in compatibility mode
+  if (_is_compat_mode_preferred) {
+    return {std::move(file_direct_off), FileWrapper{}, CUFileHandleWrapper{}};
+  }
+
+  FileWrapper file_direct_on{};
+  try {
+    file_direct_on.open(file_path, flags, true, mode);
+  } catch (...) {
+    // Try to open the file with the O_DIRECT flag. Fall back to compatibility mode, if it fails.
+    if (compat_mode_requested_v == CompatMode::AUTO) {
+      _is_compat_mode_preferred = true;
+    } else {  // CompatMode::OFF
+      throw;
+    }
+  }
+
+  if (_is_compat_mode_preferred) {
+    return {std::move(file_direct_off), FileWrapper{}, CUFileHandleWrapper{}};
+  }
+
+  CUFileHandleWrapper handle;
+  auto error_code = handle.register_handle(file_direct_on.fd());
+  assert(error_code.has_value());
+
+  // For the AUTO mode, if the first cuFile API call fails, fall back to the compatibility
+  // mode.
+  if (compat_mode_requested_v == CompatMode::AUTO && error_code.value().err != CU_FILE_SUCCESS) {
+    _is_compat_mode_preferred = true;
+  } else {
+    CUFILE_TRY(error_code.value());
+  }
+
+  // Check cuFile async API
+  static bool is_extra_symbol_available = is_stream_api_available();
+  static bool is_config_path_empty      = config_path().empty();
+  _is_compat_mode_preferred_for_async =
+    _is_compat_mode_preferred || !is_extra_symbol_available || is_config_path_empty;
+  return {std::move(file_direct_off), std::move(file_direct_on), std::move(handle)};
+}
+
+void CompatModeManager::validate_compat_mode_for_async()
+{
+  if (!_is_compat_mode_preferred && _is_compat_mode_preferred_for_async &&
+      _compat_mode_requested == CompatMode::OFF) {
+    std::string err_msg;
+    if (!is_stream_api_available()) { err_msg += "Missing the cuFile stream api."; }
+
+    // When checking for availability, we also check if cuFile's config file exists. This is
+    // because even when the stream API is available, it doesn't work if no config file exists.
+    if (config_path().empty()) { err_msg += " Missing cuFile configuration file."; }
+
+    throw std::runtime_error(err_msg);
+  }
+}
+
+}  // namespace kvikio

--- a/cpp/src/compat_mode.cpp
+++ b/cpp/src/compat_mode.cpp
@@ -119,8 +119,8 @@ CompatModeManager::CompatModeManager(std::string const& file_path,
   }
 
   // Check cuFile async API
-  static bool is_extra_symbol_available = is_stream_api_available();
-  static bool is_config_path_empty      = config_path().empty();
+  static bool const is_extra_symbol_available = is_stream_api_available();
+  static bool const is_config_path_empty      = config_path().empty();
   _is_compat_mode_preferred_for_async =
     _is_compat_mode_preferred || !is_extra_symbol_available || is_config_path_empty;
 }

--- a/cpp/src/compat_mode.cpp
+++ b/cpp/src/compat_mode.cpp
@@ -123,7 +123,6 @@ CompatModeManager::CompatModeManager(std::string const& file_path,
   static bool is_config_path_empty      = config_path().empty();
   _is_compat_mode_preferred_for_async =
     _is_compat_mode_preferred || !is_extra_symbol_available || is_config_path_empty;
-  return;
 }
 
 void CompatModeManager::validate_compat_mode_for_async() const

--- a/cpp/src/compat_mode.cpp
+++ b/cpp/src/compat_mode.cpp
@@ -128,7 +128,7 @@ CompatModeManager::CompatModeManager(std::string const& file_path,
   return;
 }
 
-void CompatModeManager::validate_compat_mode_for_async()
+void CompatModeManager::validate_compat_mode_for_async() const
 {
   if (!_is_compat_mode_preferred && _is_compat_mode_preferred_for_async &&
       _compat_mode_requested == CompatMode::OFF) {

--- a/cpp/src/compat_mode.cpp
+++ b/cpp/src/compat_mode.cpp
@@ -34,17 +34,15 @@ CompatMode parse_compat_mode_str(std::string_view compat_mode_str)
   std::transform(
     tmp.begin(), tmp.end(), tmp.begin(), [](unsigned char c) { return std::tolower(c); });
 
-  CompatMode res{};
   if (tmp == "on" || tmp == "true" || tmp == "yes" || tmp == "1") {
-    res = CompatMode::ON;
+    return CompatMode::ON;
   } else if (tmp == "off" || tmp == "false" || tmp == "no" || tmp == "0") {
-    res = CompatMode::OFF;
+    return CompatMode::OFF;
   } else if (tmp == "auto") {
-    res = CompatMode::AUTO;
+    return CompatMode::AUTO;
   } else {
     throw std::invalid_argument("Unknown compatibility mode: " + std::string{tmp});
   }
-  return res;
 }
 
 }  // namespace detail

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -34,9 +34,7 @@ FileHandle::FileHandle(std::string const& file_path,
                        std::string const& flags,
                        mode_t mode,
                        CompatMode compat_mode)
-  : _initialized{true},
-    _compat_mode_manager{
-      file_path, flags, mode, compat_mode, _file_direct_on, _file_direct_off, _cufile_handle}
+  : _initialized{true}, _compat_mode_manager{file_path, flags, mode, compat_mode, this}
 {
 }
 

--- a/docs/source/runtime_settings.rst
+++ b/docs/source/runtime_settings.rst
@@ -8,7 +8,7 @@ When KvikIO is running in compatibility mode, it doesn't load ``libcufile.so``. 
 The environment variable ``KVIKIO_COMPAT_MODE`` has three options (case-insensitive):
 
   * ``ON`` (aliases: ``TRUE``, ``YES``, ``1``): Enable the compatibility mode.
-  * ``OFF`` (aliases: ``FALSE``, ``NO``, ``0``): Disable the compatibility mode, and enforce cuFile I/O. GDS will be activated if the system requirements for cuFile are met and cuFile is properly configured. However, if the system is not suited for cuFile, I/O operations under the ``OFF`` option may error out, crash or hang.
+  * ``OFF`` (aliases: ``FALSE``, ``NO``, ``0``): Disable the compatibility mode, and enforce cuFile I/O. GDS will be activated if the system requirements for cuFile are met and cuFile is properly configured. However, if the system is not suited for cuFile, I/O operations under the ``OFF`` option may error out.
   * ``AUTO``: Try cuFile I/O first, and fall back to POSIX I/O if the system requirements for cuFile are not met.
 
 Under ``AUTO``, KvikIO falls back to the compatibility mode:


### PR DESCRIPTION
This PR improves the readability of compatibility mode handling.

The current way of determining FileHandle's compatibility mode is somewhat complicated and unintuitive. The data member `_compat_mode` accompanied by some utility functions more or less combines 3 different things into one:

- The initially requested compat mode (`ON`/`OFF`/`AUTO`)
- The capability of performing synchronous cuFile I/O (bool)
- The capability of performing asynchronous cufile I/O (bool)

The disadvantages include:
- `FileHandle::is_compat_mode_preferred()` always derives the preferred compat mode on the fly as opposed to getting an already determined value.
- `FileHandle::is_compat_mode_preferred_for_async(CompatMode)` is potentially throwing, which is asymmetric to `is_compat_mode_preferred()`. Also when the compat mode is `OFF`, it has to invoke `is_stream_api_available()` and `config_path()` on each pass instead of getting an already determined value.
- There is no way to retrieve what the original requested compat mode is.

These add to cognitive burden when rereading the source to introduce new features to FileHandle. This PR attempts to improve the logic by making it concise and crystal clear.

This PR also fixes a line number bug in error handling.

This PR is breaking in that the rarely used public functions to query the compat mode data in the `FileHandle` are removed. These data are instead queryable via the new `CompatModeManager` class.