### PR TITLE
Use `rapids-generate-version` for env var

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -22,7 +22,7 @@ conda config --set path_conflict prevent
 
 sccache --zero-stats
 
-RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry mambabuild \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/kvikio
 


### PR DESCRIPTION
Follow up on this thread: https://github.com/rapidsai/kvikio/pull/616#discussion_r1942351193