### PR TITLE
Improve config handling in cpp and python

### DIFF
--- a/cpp/examples/basic_io.cpp
+++ b/cpp/examples/basic_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,7 +124,7 @@ int main()
       check(a[i] == b[i]);
     }
   }
-  kvikio::defaults::thread_pool_nthreads_reset(16);
+  kvikio::defaults::set_thread_pool_nthreads(16);
   {
     std::cout << std::endl;
     Timer timer;

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -157,7 +157,7 @@ class defaults {
    *
    * Notice, it is not possible to change the default thread pool. KvikIO will
    * always use the same thread pool however it is possible to change number of
-   * threads in the pool (see `kvikio::default::set_thread_pool_nthreads`).
+   * threads in the pool (see `kvikio::default::set_thread_pool_nthreads()`).
    *
    * @return The default thread pool instance.
    */

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -166,7 +166,7 @@ class defaults {
   /**
    * @brief Get the number of threads in the default thread pool.
    *
-   * Set the default value using `kvikio::default::set_thread_pool_nthreads` or by
+   * Set the default value using `kvikio::default::set_thread_pool_nthreads()` or by
    * setting the `KVIKIO_NTHREADS` environment variable. If not set, the default value is 1.
    *
    * @return The number of threads.
@@ -187,7 +187,7 @@ class defaults {
   /**
    * @brief Get the default task size used for parallel IO operations.
    *
-   * Set the default value using `kvikio::default::set_task_size` or by setting
+   * Set the default value using `kvikio::default::set_task_size()` or by setting
    * the `KVIKIO_TASK_SIZE` environment variable. If not set, the default value is 4 MiB.
    *
    * @return The default task size in bytes.
@@ -207,7 +207,7 @@ class defaults {
    * In order to improve performance of small IO, `.pread()` and `.pwrite()` implement a shortcut
    * that circumvent the threadpool and use the POSIX backend directly.
    *
-   * Set the default value using `kvikio::default::set_gds_threshold` or by setting the
+   * Set the default value using `kvikio::default::set_gds_threshold()` or by setting the
    * `KVIKIO_GDS_THRESHOLD` environment variable. If not set, the default value is 1 MiB.
    *
    * @return The default GDS threshold size in bytes.
@@ -258,7 +258,7 @@ class defaults {
   /**
    * @brief The list of HTTP status codes to retry.
    *
-   * Set the value using `kvikio::default::http_status_codes()` or by setting the
+   * Set the value using `kvikio::default::set_http_status_codes()` or by setting the
    * `KVIKIO_HTTP_STATUS_CODES` environment variable. If not set, the default value is
    *
    * - 429

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -177,8 +177,7 @@ class defaults {
    * @brief Set the number of threads in the default thread pool. Waits for all currently running
    * tasks to be completed, then destroys all threads in the pool and creates a new thread pool with
    * the new number of threads. Any tasks that were waiting in the queue before the pool was reset
-   * will then be executed by the new threads. If the pool was paused before resetting it, the new
-   * pool will be paused as well.
+   * will then be executed by the new threads.
    *
    * @param nthreads The number of threads to use.
    */

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -99,14 +99,14 @@ class defaults {
   [[nodiscard]] static CompatMode compat_mode();
 
   /**
-   * @brief Reset the value of `kvikio::defaults::compat_mode()`.
+   * @brief Set the value of `kvikio::defaults::compat_mode()`.
    *
    * Changing the compatibility mode affects all the new FileHandles whose `compat_mode` argument is
    * not explicitly set, but it never affects existing FileHandles.
    *
    * @param compat_mode Compatibility mode.
    */
-  static void compat_mode_reset(CompatMode compat_mode);
+  static void set_compat_mode(CompatMode compat_mode);
 
   /**
    * @brief Infer the `AUTO` compatibility mode from the system runtime.
@@ -157,7 +157,7 @@ class defaults {
    *
    * Notice, it is not possible to change the default thread pool. KvikIO will
    * always use the same thread pool however it is possible to change number of
-   * threads in the pool (see `kvikio::default::thread_pool_nthreads_reset()`).
+   * threads in the pool (see `kvikio::default::set_thread_pool_nthreads`).
    *
    * @return The default thread pool instance.
    */
@@ -166,7 +166,7 @@ class defaults {
   /**
    * @brief Get the number of threads in the default thread pool.
    *
-   * Set the default value using `kvikio::default::thread_pool_nthreads_reset()` or by
+   * Set the default value using `kvikio::default::set_thread_pool_nthreads` or by
    * setting the `KVIKIO_NTHREADS` environment variable. If not set, the default value is 1.
    *
    * @return The number of threads.
@@ -174,7 +174,7 @@ class defaults {
   [[nodiscard]] static unsigned int thread_pool_nthreads();
 
   /**
-   * @brief Reset the number of threads in the default thread pool. Waits for all currently running
+   * @brief Set the number of threads in the default thread pool. Waits for all currently running
    * tasks to be completed, then destroys all threads in the pool and creates a new thread pool with
    * the new number of threads. Any tasks that were waiting in the queue before the pool was reset
    * will then be executed by the new threads. If the pool was paused before resetting it, the new
@@ -182,12 +182,12 @@ class defaults {
    *
    * @param nthreads The number of threads to use.
    */
-  static void thread_pool_nthreads_reset(unsigned int nthreads);
+  static void set_thread_pool_nthreads(unsigned int nthreads);
 
   /**
    * @brief Get the default task size used for parallel IO operations.
    *
-   * Set the default value using `kvikio::default::task_size_reset()` or by setting
+   * Set the default value using `kvikio::default::set_task_size` or by setting
    * the `KVIKIO_TASK_SIZE` environment variable. If not set, the default value is 4 MiB.
    *
    * @return The default task size in bytes.
@@ -195,11 +195,11 @@ class defaults {
   [[nodiscard]] static std::size_t task_size();
 
   /**
-   * @brief Reset the default task size used for parallel IO operations.
+   * @brief Set the default task size used for parallel IO operations.
    *
    * @param nbytes The default task size in bytes.
    */
-  static void task_size_reset(std::size_t nbytes);
+  static void set_task_size(std::size_t nbytes);
 
   /**
    * @brief Get the default GDS threshold, which is the minimum size to use GDS (in bytes).
@@ -207,7 +207,7 @@ class defaults {
    * In order to improve performance of small IO, `.pread()` and `.pwrite()` implement a shortcut
    * that circumvent the threadpool and use the POSIX backend directly.
    *
-   * Set the default value using `kvikio::default::gds_threshold_reset()` or by setting the
+   * Set the default value using `kvikio::default::set_gds_threshold` or by setting the
    * `KVIKIO_GDS_THRESHOLD` environment variable. If not set, the default value is 1 MiB.
    *
    * @return The default GDS threshold size in bytes.
@@ -215,15 +215,15 @@ class defaults {
   [[nodiscard]] static std::size_t gds_threshold();
 
   /**
-   * @brief Reset the default GDS threshold, which is the minimum size to use GDS (in bytes).
+   * @brief Set the default GDS threshold, which is the minimum size to use GDS (in bytes).
    * @param nbytes The default GDS threshold size in bytes.
    */
-  static void gds_threshold_reset(std::size_t nbytes);
+  static void set_gds_threshold(std::size_t nbytes);
 
   /**
    * @brief Get the size of the bounce buffer used to stage data in host memory.
    *
-   * Set the value using `kvikio::default::bounce_buffer_size_reset()` or by setting the
+   * Set the value using `kvikio::default::set_bounce_buffer_size()` or by setting the
    * `KVIKIO_BOUNCE_BUFFER_SIZE` environment variable. If not set, the value is 16 MiB.
    *
    * @return The bounce buffer size in bytes.
@@ -231,16 +231,16 @@ class defaults {
   [[nodiscard]] static std::size_t bounce_buffer_size();
 
   /**
-   * @brief Reset the size of the bounce buffer used to stage data in host memory.
+   * @brief Set the size of the bounce buffer used to stage data in host memory.
    *
    * @param nbytes The bounce buffer size in bytes.
    */
-  static void bounce_buffer_size_reset(std::size_t nbytes);
+  static void set_bounce_buffer_size(std::size_t nbytes);
 
   /**
    * @brief Get the maximum number of attempts per remote IO read.
    *
-   * Set the value using `kvikio::default::http_max_attempts_reset()` or by setting
+   * Set the value using `kvikio::default::set_http_max_attempts()` or by setting
    * the `KVIKIO_HTTP_MAX_ATTEMPTS` environment variable. If not set, the value is 3.
    *
    * @return The maximum number of remote IO reads to attempt before raising an
@@ -249,11 +249,11 @@ class defaults {
   [[nodiscard]] static std::size_t http_max_attempts();
 
   /**
-   * @brief Reset the maximum number of attempts per remote IO read.
+   * @brief Set the maximum number of attempts per remote IO read.
    *
    * @param attempts The maximum number of attempts to try before raising an error.
    */
-  static void http_max_attempts_reset(std::size_t attempts);
+  static void set_http_max_attempts(std::size_t attempts);
 
   /**
    * @brief The list of HTTP status codes to retry.
@@ -272,11 +272,11 @@ class defaults {
   [[nodiscard]] static std::vector<int> const& http_status_codes();
 
   /**
-   * @brief Reset the list of HTTP status codes to retry.
+   * @brief Set the list of HTTP status codes to retry.
    *
    * @param status_codes The HTTP status codes to retry.
    */
-  static void http_status_codes_reset(std::vector<int> status_codes);
+  static void set_http_status_codes(std::vector<int> status_codes);
 };
 
 }  // namespace kvikio

--- a/cpp/src/defaults.cpp
+++ b/cpp/src/defaults.cpp
@@ -143,7 +143,7 @@ defaults* defaults::instance()
 }
 CompatMode defaults::compat_mode() { return instance()->_compat_mode; }
 
-void defaults::compat_mode_reset(CompatMode compat_mode) { instance()->_compat_mode = compat_mode; }
+void defaults::set_compat_mode(CompatMode compat_mode) { instance()->_compat_mode = compat_mode; }
 
 CompatMode defaults::infer_compat_mode_if_auto(CompatMode compat_mode) noexcept
 {
@@ -169,7 +169,7 @@ BS_thread_pool& defaults::thread_pool() { return instance()->_thread_pool; }
 
 unsigned int defaults::thread_pool_nthreads() { return thread_pool().get_thread_count(); }
 
-void defaults::thread_pool_nthreads_reset(unsigned int nthreads)
+void defaults::set_thread_pool_nthreads(unsigned int nthreads)
 {
   if (nthreads == 0) {
     throw std::invalid_argument("number of threads must be a positive integer greater than zero");
@@ -179,7 +179,7 @@ void defaults::thread_pool_nthreads_reset(unsigned int nthreads)
 
 std::size_t defaults::task_size() { return instance()->_task_size; }
 
-void defaults::task_size_reset(std::size_t nbytes)
+void defaults::set_task_size(std::size_t nbytes)
 {
   if (nbytes == 0) {
     throw std::invalid_argument("task size must be a positive integer greater than zero");
@@ -189,11 +189,11 @@ void defaults::task_size_reset(std::size_t nbytes)
 
 std::size_t defaults::gds_threshold() { return instance()->_gds_threshold; }
 
-void defaults::gds_threshold_reset(std::size_t nbytes) { instance()->_gds_threshold = nbytes; }
+void defaults::set_gds_threshold(std::size_t nbytes) { instance()->_gds_threshold = nbytes; }
 
 std::size_t defaults::bounce_buffer_size() { return instance()->_bounce_buffer_size; }
 
-void defaults::bounce_buffer_size_reset(std::size_t nbytes)
+void defaults::set_bounce_buffer_size(std::size_t nbytes)
 {
   if (nbytes == 0) {
     throw std::invalid_argument(
@@ -204,7 +204,7 @@ void defaults::bounce_buffer_size_reset(std::size_t nbytes)
 
 std::size_t defaults::http_max_attempts() { return instance()->_http_max_attempts; }
 
-void defaults::http_max_attempts_reset(std::size_t attempts)
+void defaults::set_http_max_attempts(std::size_t attempts)
 {
   if (attempts == 0) { throw std::invalid_argument("attempts must be a positive integer"); }
   instance()->_http_max_attempts = attempts;
@@ -212,7 +212,7 @@ void defaults::http_max_attempts_reset(std::size_t attempts)
 
 std::vector<int> const& defaults::http_status_codes() { return instance()->_http_status_codes; }
 
-void defaults::http_status_codes_reset(std::vector<int> status_codes)
+void defaults::set_http_status_codes(std::vector<int> status_codes)
 {
   instance()->_http_status_codes = std::move(status_codes);
 }

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,6 +11,24 @@ CuFile
 .. autoclass:: IOFuture
     :members:
 
+CuFile driver
+-------------
+.. currentmodule:: kvikio.cufile_driver
+
+.. autoclass:: ConfigContextManager
+
+.. autofunction:: set
+
+.. autofunction:: get
+
+.. autofunction:: libcufile_version
+
+.. autofunction:: driver_open
+
+.. autofunction:: driver_close
+
+.. autofunction:: initialize
+
 Zarr
 ----
 .. currentmodule:: kvikio.zarr
@@ -29,6 +47,12 @@ Defaults
 --------
 .. currentmodule:: kvikio.defaults
 
+.. autoclass:: ConfigContextManager
+
+.. autofunction:: set
+
+.. autofunction:: get
+
 .. autofunction:: compat_mode
 
 .. autofunction:: num_threads
@@ -43,4 +67,23 @@ Defaults
 
 .. autofunction:: http_max_attempts
 
-.. autofunction:: set
+.. autofunction:: compat_mode_reset
+.. autofunction:: set_compat_mode
+
+.. autofunction:: num_threads_reset
+.. autofunction:: set_num_threads
+
+.. autofunction:: task_size_reset
+.. autofunction:: set_task_size
+
+.. autofunction:: gds_threshold_reset
+.. autofunction:: set_gds_threshold
+
+.. autofunction:: bounce_buffer_size_reset
+.. autofunction:: set_bounce_buffer_size
+
+.. autofunction:: http_status_codes_reset
+.. autofunction:: set_http_status_codes
+
+.. autofunction:: http_max_attempts_reset
+.. autofunction:: set_http_max_attempts

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -41,6 +41,6 @@ Defaults
 
 .. autofunction:: http_status_codes
 
-.. autofunction:: kvikio.defaults.http_max_attempts
+.. autofunction:: http_max_attempts
 
 .. autofunction:: set

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -31,8 +31,16 @@ Defaults
 
 .. autofunction:: compat_mode
 
-.. autofunction:: compat_mode_reset
+.. autofunction:: num_threads
 
-.. autofunction:: get_num_threads
+.. autofunction:: task_size
 
-.. autofunction:: num_threads_reset
+.. autofunction:: gds_threshold
+
+.. autofunction:: bounce_buffer_size
+
+.. autofunction:: http_status_codes
+
+.. autofunction:: kvikio.defaults.http_max_attempts
+
+.. autofunction:: set

--- a/docs/source/runtime_settings.rst
+++ b/docs/source/runtime_settings.rst
@@ -17,37 +17,37 @@ Under ``AUTO``, KvikIO falls back to the compatibility mode:
   * when running in Windows Subsystem for Linux (WSL).
   * when ``/run/udev`` isn't readable, which typically happens when running inside a docker image not launched with ``--volume /run/udev:/run/udev:ro``.
 
-This setting can also be programmatically controlled by :py:func:`kvikio.defaults.set_compat_mode` and :py:func:`kvikio.defaults.compat_mode_reset`.
+This setting can also be programmatically accessed using :py:func:`kvikio.defaults.compat_mode` (getter) and :py:func:`kvikio.defaults.set` (setter).
 
 Thread Pool ``KVIKIO_NTHREADS``
 -------------------------------
 KvikIO can use multiple threads for IO automatically. Set the environment variable ``KVIKIO_NTHREADS`` to the number of threads in the thread pool. If not set, the default value is 1.
 
-This setting can also be controlled by :py:func:`kvikio.defaults.get_num_threads`, :py:func:`kvikio.defaults.num_threads_reset`, and :py:func:`kvikio.defaults.set_num_threads`.
+This setting can also be accessed using :py:func:`kvikio.defaults.num_threads` (getter) and :py:func:`kvikio.defaults.set`  (setter).
 
 Task Size ``KVIKIO_TASK_SIZE``
 ------------------------------
 KvikIO splits parallel IO operations into multiple tasks. Set the environment variable ``KVIKIO_TASK_SIZE`` to the maximum task size (in bytes). If not set, the default value is 4194304 (4 MiB).
 
-This setting can also be controlled by :py:func:`kvikio.defaults.task_size`, :py:func:`kvikio.defaults.task_size_reset`, and :py:func:`kvikio.defaults.set_task_size`.
+This setting can also be accessed using :py:func:`kvikio.defaults.task_size` (getter) and :py:func:`kvikio.defaults.set` (setter).
 
 GDS Threshold ``KVIKIO_GDS_THRESHOLD``
 --------------------------------------
 In order to improve performance of small IO, ``.pread()`` and ``.pwrite()`` implement a shortcut that circumvent the threadpool and use the POSIX backend directly. Set the environment variable ``KVIKIO_GDS_THRESHOLD`` to the minimum size (in bytes) to use GDS. If not set, the default value is 1048576 (1 MiB).
 
-This setting can also be controlled by :py:func:`kvikio.defaults.gds_threshold`, :py:func:`kvikio.defaults.gds_threshold_reset`, and :py:func:`kvikio.defaults.set_gds_threshold`.
+This setting can also be accessed using :py:func:`kvikio.defaults.gds_threshold` (getter) and :py:func:`kvikio.defaults.set` (setter).
 
 Size of the Bounce Buffer ``KVIKIO_BOUNCE_BUFFER_SIZE``
 -------------------------------------------------------
 KvikIO might have to use intermediate host buffers (one per thread) when copying between files and device memory. Set the environment variable ``KVIKIO_BOUNCE_BUFFER_SIZE`` to the size (in bytes) of these "bounce" buffers. If not set, the default value is 16777216 (16 MiB).
 
-This setting can also be controlled by :py:func:`kvikio.defaults.bounce_buffer_size`, :py:func:`kvikio.defaults.bounce_buffer_size_reset`, and :py:func:`kvikio.defaults.set_bounce_buffer_size`.
+This setting can also be accessed using :py:func:`kvikio.defaults.bounce_buffer_size` (getter) and :py:func:`kvikio.defaults.set` (setter).
 
-#### HTTP Retries
------------------
+HTTP Retries ``KVIKIO_HTTP_STATUS_CODES``, ``KVIKIO_HTTP_MAX_ATTEMPTS``
+------------------------------------------------------------------------
 
-The behavior when a remote IO read returns a error can be controlled through the `KVIKIO_HTTP_STATUS_CODES` and `KVIKIO_HTTP_MAX_ATTEMPTS` environment variables.
+The behavior when a remote I/O read returns an error can be controlled through the ``KVIKIO_HTTP_STATUS_CODES`` and ``KVIKIO_HTTP_MAX_ATTEMPTS`` environment variables.
 
-`KVIKIO_HTTP_STATUS_CODES` controls the status codes to retry and can be controlled by :py:func:`kvikio.defaults.http_status_codes`, :py:func:`kvikio.defaults.http_status_codes_reset`, and :py:func:`kvikio.defaults.set_http_status_codes`.
+KvikIO will retry a request should any of the HTTP status code in ``KVIKIO_HTTP_STATUS_CODES`` is received. The default values are ``429, 500, 502, 503, 504``. This setting can also be accessed using :py:func:`kvikio.defaults.http_status_codes` (getter) and :py:func:`kvikio.defaults.set` (setter).
 
-`KVIKIO_HTTP_MAX_ATTEMPTS` controls the maximum number of attempts to make before throwing an exception and can be controlled by :py:func:`kvikio.defaults.http_max_attempts`, :py:func:`kvikio.defaults.http_max_attempts_reset`, and :py:func:`kvikio.defaults.set_http_max_attempts`.
+The maximum number of attempts to make before throwing an exception is controlled by ``KVIKIO_HTTP_MAX_ATTEMPTS``. The default value is 3. This setting can also be accessed using :py:func:`kvikio.defaults.http_max_attempts` (getter) and :py:func:`kvikio.defaults.set` (setter).

--- a/python/kvikio/kvikio/_lib/defaults.pyx
+++ b/python/kvikio/kvikio/_lib/defaults.pyx
@@ -14,6 +14,8 @@ cdef extern from "<kvikio/defaults.hpp>" namespace "kvikio" nogil:
         OFF = 0
         ON = 1
         AUTO = 2
+    bool cpp_is_compat_mode_preferred \
+        "kvikio::defaults::is_compat_mode_preferred"() except +
     CompatMode cpp_compat_mode "kvikio::defaults::compat_mode"() except +
     void cpp_set_compat_mode \
         "kvikio::defaults::set_compat_mode"(CompatMode compat_mode) except +
@@ -35,6 +37,10 @@ cdef extern from "<kvikio/defaults.hpp>" namespace "kvikio" nogil:
     vector[int] cpp_http_status_codes "kvikio::defaults::http_status_codes"() except +
     void cpp_set_http_status_codes \
         "kvikio::defaults::set_http_status_codes"(vector[int] status_codes) except +
+
+
+def is_compat_mode_preferred() -> bool:
+    return cpp_is_compat_mode_preferred()
 
 
 def compat_mode() -> CompatMode:

--- a/python/kvikio/kvikio/_lib/defaults.pyx
+++ b/python/kvikio/kvikio/_lib/defaults.pyx
@@ -15,79 +15,79 @@ cdef extern from "<kvikio/defaults.hpp>" namespace "kvikio" nogil:
         ON = 1
         AUTO = 2
     CompatMode cpp_compat_mode "kvikio::defaults::compat_mode"() except +
-    void cpp_compat_mode_reset \
-        "kvikio::defaults::compat_mode_reset"(CompatMode compat_mode) except +
+    void cpp_set_compat_mode \
+        "kvikio::defaults::set_compat_mode"(CompatMode compat_mode) except +
     unsigned int cpp_thread_pool_nthreads \
         "kvikio::defaults::thread_pool_nthreads"() except +
-    void cpp_thread_pool_nthreads_reset \
-        "kvikio::defaults::thread_pool_nthreads_reset" (unsigned int nthreads) except +
+    void cpp_set_thread_pool_nthreads \
+        "kvikio::defaults::set_thread_pool_nthreads" (unsigned int nthreads) except +
     size_t cpp_task_size "kvikio::defaults::task_size"() except +
-    void cpp_task_size_reset "kvikio::defaults::task_size_reset"(size_t nbytes) except +
+    void cpp_set_task_size "kvikio::defaults::set_task_size"(size_t nbytes) except +
     size_t cpp_gds_threshold "kvikio::defaults::gds_threshold"() except +
-    void cpp_gds_threshold_reset \
-        "kvikio::defaults::gds_threshold_reset"(size_t nbytes) except +
+    void cpp_set_gds_threshold \
+        "kvikio::defaults::set_gds_threshold"(size_t nbytes) except +
     size_t cpp_bounce_buffer_size "kvikio::defaults::bounce_buffer_size"() except +
-    void cpp_bounce_buffer_size_reset \
-        "kvikio::defaults::bounce_buffer_size_reset"(size_t nbytes) except +
+    void cpp_set_bounce_buffer_size \
+        "kvikio::defaults::set_bounce_buffer_size"(size_t nbytes) except +
     size_t cpp_http_max_attempts "kvikio::defaults::http_max_attempts"() except +
-    void cpp_http_max_attempts_reset \
-        "kvikio::defaults::http_max_attempts_reset"(size_t attempts) except +
+    void cpp_set_http_max_attempts \
+        "kvikio::defaults::set_http_max_attempts"(size_t attempts) except +
     vector[int] cpp_http_status_codes "kvikio::defaults::http_status_codes"() except +
-    void cpp_http_status_codes_reset \
-        "kvikio::defaults::http_status_codes_reset"(vector[int] status_codes) except +
+    void cpp_set_http_status_codes \
+        "kvikio::defaults::set_http_status_codes"(vector[int] status_codes) except +
 
 
 def compat_mode() -> CompatMode:
     return cpp_compat_mode()
 
 
-def compat_mode_reset(compat_mode: CompatMode) -> None:
-    cpp_compat_mode_reset(compat_mode)
+def set_compat_mode(compat_mode: CompatMode) -> None:
+    cpp_set_compat_mode(compat_mode)
 
 
 def thread_pool_nthreads() -> int:
     return cpp_thread_pool_nthreads()
 
 
-def thread_pool_nthreads_reset(nthreads: int) -> None:
-    cpp_thread_pool_nthreads_reset(nthreads)
+def set_thread_pool_nthreads(nthreads: int) -> None:
+    cpp_set_thread_pool_nthreads(nthreads)
 
 
 def task_size() -> int:
     return cpp_task_size()
 
 
-def task_size_reset(nbytes: int) -> None:
-    cpp_task_size_reset(nbytes)
+def set_task_size(nbytes: int) -> None:
+    cpp_set_task_size(nbytes)
 
 
 def gds_threshold() -> int:
     return cpp_gds_threshold()
 
 
-def gds_threshold_reset(nbytes: int) -> None:
-    cpp_gds_threshold_reset(nbytes)
+def set_gds_threshold(nbytes: int) -> None:
+    cpp_set_gds_threshold(nbytes)
 
 
 def bounce_buffer_size() -> int:
     return cpp_bounce_buffer_size()
 
 
-def bounce_buffer_size_reset(nbytes: int) -> None:
-    cpp_bounce_buffer_size_reset(nbytes)
+def set_bounce_buffer_size(nbytes: int) -> None:
+    cpp_set_bounce_buffer_size(nbytes)
 
 
 def http_max_attempts() -> int:
     return cpp_http_max_attempts()
 
 
-def http_max_attempts_reset(attempts: int) -> None:
-    cpp_http_max_attempts_reset(attempts)
+def set_http_max_attempts(attempts: int) -> None:
+    cpp_set_http_max_attempts(attempts)
 
 
 def http_status_codes() -> list[int]:
     return cpp_http_status_codes()
 
 
-def http_status_codes_reset(status_codes: list[int]) -> None:
-    return cpp_http_status_codes_reset(status_codes)
+def set_http_status_codes(status_codes: list[int]) -> None:
+    return cpp_set_http_status_codes(status_codes)

--- a/python/kvikio/kvikio/benchmarks/http_io.py
+++ b/python/kvikio/kvikio/benchmarks/http_io.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 import argparse
@@ -47,7 +47,7 @@ def main(args):
     cupy.cuda.set_allocator(None)  # Disable CuPy's default memory pool
     cupy.arange(10)  # Make sure CUDA is initialized
 
-    kvikio.defaults.num_threads_reset(args.nthreads)
+    kvikio.defaults.set("num_threads", args.nthreads)
     print("Roundtrip benchmark")
     print("--------------------------------------")
     print(f"nelem       | {args.nelem} ({format_bytes(args.nbytes)})")
@@ -68,7 +68,8 @@ def main(args):
             res.append(elapsed)
 
         def pprint_api_res(name, samples):
-            samples = [args.nbytes / s for s in samples]  # Convert to throughput
+            # Convert to throughput
+            samples = [args.nbytes / s for s in samples]
             mean = statistics.harmonic_mean(samples) if len(samples) > 1 else samples[0]
             ret = f"{api}-{name}".ljust(18)
             ret += f"| {format_bytes(mean).rjust(10)}/s".ljust(14)

--- a/python/kvikio/kvikio/benchmarks/s3_io.py
+++ b/python/kvikio/kvikio/benchmarks/s3_io.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 import argparse
@@ -134,7 +134,7 @@ def main(args):
     cupy.arange(10)  # Make sure CUDA is initialized
 
     os.environ["KVIKIO_NTHREADS"] = str(args.nthreads)
-    kvikio.defaults.num_threads_reset(args.nthreads)
+    kvikio.defaults.set("num_threads", args.nthreads)
 
     print("Remote S3 benchmark")
     print("--------------------------------------")
@@ -157,7 +157,8 @@ def main(args):
             res.append(elapsed)
 
         def pprint_api_res(name, samples):
-            samples = [args.nbytes / s for s in samples]  # Convert to throughput
+            # Convert to throughput
+            samples = [args.nbytes / s for s in samples]
             mean = statistics.harmonic_mean(samples) if len(samples) > 1 else samples[0]
             ret = f"{api}-{name}".ljust(18)
             ret += f"| {format_bytes(mean).rjust(10)}/s".ljust(14)

--- a/python/kvikio/kvikio/benchmarks/single_node_io.py
+++ b/python/kvikio/kvikio/benchmarks/single_node_io.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 import argparse
@@ -259,7 +259,7 @@ def main(args):
     cupy.cuda.set_allocator(None)  # Disable CuPy's default memory pool
     cupy.arange(10)  # Make sure CUDA is initialized
 
-    kvikio.defaults.num_threads_reset(args.nthreads)
+    kvikio.defaults.set("num_threads", args.nthreads)
 
     print("Roundtrip benchmark")
     print("----------------------------------")

--- a/python/kvikio/kvikio/benchmarks/utils.py
+++ b/python/kvikio/kvikio/benchmarks/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 from __future__ import annotations
@@ -28,7 +28,7 @@ def pprint_sys_info() -> None:
     """Pretty print system information"""
 
     version = kvikio.cufile_driver.libcufile_version()
-    props = kvikio.cufile_driver.DriverProperties()
+    props = kvikio.cufile_driver.properties
     try:
         import pynvml
 

--- a/python/kvikio/kvikio/benchmarks/zarr_io.py
+++ b/python/kvikio/kvikio/benchmarks/zarr_io.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 import argparse
@@ -118,7 +118,7 @@ def main(args):
     cupy.cuda.set_allocator(None)  # Disable CuPy's default memory pool
     cupy.arange(10)  # Make sure CUDA is initialized
 
-    kvikio.defaults.num_threads_reset(args.nthreads)
+    kvikio.defaults.set("num_threads", args.nthreads)
     drop_vm_cache_msg = str(args.drop_vm_cache)
     if not args.drop_vm_cache:
         drop_vm_cache_msg += " (use --drop-vm-cache for better accuracy!)"

--- a/python/kvikio/kvikio/cufile_driver.py
+++ b/python/kvikio/kvikio/cufile_driver.py
@@ -2,13 +2,114 @@
 # See file LICENSE for terms.
 
 import atexit
-from typing import Tuple
+from typing import Tuple, Any, overload
 
 from kvikio._lib import cufile_driver  # type: ignore
+import kvikio.utils
 
-# TODO: Wrap nicely, maybe as a dataclass?
-# <https://github.com/rapidsai/kvikio/issues/526>
-DriverProperties = cufile_driver.DriverProperties
+
+properties = cufile_driver.DriverProperties()
+
+
+class ConfigContextManager:
+    def __init__(self, config: dict[str, str]):
+        (
+            self._property_getters,
+            self._property_setters,
+        ) = self._property_getter_and_setter()
+        self._old_properties = {}
+
+        for key, value in config.items():
+            self._old_properties[key] = self._get_property(key)
+            self._set_property(key, value)
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self, type_unused, value, traceback_unused):
+        for key, value in self._old_properties.items():
+            self._set_property(key, value)
+
+    def _get_property(self, property: str) -> Any:
+        func = self._property_getters[property]
+
+        # getter signature: object.__get__(self, instance, owner=None)
+        return func(properties)
+
+    def _set_property(self, property: str, value: Any):
+        func = self._property_setters[property]
+
+        # setter signature: object.__set__(self, instance, value)
+        func(properties, value)
+
+    @kvikio.utils.call_once
+    def _property_getter_and_setter(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        class_dict = vars(cufile_driver.DriverProperties)
+
+        property_getter_names = ["poll_mode",
+                                 "poll_thresh_size",
+                                 "max_device_cache_size",
+                                 "max_pinned_memory_size"]
+
+        property_getters = {}
+        property_setters = {}
+
+        for name in property_getter_names:
+            property_getters[name] = class_dict[name].__get__
+            property_setters[name] = class_dict[name].__set__
+        return property_getters, property_setters
+
+
+@overload
+def set(config: dict[str, Any], /) -> ConfigContextManager:
+    ...
+
+
+@overload
+def set(key: str, value: Any, /) -> ConfigContextManager:
+    ...
+
+
+def set(*config) -> ConfigContextManager:
+    """Set cuFile driver configurations.
+
+    Examples:
+
+    - To set one or more properties
+
+      .. code-block:: python
+
+         kvikio.cufile_driver.properties.set({"prop1": value1, "prop2": value2})
+
+    - To set a single property
+
+      .. code-block:: python
+
+         kvikio.cufile_driver.properties.set("prop", value)
+
+    Parameters
+    ----------
+    config
+        The configurations. Can either be a single parameter (dict) consisting of one
+        or more properties, or two parameters key (string) and value (Any)
+        indicating a single property.
+    """
+
+    err_msg = (
+        "Valid arguments are kvikio.cufile_driver.properties.set(config: dict) or "
+        "kvikio.cufile_driver.properties.set(key: str, value: Any)"
+    )
+
+    if len(config) == 1:
+        if not isinstance(config[0], dict):
+            raise ValueError(err_msg)
+        return ConfigContextManager(config[0])
+    elif len(config) == 2:
+        if not isinstance(config[0], str):
+            raise ValueError(err_msg)
+        return ConfigContextManager({config[0]: config[1]})
+    else:
+        raise ValueError(err_msg)
 
 
 def libcufile_version() -> Tuple[int, int]:

--- a/python/kvikio/kvikio/cufile_driver.py
+++ b/python/kvikio/kvikio/cufile_driver.py
@@ -110,13 +110,27 @@ def set(*config) -> ConfigContextManager:
 
       .. code-block:: python
 
+         # Set the property globally.
          kvikio.cufile_driver.properties.set({"prop1": value1, "prop2": value2})
+
+         # Set the property with a context manager.
+         # The property automatically reverts to its old value
+         # after leaving the `with` block.
+         with kvikio.cufile_driver.properties.set({"prop1": value1, "prop2": value2}):
+             ...
 
     - To set a single property
 
       .. code-block:: python
 
+         # Set the property globally.
          kvikio.cufile_driver.properties.set("prop", value)
+
+         # Set the property with a context manager.
+         # The property automatically reverts to its old value
+         # after leaving the `with` block.
+         with kvikio.cufile_driver.properties.set("prop", value):
+             ...
 
     Parameters
     ----------
@@ -124,6 +138,23 @@ def set(*config) -> ConfigContextManager:
         The configurations. Can either be a single parameter (dict) consisting of one
         or more properties, or two parameters key (string) and value (Any)
         indicating a single property.
+
+        Valid configuration names are:
+
+        - Read-only properties:
+
+          - ``"is_gds_available"``
+          - ``"major_version"``
+          - ``"minor_version"``
+          - ``"allow_compat_mode"``
+          - ``"per_buffer_cache_size"``
+
+        - Settable properties:
+
+          - ``"poll_mode"``
+          - ``"poll_thresh_size"``
+          - ``"max_device_cache_size"``
+          - ``"max_pinned_memory_size"``
 
     Returns
     -------
@@ -156,6 +187,23 @@ def get(config_name: str) -> Any:
     ----------
     config_name: str
         The name of the configuration.
+
+        Valid configuration names are:
+
+        - Read-only properties:
+
+          - ``"is_gds_available"``
+          - ``"major_version"``
+          - ``"minor_version"``
+          - ``"allow_compat_mode"``
+          - ``"per_buffer_cache_size"``
+
+        - Settable properties:
+
+          - ``"poll_mode"``
+          - ``"poll_thresh_size"``
+          - ``"max_device_cache_size"``
+          - ``"max_pinned_memory_size"``
 
     Returns
     -------

--- a/python/kvikio/kvikio/cufile_driver.py
+++ b/python/kvikio/kvikio/cufile_driver.py
@@ -8,8 +8,8 @@ import kvikio.utils
 from kvikio._lib import cufile_driver  # type: ignore
 
 properties = cufile_driver.DriverProperties()
-"""cuFile driver configurations. Use kvikio.cufile_driver.properties.get and
-   kvikio.cufile_driver.properties.set to access the configurations.
+"""cuFile driver configurations. Use kvikio.cufile_driver.get and
+   kvikio.cufile_driver.set to access the configurations.
 """
 
 
@@ -111,12 +111,12 @@ def set(*config) -> ConfigContextManager:
       .. code-block:: python
 
          # Set the property globally.
-         kvikio.cufile_driver.properties.set({"prop1": value1, "prop2": value2})
+         kvikio.cufile_driver.set({"prop1": value1, "prop2": value2})
 
          # Set the property with a context manager.
          # The property automatically reverts to its old value
          # after leaving the `with` block.
-         with kvikio.cufile_driver.properties.set({"prop1": value1, "prop2": value2}):
+         with kvikio.cufile_driver.set({"prop1": value1, "prop2": value2}):
              ...
 
     - To set a single property
@@ -124,12 +124,12 @@ def set(*config) -> ConfigContextManager:
       .. code-block:: python
 
          # Set the property globally.
-         kvikio.cufile_driver.properties.set("prop", value)
+         kvikio.cufile_driver.set("prop", value)
 
          # Set the property with a context manager.
          # The property automatically reverts to its old value
          # after leaving the `with` block.
-         with kvikio.cufile_driver.properties.set("prop", value):
+         with kvikio.cufile_driver.set("prop", value):
              ...
 
     Parameters
@@ -164,8 +164,8 @@ def set(*config) -> ConfigContextManager:
     """
 
     err_msg = (
-        "Valid arguments are kvikio.cufile_driver.properties.set(config: dict) or "
-        "kvikio.cufile_driver.properties.set(key: str, value: Any)"
+        "Valid arguments are kvikio.cufile_driver.set(config: dict) or "
+        "kvikio.cufile_driver.set(key: str, value: Any)"
     )
 
     if len(config) == 1:

--- a/python/kvikio/kvikio/cufile_driver.py
+++ b/python/kvikio/kvikio/cufile_driver.py
@@ -1,12 +1,11 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 import atexit
-from typing import Tuple, Any, overload
+from typing import Any, Tuple, overload
 
-from kvikio._lib import cufile_driver  # type: ignore
 import kvikio.utils
-
+from kvikio._lib import cufile_driver  # type: ignore
 
 properties = cufile_driver.DriverProperties()
 
@@ -46,10 +45,12 @@ class ConfigContextManager:
     def _property_getter_and_setter(self) -> tuple[dict[str, Any], dict[str, Any]]:
         class_dict = vars(cufile_driver.DriverProperties)
 
-        property_getter_names = ["poll_mode",
-                                 "poll_thresh_size",
-                                 "max_device_cache_size",
-                                 "max_pinned_memory_size"]
+        property_getter_names = [
+            "poll_mode",
+            "poll_thresh_size",
+            "max_device_cache_size",
+            "max_pinned_memory_size",
+        ]
 
         property_getters = {}
         property_setters = {}

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -37,7 +37,7 @@ def call_once(func: Callable):
 
 
 class ConfigContextManager:
-    def __init__(self, config: dict):
+    def __init__(self, config: dict[str, str]):
         (
             self._all_getter_property_functions,
             self._all_setter_property_functions,
@@ -51,7 +51,7 @@ class ConfigContextManager:
     def __enter__(self):
         return None
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type_unused, value, traceback_unused):
         for key, value in self._old_properties.items():
             self._set_property(key, value)
 

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -81,7 +81,7 @@ def compat_mode() -> kvikio.CompatMode:
 def num_threads() -> int:
     """Get the number of threads of the thread pool.
 
-    Set the default value using `num_threads_reset()` or by setting the
+    Set the default value using `set("num_threads", value)` or by setting the
     `KVIKIO_NTHREADS` environment variable. If not set, the default value is 1.
 
     Returns
@@ -95,7 +95,7 @@ def num_threads() -> int:
 def task_size() -> int:
     """Get the default task size used for parallel IO operations.
 
-    Set the default value using `task_size_reset()` or by setting
+    Set the default value using `set("task_size", value)` or by setting
     the `KVIKIO_TASK_SIZE` environment variable. If not set,
     the default value is 4 MiB.
 
@@ -114,7 +114,7 @@ def gds_threshold() -> int:
     implements a shortcut that circumvent the threadpool and use the POSIX
     backend directly.
 
-    Set the default value using `gds_threshold_reset()` or by setting the
+    Set the default value using `set("gds_threshold", value)` or by setting the
     `KVIKIO_GDS_THRESHOLD` environment variable. If not set, the default
     value is 1 MiB.
 
@@ -129,7 +129,7 @@ def gds_threshold() -> int:
 def bounce_buffer_size() -> int:
     """Get the size of the bounce buffer used to stage data in host memory.
 
-    Set the value using `bounce_buffer_size_reset()` or by setting the
+    Set the value using `set("bounce_buffer_size", value)` or by setting the
     `KVIKIO_BOUNCE_BUFFER_SIZE` environment variable. If not set, the
     value is 16 MiB.
 
@@ -147,7 +147,7 @@ def http_max_attempts() -> int:
     Reads are retried up until ``http_max_attempts`` when the response has certain
     HTTP status codes.
 
-    Set the value using `http_max_attempts_reset()` or by setting the
+    Set the value using `set("http_max_attempts", value)` or by setting the
     ``KVIKIO_HTTP_MAX_ATTEMPTS`` environment variable. If not set, the
     value is 3.
 
@@ -163,7 +163,7 @@ def http_max_attempts() -> int:
 def http_status_codes() -> list[int]:
     """Get the list of HTTP status codes to retry.
 
-    Set the value using ``set_http_status_codes`` or by setting the
+    Set the value using ``set("http_status_codes", value)`` or by setting the
     ``KVIKIO_HTTP_STATUS_CODES`` environment variable. If not set, the
     default value is
 

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -49,7 +49,7 @@ def set(*config: Any) -> ConfigContextManager:
             raise ValueError(f"Valid arguments are {msg}")
         return ConfigContextManager({config[0]: config[1]})
     else:
-        raise ValueError("")
+        raise ValueError(f"Valid arguments are {msg}")
 
 
 def compat_mode() -> kvikio.CompatMode:

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -114,6 +114,16 @@ def set(*config) -> ConfigContextManager:
         or more properties, or two parameters key (string) and value (Any)
         indicating a single property.
 
+        Valid configuration names are:
+
+        - ``"compat_mode"``
+        - ``"num_threads"``
+        - ``"task_size"``
+        - ``"gds_threshold"``
+        - ``"bounce_buffer_size"``
+        - ``"http_max_attempts"``
+        - ``"http_status_codes"``
+
     Returns
     -------
     ConfigContextManager
@@ -146,6 +156,16 @@ def get(config_name: str) -> Any:
     config_name: str
         The name of the configuration.
 
+        Valid configuration names are:
+
+        - ``"compat_mode"``
+        - ``"num_threads"``
+        - ``"task_size"``
+        - ``"gds_threshold"``
+        - ``"bounce_buffer_size"``
+        - ``"http_max_attempts"``
+        - ``"http_status_codes"``
+
     Returns
     -------
     Any
@@ -157,7 +177,9 @@ def get(config_name: str) -> Any:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.get("compat_mode") instead')
 def compat_mode() -> kvikio.CompatMode:
-    """Check if KvikIO is running in compatibility mode.
+    """Deprecated. Use :meth:`kvikio.defaults.get` instead.
+
+    Check if KvikIO is running in compatibility mode.
 
     Notice, this is not the same as the compatibility mode in cuFile. That is,
     cuFile can run in compatibility mode while KvikIO is not.
@@ -183,7 +205,9 @@ def compat_mode() -> kvikio.CompatMode:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.get("num_threads") instead')
 def num_threads() -> int:
-    """Get the number of threads of the thread pool.
+    """Deprecated. Use :meth:`kvikio.defaults.get` instead.
+
+    Get the number of threads of the thread pool.
 
     Set the default value using `set("num_threads", value)` or by setting the
     `KVIKIO_NTHREADS` environment variable. If not set, the default value is 1.
@@ -198,7 +222,9 @@ def num_threads() -> int:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.get("task_size") instead')
 def task_size() -> int:
-    """Get the default task size used for parallel IO operations.
+    """Deprecated. Use :meth:`kvikio.defaults.get` instead.
+
+    Get the default task size used for parallel IO operations.
 
     Set the default value using `set("task_size", value)` or by setting
     the `KVIKIO_TASK_SIZE` environment variable. If not set,
@@ -214,7 +240,9 @@ def task_size() -> int:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.get("gds_threshold") instead')
 def gds_threshold() -> int:
-    """Get the default GDS threshold, which is the minimum size to use GDS.
+    """Deprecated. Use :meth:`kvikio.defaults.get` instead.
+
+    Get the default GDS threshold, which is the minimum size to use GDS.
 
     In order to improve performance of small IO, `.pread()` and `.pwrite()`
     implements a shortcut that circumvent the threadpool and use the POSIX
@@ -234,7 +262,9 @@ def gds_threshold() -> int:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.get("bounce_buffer_size") instead')
 def bounce_buffer_size() -> int:
-    """Get the size of the bounce buffer used to stage data in host memory.
+    """Deprecated. Use :meth:`kvikio.defaults.get` instead.
+
+    Get the size of the bounce buffer used to stage data in host memory.
 
     Set the value using `set("bounce_buffer_size", value)` or by setting the
     `KVIKIO_BOUNCE_BUFFER_SIZE` environment variable. If not set, the
@@ -250,7 +280,9 @@ def bounce_buffer_size() -> int:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.get("http_max_attempts") instead')
 def http_max_attempts() -> int:
-    """Get the maximum number of attempts per remote IO read.
+    """Deprecated. Use :meth:`kvikio.defaults.get` instead.
+
+    Get the maximum number of attempts per remote IO read.
 
     Reads are retried up until ``http_max_attempts`` when the response has certain
     HTTP status codes.
@@ -270,7 +302,9 @@ def http_max_attempts() -> int:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.get("http_status_codes") instead')
 def http_status_codes() -> list[int]:
-    """Get the list of HTTP status codes to retry.
+    """Deprecated. Use :meth:`kvikio.defaults.get` instead.
+
+    Get the list of HTTP status codes to retry.
 
     Set the value using ``set("http_status_codes", value)`` or by setting the
     ``KVIKIO_HTTP_STATUS_CODES`` environment variable. If not set, the
@@ -292,7 +326,9 @@ def http_status_codes() -> list[int]:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.set("compat_mode", value) instead')
 def compat_mode_reset(compatmode: kvikio.CompatMode) -> None:
-    """(Deprecated) Reset the compatibility mode.
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Reset the compatibility mode.
 
     Use this function to enable/disable compatibility mode explicitly.
 
@@ -308,13 +344,17 @@ def compat_mode_reset(compatmode: kvikio.CompatMode) -> None:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.set("compat_mode", value) instead')
 def set_compat_mode(compatmode: kvikio.CompatMode):
-    """(Deprecated) Same with compat_mode_reset."""
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Same with compat_mode_reset."""
     compat_mode_reset(compatmode)
 
 
 @kvikio_deprecation_notice('Use kvikio.defaults.set("num_threads", value) instead')
 def num_threads_reset(nthreads: int) -> None:
-    """(Deprecated) Reset the number of threads in the default thread pool.
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Reset the number of threads in the default thread pool.
 
     Waits for all currently running tasks to be completed, then destroys all threads
     in the pool and creates a new thread pool with the new number of threads. Any
@@ -334,13 +374,17 @@ def num_threads_reset(nthreads: int) -> None:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.set("num_threads", value) instead')
 def set_num_threads(nthreads: int):
-    """(Deprecated) Same with num_threads_reset."""
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Same with num_threads_reset."""
     set("num_threads", nthreads)
 
 
 @kvikio_deprecation_notice('Use kvikio.defaults.set("task_size", value) instead')
 def task_size_reset(nbytes: int) -> None:
-    """(Deprecated) Reset the default task size used for parallel IO operations.
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Reset the default task size used for parallel IO operations.
 
     Parameters
     ----------
@@ -352,13 +396,17 @@ def task_size_reset(nbytes: int) -> None:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.set("task_size", value) instead')
 def set_task_size(nbytes: int):
-    """(Deprecated) Same with task_size_reset."""
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Same with task_size_reset."""
     set("task_size", nbytes)
 
 
 @kvikio_deprecation_notice('Use kvikio.defaults.set("gds_threshold", value) instead')
 def gds_threshold_reset(nbytes: int) -> None:
-    """(Deprecated) Reset the default GDS threshold, which is the minimum size to
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Reset the default GDS threshold, which is the minimum size to
     use GDS.
 
     Parameters
@@ -371,7 +419,9 @@ def gds_threshold_reset(nbytes: int) -> None:
 
 @kvikio_deprecation_notice('Use kvikio.defaults.set("gds_threshold", value) instead')
 def set_gds_threshold(nbytes: int):
-    """(Deprecated) Same with gds_threshold_reset."""
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Same with gds_threshold_reset."""
     set("gds_threshold", nbytes)
 
 
@@ -379,7 +429,9 @@ def set_gds_threshold(nbytes: int):
     'Use kvikio.defaults.set("bounce_buffer_size", value) instead'
 )
 def bounce_buffer_size_reset(nbytes: int) -> None:
-    """(Deprecated) Reset the size of the bounce buffer used to stage data in host
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Reset the size of the bounce buffer used to stage data in host
     memory.
 
     Parameters
@@ -394,7 +446,9 @@ def bounce_buffer_size_reset(nbytes: int) -> None:
     'Use kvikio.defaults.set("bounce_buffer_size", value) instead'
 )
 def set_bounce_buffer_size(nbytes: int):
-    """(Deprecated) Same with bounce_buffer_size_reset."""
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Same with bounce_buffer_size_reset."""
     set("bounce_buffer_size", nbytes)
 
 
@@ -402,7 +456,9 @@ def set_bounce_buffer_size(nbytes: int):
     'Use kvikio.defaults.set("http_max_attempts", value) instead'
 )
 def http_max_attempts_reset(attempts: int) -> None:
-    """(Deprecated) Reset the maximum number of attempts per remote IO read.
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Reset the maximum number of attempts per remote IO read.
 
     Parameters
     ----------
@@ -416,7 +472,9 @@ def http_max_attempts_reset(attempts: int) -> None:
     'Use kvikio.defaults.set("http_max_attempts", value) instead'
 )
 def set_http_max_attempts(attempts: int):
-    """(Deprecated) Same with http_max_attempts_reset."""
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Same with http_max_attempts_reset."""
     set("http_max_attempts", attempts)
 
 
@@ -424,7 +482,9 @@ def set_http_max_attempts(attempts: int):
     'Use kvikio.defaults.set("http_status_codes", value) instead'
 )
 def http_status_codes_reset(status_codes: list[int]) -> None:
-    """(Deprecated) Reset the list of HTTP status codes to retry.
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Reset the list of HTTP status codes to retry.
 
     Parameters
     ----------
@@ -438,5 +498,7 @@ def http_status_codes_reset(status_codes: list[int]) -> None:
     'Use kvikio.defaults.set("http_status_codes", value) instead'
 )
 def set_http_status_codes(status_codes: list[int]):
-    """(Deprecated) Same with http_status_codes_reset."""
+    """Deprecated. Use :meth:`kvikio.defaults.set` instead.
+
+    Same with http_status_codes_reset."""
     set("http_status_codes", status_codes)

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -36,6 +36,16 @@ class ConfigContextManager:
 
 
 def set(*config: Any) -> ConfigContextManager:
+    """Set KvikIO configurations.
+
+    Parameters
+    -------
+    Any
+        The configurations. Can either be a single parameter (dict) consisting of one
+        or more properties, or two parameters key (string) and value (Any)
+        indicating a single property.
+    """
+
     err_msg = (
         "Valid arguments are kvikio.defaults.set(config: dict) or "
         "kvikio.defaults.set(key: str, value: Any)"

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -38,8 +38,22 @@ class ConfigContextManager:
 def set(*config: Any) -> ConfigContextManager:
     """Set KvikIO configurations.
 
+    Examples:
+
+    - To set one or more properties
+
+      .. code-block:: python
+
+         kvikio.defaults.set({"prop1": value1, "prop2": value2})
+
+    - To set a single property
+
+      .. code-block:: python
+
+         kvikio.defaults.set("prop", value)
+
     Parameters
-    -------
+    ----------
     Any
         The configurations. Can either be a single parameter (dict) consisting of one
         or more properties, or two parameters key (string) and value (Any)

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -43,13 +43,15 @@ class ConfigContextManager:
     def _property_getter_and_setter(self) -> tuple[dict[str, Any], dict[str, Any]]:
         module_dict = vars(kvikio._lib.defaults)
 
-        property_getter_names = ["compat_mode",
-                                 "thread_pool_nthreads",
-                                 "task_size",
-                                 "gds_threshold",
-                                 "bounce_buffer_size",
-                                 "http_max_attempts",
-                                 "http_status_codes"]
+        property_getter_names = [
+            "compat_mode",
+            "thread_pool_nthreads",
+            "task_size",
+            "gds_threshold",
+            "bounce_buffer_size",
+            "http_max_attempts",
+            "http_status_codes",
+        ]
 
         property_getters = {}
         property_setters = {}

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -36,20 +36,21 @@ class ConfigContextManager:
 
 
 def set(*config: Any) -> ConfigContextManager:
-    msg = (
-        "kvikio.defaults.set(config: dict) or kvikio.defaults.set(key: str, value: Any)"
+    err_msg = (
+        "Valid arguments are kvikio.defaults.set(config: dict) or "
+        "kvikio.defaults.set(key: str, value: Any)"
     )
 
     if len(config) == 1:
         if not isinstance(config[0], dict):
-            raise ValueError(f"Valid arguments are {msg}")
+            raise ValueError(err_msg)
         return ConfigContextManager(config[0])
     elif len(config) == 2:
         if not isinstance(config[0], str):
-            raise ValueError(f"Valid arguments are {msg}")
+            raise ValueError(err_msg)
         return ConfigContextManager({config[0]: config[1]})
     else:
-        raise ValueError(f"Valid arguments are {msg}")
+        raise ValueError(err_msg)
 
 
 def compat_mode() -> kvikio.CompatMode:

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -16,7 +16,7 @@ class ConfigContextManager:
             self._set_property(key, value)
 
     def __enter__(self):
-        pass
+        return None
 
     def __exit__(self, type, value, traceback):
         for key, value in self._old_properties.items():

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -2,6 +2,7 @@
 # See file LICENSE for terms.
 
 import re
+import warnings
 from typing import Any, Callable, overload
 
 import kvikio._lib.defaults
@@ -261,3 +262,166 @@ def http_status_codes() -> list[int]:
         The HTTP status codes to retry.
     """
     return kvikio._lib.defaults.http_status_codes()
+
+
+def kvikio_deprecation_notice(msg: str):
+    def decorator_imp(func: Callable):
+        def wrapper(*args, **kwargs):
+            warnings.warn(msg, category=FutureWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator_imp
+
+
+@kvikio_deprecation_notice('Use kvikio.defaults.set("compat_mode", value) instead')
+def compat_mode_reset(compatmode: kvikio.CompatMode) -> None:
+    """(deprecated) Reset the compatibility mode.
+
+    Use this function to enable/disable compatibility mode explicitly.
+
+    Parameters
+    ----------
+    compatmode : kvikio.CompatMode
+        Set to kvikio.CompatMode.ON to enable and kvikio.CompatMode.OFF to disable
+        compatibility mode, or kvikio.CompatMode.AUTO to let KvikIO determine: try
+        OFF first, and upon failure, fall back to ON.
+    """
+    set("compat_mode", compatmode)
+
+
+@kvikio_deprecation_notice('Use kvikio.defaults.set("compat_mode", value) instead')
+def set_compat_mode(compatmode: kvikio.CompatMode):
+    """(deprecated) Same with compat_mode_reset."""
+    compat_mode_reset(compatmode)
+
+
+@kvikio_deprecation_notice('Use kvikio.defaults.set("num_threads", value) instead')
+def num_threads_reset(nthreads: int) -> None:
+    """(deprecated) Reset the number of threads in the default thread pool.
+
+    Waits for all currently running tasks to be completed, then destroys all threads
+    in the pool and creates a new thread pool with the new number of threads. Any
+    tasks that were waiting in the queue before the pool was reset will then be
+    executed by the new threads. If the pool was paused before resetting it, the new
+    pool will be paused as well.
+
+    Parameters
+    ----------
+    nthreads : int
+        The number of threads to use. The default value can be specified by setting
+        the `KVIKIO_NTHREADS` environment variable. If not set, the default value
+        is 1.
+    """
+    set("num_threads", nthreads)
+
+
+@kvikio_deprecation_notice('Use kvikio.defaults.set("num_threads", value) instead')
+def set_num_threads(nthreads: int):
+    """(deprecated) Same with num_threads_reset."""
+    set("num_threads", nthreads)
+
+
+@kvikio_deprecation_notice('Use kvikio.defaults.set("task_size", value) instead')
+def task_size_reset(nbytes: int) -> None:
+    """(deprecated) Reset the default task size used for parallel IO operations.
+
+    Parameters
+    ----------
+    nbytes : int
+        The default task size in bytes.
+    """
+    set("task_size", nbytes)
+
+
+@kvikio_deprecation_notice('Use kvikio.defaults.set("task_size", value) instead')
+def set_task_size(nbytes: int):
+    """(deprecated) Same with task_size_reset."""
+    set("task_size", nbytes)
+
+
+@kvikio_deprecation_notice('Use kvikio.defaults.set("gds_threshold", value) instead')
+def gds_threshold_reset(nbytes: int) -> None:
+    """(deprecated) Reset the default GDS threshold, which is the minimum size to
+    use GDS.
+
+    Parameters
+    ----------
+    nbytes : int
+        The default GDS threshold size in bytes.
+    """
+    set("gds_threshold", nbytes)
+
+
+@kvikio_deprecation_notice('Use kvikio.defaults.set("gds_threshold", value) instead')
+def set_gds_threshold(nbytes: int):
+    """(deprecated) Same with gds_threshold_reset."""
+    set("gds_threshold", nbytes)
+
+
+@kvikio_deprecation_notice(
+    'Use kvikio.defaults.set("bounce_buffer_size", value) instead'
+)
+def bounce_buffer_size_reset(nbytes: int) -> None:
+    """(deprecated) Reset the size of the bounce buffer used to stage data in host
+    memory.
+
+    Parameters
+    ----------
+    nbytes : int
+        The bounce buffer size in bytes.
+    """
+    set("bounce_buffer_size", nbytes)
+
+
+@kvikio_deprecation_notice(
+    'Use kvikio.defaults.set("bounce_buffer_size", value) instead'
+)
+def set_bounce_buffer_size(nbytes: int):
+    """(deprecated) Same with bounce_buffer_size_reset."""
+    set("bounce_buffer_size", nbytes)
+
+
+@kvikio_deprecation_notice(
+    'Use kvikio.defaults.set("http_max_attempts", value) instead'
+)
+def http_max_attempts_reset(attempts: int) -> None:
+    """(deprecated) Reset the maximum number of attempts per remote IO read.
+
+    Parameters
+    ----------
+    attempts : int
+        The maximum number of attempts to try before raising an error.
+    """
+    set("http_max_attempts", attempts)
+
+
+@kvikio_deprecation_notice(
+    'Use kvikio.defaults.set("http_max_attempts", value) instead'
+)
+def set_http_max_attempts(attempts: int):
+    """(deprecated) Same with http_max_attempts_reset."""
+    set("http_max_attempts", attempts)
+
+
+@kvikio_deprecation_notice(
+    'Use kvikio.defaults.set("http_status_codes", value) instead'
+)
+def http_status_codes_reset(status_codes: list[int]) -> None:
+    """(deprecated) Reset the list of HTTP status codes to retry.
+
+    Parameters
+    ----------
+    status_codes : list[int]
+        The HTTP status codes to retry.
+    """
+    set("http_status_codes", status_codes)
+
+
+@kvikio_deprecation_notice(
+    'Use kvikio.defaults.set("http_status_codes", value) instead'
+)
+def set_http_status_codes(status_codes: list[int]):
+    """(deprecated) Same with http_status_codes_reset."""
+    set("http_status_codes", status_codes)

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -175,6 +175,10 @@ def get(config_name: str) -> Any:
     return context_manager._get_property(config_name)
 
 
+def is_compat_mode_preferred() -> bool:
+    return kvikio._lib.defaults.is_compat_mode_preferred()
+
+
 @kvikio_deprecation_notice('Use kvikio.defaults.get("compat_mode") instead')
 def compat_mode() -> kvikio.CompatMode:
     """Deprecated. Use :meth:`kvikio.defaults.get` instead.

--- a/python/kvikio/kvikio/defaults.py
+++ b/python/kvikio/kvikio/defaults.py
@@ -2,7 +2,6 @@
 # See file LICENSE for terms.
 
 
-# import contextlib
 from typing import Any
 
 import kvikio._lib.defaults

--- a/python/kvikio/kvikio/utils.py
+++ b/python/kvikio/kvikio/utils.py
@@ -157,6 +157,8 @@ def kvikio_deprecation_notice(msg: str) -> Callable:
             warnings.warn(msg, category=FutureWarning, stacklevel=2)
             return func(*args, **kwargs)
 
+        # Allow the docstring to be corrected generated for the decorated func in Sphinx
+        wrapper.__doc__ = func.__doc__
         return wrapper
 
     return decorator

--- a/python/kvikio/kvikio/utils.py
+++ b/python/kvikio/kvikio/utils.py
@@ -6,6 +6,7 @@ import multiprocessing
 import pathlib
 import threading
 import time
+import warnings
 from http.server import (
     BaseHTTPRequestHandler,
     SimpleHTTPRequestHandler,
@@ -96,20 +97,25 @@ class LocalHttpServer:
         self.process.kill()
 
 
-def call_once(func: Callable):
+def call_once(func: Callable) -> Callable:
     """Decorate a function such that it is only called once
 
     Examples:
 
     .. code-block:: python
 
-       @call_once
+       @kvikio.utils.call_once
        foo(args)
 
     Parameters
     ----------
     func: Callable
         The function to be decorated.
+
+    Returns
+    -------
+    Callable
+        A decorated function.
     """
     once_flag = True
     cached_result = None
@@ -123,3 +129,34 @@ def call_once(func: Callable):
         return cached_result
 
     return wrapper
+
+
+def kvikio_deprecation_notice(msg: str) -> Callable:
+    """Decorate a function to print the deprecation notice at runtime.
+
+    Examples:
+
+    .. code-block:: python
+
+       @kvikio.utils.kvikio_deprecation_notice("Use bar(args) instead.")
+       foo(args)
+
+    Parameters
+    ----------
+    msg: str
+        The deprecation notice.
+
+    Returns
+    -------
+    Callable
+        A decorated function.
+    """
+
+    def decorator(func: Callable):
+        def wrapper(*args, **kwargs):
+            warnings.warn(msg, category=FutureWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/python/kvikio/kvikio/utils.py
+++ b/python/kvikio/kvikio/utils.py
@@ -11,7 +11,7 @@ from http.server import (
     SimpleHTTPRequestHandler,
     ThreadingHTTPServer,
 )
-from typing import Any
+from typing import Any, Callable
 
 
 class LocalHttpServer:
@@ -79,7 +79,8 @@ class LocalHttpServer:
         else:
             handler = SimpleHTTPRequestHandler
 
-        handler_options = {**self.handler_options, **{"directory": self.root_path}}
+        handler_options = {**self.handler_options,
+                           **{"directory": self.root_path}}
 
         self.process = multiprocessing.Process(
             target=LocalHttpServer._server,
@@ -94,3 +95,32 @@ class LocalHttpServer:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.process.kill()
+
+
+def call_once(func: Callable):
+    """Decorate a function such that it is only called once
+
+    Examples:
+
+    .. code-block:: python
+
+       @call_once
+       foo(args)
+
+    Parameters
+    ----------
+    func: Callable
+        The function to be decorated.
+    """
+    once_flag = True
+    cached_result = None
+
+    def wrapper(*args, **kwargs):
+        nonlocal once_flag
+        nonlocal cached_result
+        if once_flag:
+            once_flag = False
+            cached_result = func(*args, **kwargs)
+        return cached_result
+
+    return wrapper

--- a/python/kvikio/kvikio/utils.py
+++ b/python/kvikio/kvikio/utils.py
@@ -79,8 +79,7 @@ class LocalHttpServer:
         else:
             handler = SimpleHTTPRequestHandler
 
-        handler_options = {**self.handler_options,
-                           **{"directory": self.root_path}}
+        handler_options = {**self.handler_options, **{"directory": self.root_path}}
 
         self.process = multiprocessing.Process(
             target=LocalHttpServer._server,

--- a/python/kvikio/tests/conftest.py
+++ b/python/kvikio/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 import contextlib
@@ -94,5 +94,5 @@ def xp(request):
 def gds_threshold(request):
     """Fixture to parametrize over GDS threshold values"""
 
-    with kvikio.defaults.set_gds_threshold(request.param):
+    with kvikio.defaults.set("gds_threshold", request.param):
         yield request.param

--- a/python/kvikio/tests/test_basic_io.py
+++ b/python/kvikio/tests/test_basic_io.py
@@ -98,12 +98,11 @@ def test_incorrect_open_mode_error(tmp_path, xp):
 
 
 @pytest.mark.skipif(
-    kvikio.defaults.compat_mode(),
+    kvikio.defaults.is_compat_mode_preferred(),
     reason="cannot test `set_compat_mode` when already running in compatibility mode",
 )
 def test_set_compat_mode_between_io(tmp_path):
     """Test changing `compat_mode`"""
-
     with kvikio.defaults.set("compat_mode", kvikio.CompatMode.OFF):
         f = kvikio.CuFile(tmp_path / "test-file", "w")
         assert not f.closed

--- a/python/kvikio/tests/test_cufile_driver.py
+++ b/python/kvikio/tests/test_cufile_driver.py
@@ -18,35 +18,41 @@ def test_open_and_close():
     kvikio.cufile_driver.driver_close()
 
 
-def test_property_setter():
-    """Test the method `set`"""
+def test_property_accessor():
+    """Test the method `get` and `set`"""
 
     # Attempt to set a nonexistent property
     with pytest.raises(KeyError):
         kvikio.cufile_driver.set("nonexistent_property", 123)
 
+    # Attempt to get a nonexistent property
+    with pytest.raises(KeyError):
+        kvikio.cufile_driver.get("nonexistent_property")
+
+    # Attempt to set a read-only property
+    with pytest.raises(KeyError, match="read-only"):
+        kvikio.cufile_driver.set("major_version", 2077)
+
     # Nested context managers
-    poll_thresh_size_default = kvikio.cufile_driver.properties.poll_thresh_size
+    poll_thresh_size_default = kvikio.cufile_driver.get("poll_thresh_size")
     with kvikio.cufile_driver.set("poll_thresh_size", 1024):
-        assert kvikio.cufile_driver.properties.poll_thresh_size == 1024
+        assert kvikio.cufile_driver.get("poll_thresh_size") == 1024
         with kvikio.cufile_driver.set("poll_thresh_size", 2048):
-            assert kvikio.cufile_driver.properties.poll_thresh_size == 2048
+            assert kvikio.cufile_driver.get("poll_thresh_size") == 2048
             with kvikio.cufile_driver.set("poll_thresh_size", 4096):
-                assert kvikio.cufile_driver.properties.poll_thresh_size == 4096
-            assert kvikio.cufile_driver.properties.poll_thresh_size == 2048
-        assert kvikio.cufile_driver.properties.poll_thresh_size == 1024
-    assert kvikio.cufile_driver.properties.poll_thresh_size == poll_thresh_size_default
+                assert kvikio.cufile_driver.get("poll_thresh_size") == 4096
+            assert kvikio.cufile_driver.get("poll_thresh_size") == 2048
+        assert kvikio.cufile_driver.get("poll_thresh_size") == 1024
+    assert kvikio.cufile_driver.get("poll_thresh_size") == poll_thresh_size_default
 
     # Multiple context managers
-    poll_mode_default = kvikio.cufile_driver.properties.poll_mode
-    max_device_cache_size_default = (
-        kvikio.cufile_driver.properties.max_device_cache_size
-    )
+    poll_mode_default = kvikio.cufile_driver.get("poll_mode")
+    max_device_cache_size_default = kvikio.cufile_driver.get("max_device_cache_size")
     with kvikio.cufile_driver.set({"poll_mode": True, "max_device_cache_size": 2048}):
-        assert kvikio.cufile_driver.properties.poll_mode and (
-            kvikio.cufile_driver.properties.max_device_cache_size == 2048
+        assert kvikio.cufile_driver.get("poll_mode") and (
+            kvikio.cufile_driver.get("max_device_cache_size") == 2048
         )
-    assert (kvikio.cufile_driver.properties.poll_mode == poll_mode_default) and (
-        kvikio.cufile_driver.properties.max_device_cache_size
+    assert (kvikio.cufile_driver.get("poll_mode") == poll_mode_default) and (
+        kvikio.cufile_driver.get("max_device_cache_size")
         == max_device_cache_size_default
     )

--- a/python/kvikio/tests/test_cufile_driver.py
+++ b/python/kvikio/tests/test_cufile_driver.py
@@ -16,3 +16,33 @@ def test_version():
 def test_open_and_close():
     kvikio.cufile_driver.driver_open()
     kvikio.cufile_driver.driver_close()
+
+
+def test_property_setter():
+    """Test the method `set`"""
+
+    # Attempt to set a nonexistent property
+    with pytest.raises(KeyError):
+        kvikio.cufile_driver.set("nonexistent_property", 123)
+
+    # Nested context managers
+    poll_thresh_size_default = kvikio.cufile_driver.properties.poll_thresh_size
+    with kvikio.cufile_driver.set("poll_thresh_size", 1024):
+        assert kvikio.cufile_driver.properties.poll_thresh_size == 1024
+        with kvikio.cufile_driver.set("poll_thresh_size", 2048):
+            assert kvikio.cufile_driver.properties.poll_thresh_size == 2048
+            with kvikio.cufile_driver.set("poll_thresh_size", 4096):
+                assert kvikio.cufile_driver.properties.poll_thresh_size == 4096
+            assert kvikio.cufile_driver.properties.poll_thresh_size == 2048
+        assert kvikio.cufile_driver.properties.poll_thresh_size == 1024
+    assert kvikio.cufile_driver.properties.poll_thresh_size == poll_thresh_size_default
+
+    # Multiple context managers
+    poll_mode_default = kvikio.cufile_driver.properties.poll_mode
+    max_device_cache_size_default = kvikio.cufile_driver.properties.max_device_cache_size
+    with kvikio.cufile_driver.set({"poll_mode": True, "max_device_cache_size": 2048}):
+        assert kvikio.cufile_driver.properties.poll_mode and\
+            (kvikio.cufile_driver.properties.max_device_cache_size == 2048)
+    assert (kvikio.cufile_driver.properties.poll_mode == poll_mode_default) and\
+        (kvikio.cufile_driver.properties.max_device_cache_size ==
+         max_device_cache_size_default)

--- a/python/kvikio/tests/test_cufile_driver.py
+++ b/python/kvikio/tests/test_cufile_driver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 import pytest
@@ -39,10 +39,14 @@ def test_property_setter():
 
     # Multiple context managers
     poll_mode_default = kvikio.cufile_driver.properties.poll_mode
-    max_device_cache_size_default = kvikio.cufile_driver.properties.max_device_cache_size
+    max_device_cache_size_default = (
+        kvikio.cufile_driver.properties.max_device_cache_size
+    )
     with kvikio.cufile_driver.set({"poll_mode": True, "max_device_cache_size": 2048}):
-        assert kvikio.cufile_driver.properties.poll_mode and\
-            (kvikio.cufile_driver.properties.max_device_cache_size == 2048)
-    assert (kvikio.cufile_driver.properties.poll_mode == poll_mode_default) and\
-        (kvikio.cufile_driver.properties.max_device_cache_size ==
-         max_device_cache_size_default)
+        assert kvikio.cufile_driver.properties.poll_mode and (
+            kvikio.cufile_driver.properties.max_device_cache_size == 2048
+        )
+    assert (kvikio.cufile_driver.properties.poll_mode == poll_mode_default) and (
+        kvikio.cufile_driver.properties.max_device_cache_size
+        == max_device_cache_size_default
+    )

--- a/python/kvikio/tests/test_defaults.py
+++ b/python/kvikio/tests/test_defaults.py
@@ -31,6 +31,18 @@ def test_property_setter():
         assert kvikio.defaults.task_size() == 1024
     assert kvikio.defaults.task_size() == task_size_default
 
+    # Multiple context managers
+    task_size_default = kvikio.defaults.task_size()
+    num_threads_default = kvikio.defaults.num_threads()
+    bounce_buffer_size_default = kvikio.defaults.bounce_buffer_size()
+    with kvikio.defaults.set({"task_size": 1024, "num_threads": 16, "bounce_buffer_size": 1024}):
+        assert (kvikio.defaults.task_size() == 1024) and\
+            (kvikio.defaults.num_threads() == 16) and\
+            (kvikio.defaults.bounce_buffer_size() == 1024)
+    assert (kvikio.defaults.task_size() == task_size_default) and\
+        (kvikio.defaults.num_threads() == num_threads_default) and\
+        (kvikio.defaults.bounce_buffer_size() == bounce_buffer_size_default)
+
 
 @pytest.mark.skipif(
     kvikio.defaults.compat_mode() == kvikio.CompatMode.ON,

--- a/python/kvikio/tests/test_defaults.py
+++ b/python/kvikio/tests/test_defaults.py
@@ -15,11 +15,11 @@ def test_compat_mode():
     """Test changing `compat_mode`"""
 
     before = kvikio.defaults.compat_mode()
-    with kvikio.defaults.set_compat_mode(kvikio.CompatMode.ON):
+    with kvikio.defaults.set("compat_mode", kvikio.CompatMode.ON):
         assert kvikio.defaults.compat_mode() == kvikio.CompatMode.ON
-        kvikio.defaults.compat_mode_reset(kvikio.CompatMode.OFF)
+        kvikio.defaults.set("compat_mode", kvikio.CompatMode.OFF)
         assert kvikio.defaults.compat_mode() == kvikio.CompatMode.OFF
-        kvikio.defaults.compat_mode_reset(kvikio.CompatMode.AUTO)
+        kvikio.defaults.set("compat_mode", kvikio.CompatMode.AUTO)
         assert kvikio.defaults.compat_mode() == kvikio.CompatMode.AUTO
     assert before == kvikio.defaults.compat_mode()
 
@@ -27,91 +27,91 @@ def test_compat_mode():
 def test_num_threads():
     """Test changing `num_threads`"""
 
-    before = kvikio.defaults.get_num_threads()
-    with kvikio.defaults.set_num_threads(3):
-        assert kvikio.defaults.get_num_threads() == 3
-        kvikio.defaults.num_threads_reset(4)
-        assert kvikio.defaults.get_num_threads() == 4
-    assert before == kvikio.defaults.get_num_threads()
+    before = kvikio.defaults.num_threads()
+    with kvikio.defaults.set("num_threads", 3):
+        assert kvikio.defaults.num_threads() == 3
+        kvikio.defaults.set("num_threads", 4)
+        assert kvikio.defaults.num_threads() == 4
+    assert before == kvikio.defaults.num_threads()
 
     with pytest.raises(ValueError, match="positive integer greater than zero"):
-        kvikio.defaults.num_threads_reset(0)
+        kvikio.defaults.set("num_threads", 0)
     with pytest.raises(OverflowError, match="negative value"):
-        kvikio.defaults.num_threads_reset(-1)
+        kvikio.defaults.set("num_threads", -1)
 
 
 def test_task_size():
     """Test changing `task_size`"""
 
     before = kvikio.defaults.task_size()
-    with kvikio.defaults.set_task_size(3):
+    with kvikio.defaults.set("task_size", 3):
         assert kvikio.defaults.task_size() == 3
-        kvikio.defaults.task_size_reset(4)
+        kvikio.defaults.set("task_size", 4)
         assert kvikio.defaults.task_size() == 4
     assert before == kvikio.defaults.task_size()
 
     with pytest.raises(ValueError, match="positive integer greater than zero"):
-        kvikio.defaults.task_size_reset(0)
+        kvikio.defaults.set("task_size", 0)
     with pytest.raises(OverflowError, match="negative value"):
-        kvikio.defaults.task_size_reset(-1)
+        kvikio.defaults.set("task_size", -1)
 
 
 def test_gds_threshold():
     """Test changing `gds_threshold`"""
 
     before = kvikio.defaults.gds_threshold()
-    with kvikio.defaults.set_gds_threshold(3):
+    with kvikio.defaults.set("gds_threshold", 3):
         assert kvikio.defaults.gds_threshold() == 3
-        kvikio.defaults.gds_threshold_reset(4)
+        kvikio.defaults.set("gds_threshold", 4)
         assert kvikio.defaults.gds_threshold() == 4
     assert before == kvikio.defaults.gds_threshold()
 
     with pytest.raises(OverflowError, match="negative value"):
-        kvikio.defaults.gds_threshold_reset(-1)
+        kvikio.defaults.set("gds_threshold", -1)
 
 
 def test_bounce_buffer_size():
     """Test changing `bounce_buffer_size`"""
 
     before = kvikio.defaults.bounce_buffer_size()
-    with kvikio.defaults.set_bounce_buffer_size(3):
+    with kvikio.defaults.set("bounce_buffer_size", 3):
         assert kvikio.defaults.bounce_buffer_size() == 3
-        kvikio.defaults.bounce_buffer_size_reset(4)
+        kvikio.defaults.set("bounce_buffer_size", 4)
         assert kvikio.defaults.bounce_buffer_size() == 4
     assert before == kvikio.defaults.bounce_buffer_size()
 
     with pytest.raises(ValueError, match="positive integer greater than zero"):
-        kvikio.defaults.bounce_buffer_size_reset(0)
+        kvikio.defaults.set("bounce_buffer_size", 0)
     with pytest.raises(OverflowError, match="negative value"):
-        kvikio.defaults.bounce_buffer_size_reset(-1)
+        kvikio.defaults.set("bounce_buffer_size", -1)
 
 
 def test_http_max_attempts():
     before = kvikio.defaults.http_max_attempts()
 
-    with kvikio.defaults.set_http_max_attempts(5):
+    with kvikio.defaults.set("http_max_attempts", 5):
         assert kvikio.defaults.http_max_attempts() == 5
-        kvikio.defaults.http_max_attempts_reset(4)
+        kvikio.defaults.set("http_max_attempts", 4)
         assert kvikio.defaults.http_max_attempts() == 4
     assert kvikio.defaults.http_max_attempts() == before
 
     with pytest.raises(ValueError, match="positive integer"):
-        kvikio.defaults.http_max_attempts_reset(0)
+        kvikio.defaults.set("http_max_attempts", 0)
     with pytest.raises(OverflowError, match="negative value"):
-        kvikio.defaults.http_max_attempts_reset(-1)
+        kvikio.defaults.set("http_max_attempts", -1)
 
 
 def test_http_status_codes():
     before = kvikio.defaults.http_status_codes()
 
-    with kvikio.defaults.set_http_status_codes([500]):
+    with kvikio.defaults.set("http_status_codes", [500]):
         assert kvikio.defaults.http_status_codes() == [500]
-        kvikio.defaults.http_status_codes_reset([429, 500])
+        kvikio.defaults.set("http_status_codes", [429, 500])
         assert kvikio.defaults.http_status_codes() == [429, 500]
     assert kvikio.defaults.http_status_codes() == before
 
     with pytest.raises(TypeError):
-        kvikio.defaults.http_status_codes_reset(0)
+        kvikio.defaults.set("http_status_codes", 0)
 
     with pytest.raises(TypeError):
-        kvikio.defaults.http_status_codes_reset(["a"])
+        kvikio.defaults.set("http_status_codes", ["a"])

--- a/python/kvikio/tests/test_defaults.py
+++ b/python/kvikio/tests/test_defaults.py
@@ -35,13 +35,19 @@ def test_property_setter():
     task_size_default = kvikio.defaults.task_size()
     num_threads_default = kvikio.defaults.num_threads()
     bounce_buffer_size_default = kvikio.defaults.bounce_buffer_size()
-    with kvikio.defaults.set({"task_size": 1024, "num_threads": 16, "bounce_buffer_size": 1024}):
-        assert (kvikio.defaults.task_size() == 1024) and\
-            (kvikio.defaults.num_threads() == 16) and\
-            (kvikio.defaults.bounce_buffer_size() == 1024)
-    assert (kvikio.defaults.task_size() == task_size_default) and\
-        (kvikio.defaults.num_threads() == num_threads_default) and\
-        (kvikio.defaults.bounce_buffer_size() == bounce_buffer_size_default)
+    with kvikio.defaults.set(
+        {"task_size": 1024, "num_threads": 16, "bounce_buffer_size": 1024}
+    ):
+        assert (
+            (kvikio.defaults.task_size() == 1024)
+            and (kvikio.defaults.num_threads() == 16)
+            and (kvikio.defaults.bounce_buffer_size() == 1024)
+        )
+    assert (
+        (kvikio.defaults.task_size() == task_size_default)
+        and (kvikio.defaults.num_threads() == num_threads_default)
+        and (kvikio.defaults.bounce_buffer_size() == bounce_buffer_size_default)
+    )
 
 
 @pytest.mark.skipif(

--- a/python/kvikio/tests/test_defaults.py
+++ b/python/kvikio/tests/test_defaults.py
@@ -7,12 +7,16 @@ import pytest
 import kvikio.defaults
 
 
-def test_property_setter():
-    """Test the method `set`"""
+def test_property_accessor():
+    """Test the method `get` and `set`"""
 
     # Attempt to set a nonexistent property
     with pytest.raises(KeyError):
         kvikio.defaults.set("nonexistent_property", 123)
+
+    # Attempt to get a nonexistent property
+    with pytest.raises(KeyError):
+        kvikio.defaults.get("nonexistent_property")
 
     # Attempt to set a property whose name is mistakenly prefixed by "set_"
     # (coinciding with the setter method).
@@ -20,62 +24,62 @@ def test_property_setter():
         kvikio.defaults.set("set_task_size", 123)
 
     # Nested context managers
-    task_size_default = kvikio.defaults.task_size()
+    task_size_default = kvikio.defaults.get("task_size")
     with kvikio.defaults.set("task_size", 1024):
-        assert kvikio.defaults.task_size() == 1024
+        assert kvikio.defaults.get("task_size") == 1024
         with kvikio.defaults.set("task_size", 2048):
-            assert kvikio.defaults.task_size() == 2048
+            assert kvikio.defaults.get("task_size") == 2048
             with kvikio.defaults.set("task_size", 4096):
-                assert kvikio.defaults.task_size() == 4096
-            assert kvikio.defaults.task_size() == 2048
-        assert kvikio.defaults.task_size() == 1024
-    assert kvikio.defaults.task_size() == task_size_default
+                assert kvikio.defaults.get("task_size") == 4096
+            assert kvikio.defaults.get("task_size") == 2048
+        assert kvikio.defaults.get("task_size") == 1024
+    assert kvikio.defaults.get("task_size") == task_size_default
 
     # Multiple context managers
-    task_size_default = kvikio.defaults.task_size()
-    num_threads_default = kvikio.defaults.num_threads()
-    bounce_buffer_size_default = kvikio.defaults.bounce_buffer_size()
+    task_size_default = kvikio.defaults.get("task_size")
+    num_threads_default = kvikio.defaults.get("num_threads")
+    bounce_buffer_size_default = kvikio.defaults.get("bounce_buffer_size")
     with kvikio.defaults.set(
         {"task_size": 1024, "num_threads": 16, "bounce_buffer_size": 1024}
     ):
         assert (
-            (kvikio.defaults.task_size() == 1024)
-            and (kvikio.defaults.num_threads() == 16)
-            and (kvikio.defaults.bounce_buffer_size() == 1024)
+            (kvikio.defaults.get("task_size") == 1024)
+            and (kvikio.defaults.get("num_threads") == 16)
+            and (kvikio.defaults.get("bounce_buffer_size") == 1024)
         )
     assert (
-        (kvikio.defaults.task_size() == task_size_default)
-        and (kvikio.defaults.num_threads() == num_threads_default)
-        and (kvikio.defaults.bounce_buffer_size() == bounce_buffer_size_default)
+        (kvikio.defaults.get("task_size") == task_size_default)
+        and (kvikio.defaults.get("num_threads") == num_threads_default)
+        and (kvikio.defaults.get("bounce_buffer_size") == bounce_buffer_size_default)
     )
 
 
 @pytest.mark.skipif(
-    kvikio.defaults.compat_mode() == kvikio.CompatMode.ON,
+    kvikio.defaults.get("compat_mode") == kvikio.CompatMode.ON,
     reason="cannot test `compat_mode` when already running in compatibility mode",
 )
 def test_compat_mode():
     """Test changing `compat_mode`"""
 
-    before = kvikio.defaults.compat_mode()
+    before = kvikio.defaults.get("compat_mode")
     with kvikio.defaults.set("compat_mode", kvikio.CompatMode.ON):
-        assert kvikio.defaults.compat_mode() == kvikio.CompatMode.ON
+        assert kvikio.defaults.get("compat_mode") == kvikio.CompatMode.ON
         kvikio.defaults.set("compat_mode", kvikio.CompatMode.OFF)
-        assert kvikio.defaults.compat_mode() == kvikio.CompatMode.OFF
+        assert kvikio.defaults.get("compat_mode") == kvikio.CompatMode.OFF
         kvikio.defaults.set("compat_mode", kvikio.CompatMode.AUTO)
-        assert kvikio.defaults.compat_mode() == kvikio.CompatMode.AUTO
-    assert before == kvikio.defaults.compat_mode()
+        assert kvikio.defaults.get("compat_mode") == kvikio.CompatMode.AUTO
+    assert before == kvikio.defaults.get("compat_mode")
 
 
 def test_num_threads():
     """Test changing `num_threads`"""
 
-    before = kvikio.defaults.num_threads()
+    before = kvikio.defaults.get("num_threads")
     with kvikio.defaults.set("num_threads", 3):
-        assert kvikio.defaults.num_threads() == 3
+        assert kvikio.defaults.get("num_threads") == 3
         kvikio.defaults.set("num_threads", 4)
-        assert kvikio.defaults.num_threads() == 4
-    assert before == kvikio.defaults.num_threads()
+        assert kvikio.defaults.get("num_threads") == 4
+    assert before == kvikio.defaults.get("num_threads")
 
     with pytest.raises(ValueError, match="positive integer greater than zero"):
         kvikio.defaults.set("num_threads", 0)
@@ -86,12 +90,12 @@ def test_num_threads():
 def test_task_size():
     """Test changing `task_size`"""
 
-    before = kvikio.defaults.task_size()
+    before = kvikio.defaults.get("task_size")
     with kvikio.defaults.set("task_size", 3):
-        assert kvikio.defaults.task_size() == 3
+        assert kvikio.defaults.get("task_size") == 3
         kvikio.defaults.set("task_size", 4)
-        assert kvikio.defaults.task_size() == 4
-    assert before == kvikio.defaults.task_size()
+        assert kvikio.defaults.get("task_size") == 4
+    assert before == kvikio.defaults.get("task_size")
 
     with pytest.raises(ValueError, match="positive integer greater than zero"):
         kvikio.defaults.set("task_size", 0)
@@ -102,12 +106,12 @@ def test_task_size():
 def test_gds_threshold():
     """Test changing `gds_threshold`"""
 
-    before = kvikio.defaults.gds_threshold()
+    before = kvikio.defaults.get("gds_threshold")
     with kvikio.defaults.set("gds_threshold", 3):
-        assert kvikio.defaults.gds_threshold() == 3
+        assert kvikio.defaults.get("gds_threshold") == 3
         kvikio.defaults.set("gds_threshold", 4)
-        assert kvikio.defaults.gds_threshold() == 4
-    assert before == kvikio.defaults.gds_threshold()
+        assert kvikio.defaults.get("gds_threshold") == 4
+    assert before == kvikio.defaults.get("gds_threshold")
 
     with pytest.raises(OverflowError, match="negative value"):
         kvikio.defaults.set("gds_threshold", -1)
@@ -116,12 +120,12 @@ def test_gds_threshold():
 def test_bounce_buffer_size():
     """Test changing `bounce_buffer_size`"""
 
-    before = kvikio.defaults.bounce_buffer_size()
+    before = kvikio.defaults.get("bounce_buffer_size")
     with kvikio.defaults.set("bounce_buffer_size", 3):
-        assert kvikio.defaults.bounce_buffer_size() == 3
+        assert kvikio.defaults.get("bounce_buffer_size") == 3
         kvikio.defaults.set("bounce_buffer_size", 4)
-        assert kvikio.defaults.bounce_buffer_size() == 4
-    assert before == kvikio.defaults.bounce_buffer_size()
+        assert kvikio.defaults.get("bounce_buffer_size") == 4
+    assert before == kvikio.defaults.get("bounce_buffer_size")
 
     with pytest.raises(ValueError, match="positive integer greater than zero"):
         kvikio.defaults.set("bounce_buffer_size", 0)
@@ -130,13 +134,13 @@ def test_bounce_buffer_size():
 
 
 def test_http_max_attempts():
-    before = kvikio.defaults.http_max_attempts()
+    before = kvikio.defaults.get("http_max_attempts")
 
     with kvikio.defaults.set("http_max_attempts", 5):
-        assert kvikio.defaults.http_max_attempts() == 5
+        assert kvikio.defaults.get("http_max_attempts") == 5
         kvikio.defaults.set("http_max_attempts", 4)
-        assert kvikio.defaults.http_max_attempts() == 4
-    assert kvikio.defaults.http_max_attempts() == before
+        assert kvikio.defaults.get("http_max_attempts") == 4
+    assert kvikio.defaults.get("http_max_attempts") == before
 
     with pytest.raises(ValueError, match="positive integer"):
         kvikio.defaults.set("http_max_attempts", 0)
@@ -145,13 +149,13 @@ def test_http_max_attempts():
 
 
 def test_http_status_codes():
-    before = kvikio.defaults.http_status_codes()
+    before = kvikio.defaults.get("http_status_codes")
 
     with kvikio.defaults.set("http_status_codes", [500]):
-        assert kvikio.defaults.http_status_codes() == [500]
+        assert kvikio.defaults.get("http_status_codes") == [500]
         kvikio.defaults.set("http_status_codes", [429, 500])
-        assert kvikio.defaults.http_status_codes() == [429, 500]
-    assert kvikio.defaults.http_status_codes() == before
+        assert kvikio.defaults.get("http_status_codes") == [429, 500]
+    assert kvikio.defaults.get("http_status_codes") == before
 
     with pytest.raises(TypeError):
         kvikio.defaults.set("http_status_codes", 0)

--- a/python/kvikio/tests/test_defaults.py
+++ b/python/kvikio/tests/test_defaults.py
@@ -7,6 +7,31 @@ import pytest
 import kvikio.defaults
 
 
+def test_property_setter():
+    """Test the method `set`"""
+
+    # Attempt to set a nonexistent property
+    with pytest.raises(AttributeError):
+        kvikio.defaults.set("nonexistent_property", 123)
+
+    # Attempt to set a property whose name is mistakenly prefixed by "set_"
+    # (coinciding with the setter method).
+    with pytest.raises(TypeError):
+        kvikio.defaults.set("set_task_size", 123)
+
+    # Nested context managers
+    task_size_default = kvikio.defaults.task_size()
+    with kvikio.defaults.set("task_size", 1024):
+        assert kvikio.defaults.task_size() == 1024
+        with kvikio.defaults.set("task_size", 2048):
+            assert kvikio.defaults.task_size() == 2048
+            with kvikio.defaults.set("task_size", 4096):
+                assert kvikio.defaults.task_size() == 4096
+            assert kvikio.defaults.task_size() == 2048
+        assert kvikio.defaults.task_size() == 1024
+    assert kvikio.defaults.task_size() == task_size_default
+
+
 @pytest.mark.skipif(
     kvikio.defaults.compat_mode() == kvikio.CompatMode.ON,
     reason="cannot test `compat_mode` when already running in compatibility mode",

--- a/python/kvikio/tests/test_defaults.py
+++ b/python/kvikio/tests/test_defaults.py
@@ -11,12 +11,12 @@ def test_property_setter():
     """Test the method `set`"""
 
     # Attempt to set a nonexistent property
-    with pytest.raises(AttributeError):
+    with pytest.raises(KeyError):
         kvikio.defaults.set("nonexistent_property", 123)
 
     # Attempt to set a property whose name is mistakenly prefixed by "set_"
     # (coinciding with the setter method).
-    with pytest.raises(TypeError):
+    with pytest.raises(KeyError):
         kvikio.defaults.set("set_task_size", 123)
 
     # Nested context managers

--- a/python/kvikio/tests/test_http_io.py
+++ b/python/kvikio/tests/test_http_io.py
@@ -58,7 +58,8 @@ class HTTP503Handler(SimpleHTTPRequestHandler):
         if self.error_counter.value < self.max_error_count:
             self.error_counter.value += 1
             self.send_error(http.HTTPStatus.SERVICE_UNAVAILABLE)
-            self.send_header("CurrentErrorCount", str(self.error_counter.value))
+            self.send_header("CurrentErrorCount",
+                             str(self.error_counter.value))
             self.send_header("MaxErrorCount", str(self.max_error_count))
             return None
         else:
@@ -99,14 +100,13 @@ def test_read(http_server, tmpdir, xp, size, nthreads, tasksize):
     a = xp.arange(size)
     a.tofile(tmpdir / "a")
 
-    with kvikio.defaults.set_num_threads(nthreads):
-        with kvikio.defaults.set_task_size(tasksize):
-            with kvikio.RemoteFile.open_http(f"{http_server}/a") as f:
-                assert f.nbytes() == a.nbytes
-                assert f"{http_server}/a" in str(f)
-                b = xp.empty_like(a)
-                assert f.read(b) == a.nbytes
-                xp.testing.assert_array_equal(a, b)
+    with kvikio.defaults.set({"num_threads": nthreads, "task_size": tasksize}):
+        with kvikio.RemoteFile.open_http(f"{http_server}/a") as f:
+            assert f.nbytes() == a.nbytes
+            assert f"{http_server}/a" in str(f)
+            b = xp.empty_like(a)
+            assert f.read(b) == a.nbytes
+            xp.testing.assert_array_equal(a, b)
 
 
 @pytest.mark.parametrize("nthreads", [1, 10])
@@ -114,7 +114,7 @@ def test_large_read(http_server, tmpdir, xp, nthreads):
     a = xp.arange(16_000_000)
     a.tofile(tmpdir / "a")
 
-    with kvikio.defaults.set_num_threads(nthreads):
+    with kvikio.defaults.set("num_threads", nthreads):
         with kvikio.RemoteFile.open_http(f"{http_server}/a") as f:
             assert f.nbytes() == a.nbytes
             assert f"{http_server}/a" in str(f)
@@ -181,17 +181,19 @@ def test_retry_http_503_fails(tmpdir, xp, capfd):
         tmpdir,
         max_lifetime=60,
         handler=HTTP503Handler,
-        handler_options={"error_counter": ErrorCounter(), "max_error_count": 100},
+        handler_options={"error_counter": ErrorCounter(),
+                         "max_error_count": 100},
     ) as server:
         a = xp.arange(100, dtype="uint8")
         a.tofile(tmpdir / "a")
         b = xp.empty_like(a)
 
-        with pytest.raises(RuntimeError) as m, kvikio.defaults.set_http_max_attempts(2):
+        with pytest.raises(RuntimeError) as m, kvikio.defaults.set("http_max_attempts", 2):
             with kvikio.RemoteFile.open_http(f"{server.url}/a") as f:
                 f.read(b)
 
-        assert m.match(r"KvikIO: HTTP request reached maximum number of attempts \(2\)")
+        assert m.match(
+            r"KvikIO: HTTP request reached maximum number of attempts \(2\)")
         assert m.match("Got HTTP code 503")
         captured = capfd.readouterr()
 
@@ -212,7 +214,7 @@ def test_no_retries_ok(tmpdir):
     ) as server:
         http_server = server.url
         b = np.empty_like(a)
-        with kvikio.defaults.set_http_max_attempts(1):
+        with kvikio.defaults.set("http_max_attempts", 1):
             with kvikio.RemoteFile.open_http(f"{http_server}/a") as f:
                 assert f.nbytes() == a.nbytes
                 assert f"{http_server}/a" in str(f)
@@ -227,7 +229,7 @@ def test_set_http_status_code(tmpdir):
         handler_options={"error_counter": ErrorCounter()},
     ) as server:
         http_server = server.url
-        with kvikio.defaults.set_http_status_codes([429]):
+        with kvikio.defaults.set("http_status_codes", [429]):
             # this raises on the first 503 error, since it's not in the list.
             assert kvikio.defaults.http_status_codes() == [429]
             with pytest.raises(RuntimeError, match="503"):

--- a/python/kvikio/tests/test_http_io.py
+++ b/python/kvikio/tests/test_http_io.py
@@ -230,7 +230,7 @@ def test_set_http_status_code(tmpdir):
         http_server = server.url
         with kvikio.defaults.set("http_status_codes", [429]):
             # this raises on the first 503 error, since it's not in the list.
-            assert kvikio.defaults.http_status_codes() == [429]
+            assert kvikio.defaults.get("http_status_codes") == [429]
             with pytest.raises(RuntimeError, match="503"):
                 with kvikio.RemoteFile.open_http(f"{http_server}/a"):
                     pass

--- a/python/kvikio/tests/test_http_io.py
+++ b/python/kvikio/tests/test_http_io.py
@@ -58,8 +58,7 @@ class HTTP503Handler(SimpleHTTPRequestHandler):
         if self.error_counter.value < self.max_error_count:
             self.error_counter.value += 1
             self.send_error(http.HTTPStatus.SERVICE_UNAVAILABLE)
-            self.send_header("CurrentErrorCount",
-                             str(self.error_counter.value))
+            self.send_header("CurrentErrorCount", str(self.error_counter.value))
             self.send_header("MaxErrorCount", str(self.max_error_count))
             return None
         else:
@@ -181,19 +180,19 @@ def test_retry_http_503_fails(tmpdir, xp, capfd):
         tmpdir,
         max_lifetime=60,
         handler=HTTP503Handler,
-        handler_options={"error_counter": ErrorCounter(),
-                         "max_error_count": 100},
+        handler_options={"error_counter": ErrorCounter(), "max_error_count": 100},
     ) as server:
         a = xp.arange(100, dtype="uint8")
         a.tofile(tmpdir / "a")
         b = xp.empty_like(a)
 
-        with pytest.raises(RuntimeError) as m, kvikio.defaults.set("http_max_attempts", 2):
+        with pytest.raises(RuntimeError) as m, kvikio.defaults.set(
+            "http_max_attempts", 2
+        ):
             with kvikio.RemoteFile.open_http(f"{server.url}/a") as f:
                 f.read(b)
 
-        assert m.match(
-            r"KvikIO: HTTP request reached maximum number of attempts \(2\)")
+        assert m.match(r"KvikIO: HTTP request reached maximum number of attempts \(2\)")
         assert m.match("Got HTTP code 503")
         captured = capfd.readouterr()
 


### PR DESCRIPTION
Closes https://github.com/rapidsai/kvikio/issues/642
Closes #526 

This PR makes the following changes:

## Improve config setter/getter

This PR lets the properties in `kvikio.defaults` and `kvikio.cufile_driver` be set using a friendly Pythonic interface (C++ interface has also been adjusted for improved clarity). The expression below can appear standalone which sets the properties globally, or in a `with` statement which sets the properties via a context manager.

- To set one or more properties

```python
# Set the property globally.
kvikio.defaults.set({"prop1": value1, "prop2": value2})
kvikio.cufile_driver.set({"prop1": value1, "prop2": value2})

# Set the property with a context manager.
# The property automatically reverts to its old value
# after leaving the `with` block.
with kvikio.defaults.set({"prop1": value1, "prop2": value2}):
with kvikio.cufile_driver.set({"prop1": value1, "prop2": value2}):
    ...
```

- To set a single property

```python
# Set the property globally.
kvikio.defaults.set("prop", value)
kvikio.cufile_driver.set("prop", value)

# Set the property with a context manager.
# The property automatically reverts to its old value
# after leaving the `with` block.
with kvikio.defaults.set("prop", value):
with kvikio.cufile_driver.set("prop", value):
    ...
```

In addition, this PR supports the getter method:
```python
p = kvikio.defaults.get("prop",)
p = kvikio.cufile_driver.get("prop",)
```

## Deprecate the old ways of setting configs

The `<prop>_reset` and `set_<prop>` functions are now deprecated. Deprecation warnings (of type `FutureWarning`) are issued at runtime.

## Add Python function is_compat_mode_preferred

The C++ function `kvikio::defaults::is_compat_mode_preferred()` resolves and queries the current global compat mode. This PR introduces this function to Python.

## Python documentation update
