### PR TITLE
Add macros KVIKIO_EXPECT and KVIKIO_FAIL to improve exception handling

### DIFF
--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -41,10 +41,9 @@ T getenv_or(std::string_view env_var_name, T default_val)
   std::stringstream sstream(env_val);
   T converted_val;
   sstream >> converted_val;
-  if (sstream.fail()) {
-    throw std::invalid_argument("unknown config value " + std::string{env_var_name} + "=" +
-                                std::string{env_val});
-  }
+  KVIKIO_EXPECT(!sstream.fail(),
+                "unknown config value " + std::string{env_var_name} + "=" + std::string{env_val},
+                std::invalid_argument);
   return converted_val;
 }
 

--- a/cpp/include/kvikio/error.hpp
+++ b/cpp/include/kvikio/error.hpp
@@ -16,7 +16,8 @@
 #pragma once
 
 #include <cstring>
-#include <exception>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 
@@ -39,9 +40,36 @@ class GenericSystemError : public std::system_error {
 };
 
 #ifndef CUDA_DRIVER_TRY
+/**
+ * @addtogroup utility_error
+ * @{
+ */
+
+/**
+ * @brief Error checking macro for CUDA driver API functions.
+ *
+ * Invoke a CUDA driver API function call. If the call does not return CUDA_SUCCESS, throw an
+ * exception detailing the CUDA error that occurred.
+ *
+ * Example:
+ * ```
+ * // Throws kvikio::CUfileException
+ * CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(_stream));
+ *
+ * // Throws std::runtime_error
+ * CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(_stream), std::runtime_error);
+ * ```
+ *
+ * @param ... This macro accepts either one or two arguments:
+ *   - The first argument must be a CUDA driver API error code.
+ *   - When given, the second argument is the exception to be thrown. When not
+ *     specified, defaults to kvikio::CUfileException.
+ */
 #define CUDA_DRIVER_TRY(...)                                                   \
   GET_CUDA_DRIVER_TRY_MACRO(__VA_ARGS__, CUDA_DRIVER_TRY_2, CUDA_DRIVER_TRY_1) \
   (__VA_ARGS__)
+/** @} */
+
 #define GET_CUDA_DRIVER_TRY_MACRO(_1, _2, NAME, ...) NAME
 #define CUDA_DRIVER_TRY_2(_call, _exception_type)                                  \
   do {                                                                             \
@@ -51,9 +79,36 @@ class GenericSystemError : public std::system_error {
 #endif
 
 #ifndef CUFILE_TRY
+/**
+ * @addtogroup utility_error
+ * @{
+ */
+
+/**
+ * @brief Error checking macro for cuFile API functions.
+ *
+ * Invoke a cuFile API function call. If the call does not return CU_FILE_SUCCESS, throw an
+ * exception detailing the cuFile error that occurred.
+ *
+ * Example:
+ * ```
+ * // Throws kvikio::CUfileException
+ * CUFILE_TRY(cuFileAPI::instance().ReadAsync(...));
+ *
+ * // Throws std::runtime_error
+ * CUFILE_TRY(cuFileAPI::instance().ReadAsync(...), std::runtime_error);
+ * ```
+ *
+ * @param ... This macro accepts either one or two arguments:
+ *   - The first argument must be a cuFile API error code.
+ *   - When given, the second argument is the exception to be thrown. When not
+ *     specified, defaults to kvikio::CUfileException.
+ */
 #define CUFILE_TRY(...)                                         \
   GET_CUFILE_TRY_MACRO(__VA_ARGS__, CUFILE_TRY_2, CUFILE_TRY_1) \
   (__VA_ARGS__)
+/** @} */
+
 #define GET_CUFILE_TRY_MACRO(_1, _2, NAME, ...) NAME
 #define CUFILE_TRY_2(_call, _exception_type)                                  \
   do {                                                                        \
@@ -129,8 +184,38 @@ void log_error(std::string_view err_msg, int line_number, char const* filename);
 
 }  // namespace detail
 
+/**
+ * @addtogroup utility_error
+ * @{
+ */
+
+/**
+ * @brief Macro for checking pre-conditions or conditions that throws an exception when
+ * a condition is violated.
+ *
+ * Defaults to throwing kvikio::CUfileException, but a custom exception may also be
+ * specified.
+ *
+ * Example:
+ * ```
+ * // Throws kvikio::CUfileException
+ * KVIKIO_EXPECT(p != nullptr, "Unexpected null pointer");
+ *
+ * // Throws std::runtime_error
+ * KVIKIO_EXPECT(p != nullptr, "Unexpected nullptr", std::runtime_error);
+ * ```
+ *
+ * @param ... This macro accepts either two or three arguments:
+ *   - The first argument must be an expression that evaluates to true or
+ *     false, and is the condition being checked.
+ *   - The second argument is a string literal used to construct the `what` of
+ *     the exception.
+ *   - When given, the third argument is the exception to be thrown. When not
+ *     specified, defaults to kvikio::CUfileException.
+ */
 #define KVIKIO_EXPECT(...) \
   GET_KVIKIO_EXPECT_MACRO(__VA_ARGS__, KVIKIO_EXPECT_3, KVIKIO_EXPECT_2)(__VA_ARGS__)
+/** @} */
 
 #define GET_KVIKIO_EXPECT_MACRO(_1, _2, _3, NAME, ...) NAME
 
@@ -141,8 +226,32 @@ void log_error(std::string_view err_msg, int line_number, char const* filename);
 
 #define KVIKIO_EXPECT_2(_condition, _msg) KVIKIO_EXPECT_3(_condition, _msg, kvikio::CUfileException)
 
+/**
+ * @addtogroup utility_error
+ * @{
+ */
+
+/**
+ * @brief Indicates that an erroneous code path has been taken.
+ *
+ * Example usage:
+ * ```
+ * // Throws kvikio::CUfileException
+ * KVIKIO_FAIL("Unsupported code path");
+ *
+ * // Throws std::runtime_error
+ * KVIKIO_FAIL("Unsupported code path", std::runtime_error);
+ * ```
+ *
+ * @param ... This macro accepts either one or two arguments:
+ *   - The first argument is a string literal used to construct the `what` of
+ *     the exception.
+ *   - When given, the second argument is the exception to be thrown. When not
+ *     specified, defaults to kvikio::CUfileException.
+ */
 #define KVIKIO_FAIL(...) \
   GET_KVIKIO_FAIL_MACRO(__VA_ARGS__, KVIKIO_FAIL_2, KVIKIO_FAIL_1)(__VA_ARGS__)
+/** @} */
 
 #define GET_KVIKIO_FAIL_MACRO(_1, _2, NAME, ...) NAME
 
@@ -158,9 +267,15 @@ template <typename Exception>
 void kvikio_assertion(bool condition, const char* msg, int line_number, char const* filename)
 {
   if (!condition) {
-    throw Exception{std::string{"KvikIO failure at: "} + filename + ":" +
-                    std::to_string(line_number) + ": " + msg};
-  }
+    std::stringstream ss;
+    ss << "KvikIO failure at: " << filename << ":" << line_number << ": ";
+    if (msg == nullptr) {
+      ss << "(no message)";
+    } else {
+      ss << msg;
+    }
+    throw Exception{ss.str()};
+  };
 }
 
 template <typename Exception>

--- a/cpp/include/kvikio/parallel_operation.hpp
+++ b/cpp/include/kvikio/parallel_operation.hpp
@@ -89,7 +89,7 @@ std::future<std::size_t> parallel_io(F op,
                                      std::uint64_t call_idx     = 0,
                                      nvtx_color_type nvtx_color = NvtxManager::default_color())
 {
-  if (task_size == 0) { throw std::invalid_argument("`task_size` cannot be zero"); }
+  KVIKIO_EXPECT(task_size > 0, "`task_size` must be positive", std::invalid_argument);
 
   // Single-task guard
   if (task_size >= size || page_size >= size) {

--- a/cpp/include/kvikio/shim/cuda_h_wrapper.hpp
+++ b/cpp/include/kvikio/shim/cuda_h_wrapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ using CUstream  = struct CUstream_st*;
 #define CU_POINTER_ATTRIBUTE_CONTEXT        0
 #define CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL 0
 #define CU_POINTER_ATTRIBUTE_DEVICE_POINTER 0
-#define CU_MEMHOSTREGISTER_PORTABLE         0
+#define CU_MEMHOSTALLOC_PORTABLE            0
 #define CU_STREAM_DEFAULT                   0
 
 CUresult cuInit(...);

--- a/cpp/include/kvikio/shim/libcurl.hpp
+++ b/cpp/include/kvikio/shim/libcurl.hpp
@@ -29,6 +29,8 @@
 
 #include <curl/curl.h>
 
+#include <kvikio/error.hpp>
+
 namespace kvikio {
 
 /**
@@ -90,8 +92,6 @@ class CurlHandle {
  private:
   char _errbuf[CURL_ERROR_SIZE];
   LibCurl::UniqueHandlePtr _handle;
-  std::string _source_file;
-  std::string _source_line;
 
  public:
   /**
@@ -133,9 +133,9 @@ class CurlHandle {
     CURLcode err = curl_easy_setopt(handle(), option, value);
     if (err != CURLE_OK) {
       std::stringstream ss;
-      ss << "curl_easy_setopt() error near " << _source_file << ":" << _source_line;
-      ss << "(" << curl_easy_strerror(err) << ")";
-      throw std::runtime_error(ss.str());
+      ss << "curl_easy_setopt() error "
+         << "(" << curl_easy_strerror(err) << ")";
+      KVIKIO_FAIL(ss.str(), std::runtime_error);
     }
   }
 
@@ -160,9 +160,9 @@ class CurlHandle {
     CURLcode err = curl_easy_getinfo(handle(), info, output);
     if (err != CURLE_OK) {
       std::stringstream ss;
-      ss << "curl_easy_getinfo() error near " << _source_file << ":" << _source_line;
-      ss << "(" << curl_easy_strerror(err) << ")";
-      throw std::runtime_error(ss.str());
+      ss << "curl_easy_getinfo() error "
+         << "(" << curl_easy_strerror(err) << ")";
+      KVIKIO_FAIL(ss.str(), std::runtime_error);
     }
   }
 };

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -23,6 +23,7 @@
 #include <tuple>
 #include <type_traits>
 
+#include <kvikio/error.hpp>
 #include <kvikio/shim/cuda.hpp>
 
 namespace kvikio {
@@ -43,9 +44,9 @@ template <typename T, std::enable_if_t<std::is_integral_v<T>>* = nullptr>
 [[nodiscard]] std::int64_t convert_to_64bit(T value)
 {
   if constexpr (std::numeric_limits<T>::max() > std::numeric_limits<std::int64_t>::max()) {
-    if (value > std::numeric_limits<std::int64_t>::max()) {
-      throw std::overflow_error("convert_to_64bit(x): x too large to fit std::int64_t");
-    }
+    KVIKIO_EXPECT(value <= std::numeric_limits<std::int64_t>::max(),
+                  "convert_to_64bit(x): x too large to fit std::int64_t",
+                  std::overflow_error);
   }
   return std::int64_t(value);
 }

--- a/cpp/src/compat_mode.cpp
+++ b/cpp/src/compat_mode.cpp
@@ -41,8 +41,9 @@ CompatMode parse_compat_mode_str(std::string_view compat_mode_str)
   } else if (tmp == "auto") {
     return CompatMode::AUTO;
   } else {
-    throw std::invalid_argument("Unknown compatibility mode: " + std::string{tmp});
+    KVIKIO_FAIL("Unknown compatibility mode: " + std::string{tmp}, std::invalid_argument);
   }
+  return {};
 }
 
 }  // namespace detail
@@ -83,10 +84,9 @@ CompatModeManager::CompatModeManager(std::string const& file_path,
                                      CompatMode compat_mode_requested_v,
                                      FileHandle* file_handle)
 {
-  if (file_handle == nullptr) {
-    throw std::invalid_argument(
-      "The compatibility mode manager does not have a proper owning file handle.");
-  }
+  KVIKIO_EXPECT(file_handle != nullptr,
+                "The compatibility mode manager does not have a proper owning file handle.",
+                std::invalid_argument);
 
   file_handle->_file_direct_off.open(file_path, flags, false, mode);
   _is_compat_mode_preferred = is_compat_mode_preferred(compat_mode_requested_v);
@@ -136,7 +136,7 @@ void CompatModeManager::validate_compat_mode_for_async() const
     // because even when the stream API is available, it doesn't work if no config file exists.
     if (config_path().empty()) { err_msg += " Missing cuFile configuration file."; }
 
-    throw std::runtime_error(err_msg);
+    KVIKIO_FAIL(err_msg, std::runtime_error);
   }
 }
 

--- a/cpp/src/cufile/driver.cpp
+++ b/cpp/src/cufile/driver.cpp
@@ -203,7 +203,7 @@ bool DriverProperties::get_nvfs_poll_mode()
 std::size_t DriverProperties::get_nvfs_poll_thresh_size()
 {
   KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
-  return 0;
+  return {};
 }
 
 void DriverProperties::set_nvfs_poll_mode(bool enable)

--- a/cpp/src/cufile/driver.cpp
+++ b/cpp/src/cufile/driver.cpp
@@ -178,72 +178,86 @@ bool DriverProperties::is_gds_available() { return false; }
 
 unsigned int DriverProperties::get_nvfs_major_version()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return {};
 }
 
 unsigned int DriverProperties::get_nvfs_minor_version()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return {};
 }
 
 bool DriverProperties::get_nvfs_allow_compat_mode()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return {};
 }
 
 bool DriverProperties::get_nvfs_poll_mode()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return {};
 }
 
 std::size_t DriverProperties::get_nvfs_poll_thresh_size()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return 0;
 }
 
 void DriverProperties::set_nvfs_poll_mode(bool enable)
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return;
 }
 
 void DriverProperties::set_nvfs_poll_thresh_size(std::size_t size_in_kb)
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return;
 }
 
 std::vector<CUfileDriverControlFlags> DriverProperties::get_nvfs_statusflags()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return {};
 }
 
 std::size_t DriverProperties::get_max_device_cache_size()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return {};
 }
 
 void DriverProperties::set_max_device_cache_size(std::size_t size_in_kb)
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return;
 }
 
 std::size_t DriverProperties::get_per_buffer_cache_size()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return {};
 }
 
 std::size_t DriverProperties::get_max_pinned_memory_size()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return {};
 }
 
 void DriverProperties::set_max_pinned_memory_size(std::size_t size_in_kb)
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return;
 }
 
 std::size_t DriverProperties::get_max_batch_io_size()
 {
-  throw CUfileException("KvikIO not compiled with cuFile.h");
+  KVIKIO_FAIL("KvikIO not compiled with cuFile.h");
+  return {};
 }
 #endif
 

--- a/cpp/src/error.cpp
+++ b/cpp/src/error.cpp
@@ -20,6 +20,13 @@
 
 namespace kvikio {
 
+GenericSystemError::GenericSystemError(const std::string& msg) : GenericSystemError(msg.c_str()) {}
+
+GenericSystemError::GenericSystemError(const char* msg)
+  : std::system_error(errno, std::generic_category(), msg)
+{
+}
+
 namespace detail {
 
 void log_error(std::string_view err_msg, int line_number, char const* filename)

--- a/cpp/src/http_status_codes.cpp
+++ b/cpp/src/http_status_codes.cpp
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+#include <kvikio/error.hpp>
+
 namespace kvikio {
 
 namespace detail {
@@ -30,10 +32,9 @@ std::vector<int> parse_http_status_codes(std::string_view env_var_name,
 {
   // Ensure `status_codes` consists only of 3-digit integers separated by commas, allowing spaces.
   std::regex const check_pattern(R"(^\s*\d{3}\s*(\s*,\s*\d{3}\s*)*$)");
-  if (!std::regex_match(status_codes, check_pattern)) {
-    throw std::invalid_argument(std::string{env_var_name} +
-                                ": invalid format, expected comma-separated integers.");
-  }
+  KVIKIO_EXPECT(std::regex_match(status_codes, check_pattern),
+                std::string{env_var_name} + ": invalid format, expected comma-separated integers.",
+                std::invalid_argument);
 
   // Match every integer in `status_codes`.
   std::regex const number_pattern(R"(\d+)");

--- a/cpp/src/shim/cuda.cpp
+++ b/cpp/src/shim/cuda.cpp
@@ -16,6 +16,7 @@
 
 #include <stdexcept>
 
+#include <kvikio/error.hpp>
 #include <kvikio/shim/cuda.hpp>
 
 namespace kvikio {
@@ -48,7 +49,7 @@ cudaAPI::cudaAPI()
   get_symbol(StreamDestroy, lib, KVIKIO_STRINGIFY(cuStreamDestroy));
 }
 #else
-cudaAPI::cudaAPI() { throw std::runtime_error("KvikIO not compiled with CUDA support"); }
+cudaAPI::cudaAPI() { KVIKIO_FAIL("KvikIO not compiled with CUDA support", std::runtime_error); }
 #endif
 
 cudaAPI& cudaAPI::instance()

--- a/cpp/src/shim/cufile.cpp
+++ b/cpp/src/shim/cufile.cpp
@@ -17,6 +17,7 @@
 #include <stdexcept>
 #include <string>
 
+#include <kvikio/error.hpp>
 #include <kvikio/shim/cufile.hpp>
 #include <kvikio/shim/cufile_h_wrapper.hpp>
 #include <kvikio/shim/utils.hpp>
@@ -95,7 +96,7 @@ cuFileAPI::~cuFileAPI()
   if (version < 1050) { driver_close(); }
 }
 #else
-cuFileAPI::cuFileAPI() { throw std::runtime_error("KvikIO not compiled with cuFile.h"); }
+cuFileAPI::cuFileAPI() { KVIKIO_FAIL("KvikIO not compiled with cuFile.h", std::runtime_error); }
 #endif
 
 cuFileAPI& cuFileAPI::instance()
@@ -107,19 +108,17 @@ cuFileAPI& cuFileAPI::instance()
 void cuFileAPI::driver_open()
 {
   CUfileError_t const error = DriverOpen();
-  if (error.err != CU_FILE_SUCCESS) {
-    throw std::runtime_error(std::string{"Unable to open GDS file driver: "} +
-                             cufileop_status_error(error.err));
-  }
+  KVIKIO_EXPECT(error.err == CU_FILE_SUCCESS,
+                std::string{"Unable to open GDS file driver: "} + cufileop_status_error(error.err),
+                std::runtime_error);
 }
 
 void cuFileAPI::driver_close()
 {
   CUfileError_t const error = DriverClose();
-  if (error.err != CU_FILE_SUCCESS) {
-    throw std::runtime_error(std::string{"Unable to close GDS file driver: "} +
-                             cufileop_status_error(error.err));
-  }
+  KVIKIO_EXPECT(error.err == CU_FILE_SUCCESS,
+                std::string{"Unable to close GDS file driver: "} + cufileop_status_error(error.err),
+                std::runtime_error);
 }
 
 #ifdef KVIKIO_CUFILE_FOUND

--- a/cpp/src/shim/utils.cpp
+++ b/cpp/src/shim/utils.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <vector>
 
+#include <kvikio/error.hpp>
 #include <kvikio/shim/utils.hpp>
 
 namespace kvikio {
@@ -28,7 +29,7 @@ void* load_library(std::string const& name, int mode)
 {
   ::dlerror();  // Clear old errors
   void* ret = ::dlopen(name.c_str(), mode);
-  if (ret == nullptr) { throw std::runtime_error(::dlerror()); }
+  KVIKIO_EXPECT(ret != nullptr, ::dlerror(), std::runtime_error);
   return ret;
 }
 
@@ -42,7 +43,8 @@ void* load_library(std::vector<std::string> const& names, int mode)
     } catch (std::runtime_error const&) {
     }
   }
-  throw std::runtime_error("cannot open shared object file, tried: " + ss.str());
+  KVIKIO_FAIL("cannot open shared object file, tried: " + ss.str(), std::runtime_error);
+  return {};
 }
 
 bool is_running_in_wsl() noexcept

--- a/cpp/src/stream.cpp
+++ b/cpp/src/stream.cpp
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <cstdlib>
 #include <iostream>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 
@@ -33,9 +34,10 @@ StreamFuture::StreamFuture(
 {
   // Notice, we allocate the arguments using malloc() as specified in the cuFile docs:
   // <https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html#cufilewriteasync>
-  if ((_val = static_cast<ArgByVal*>(std::malloc(sizeof(ArgByVal)))) == nullptr) {
-    throw std::bad_alloc{};
-  }
+  KVIKIO_EXPECT((_val = static_cast<ArgByVal*>(std::malloc(sizeof(ArgByVal)))) != nullptr,
+                "Bad memory allocation",
+                std::runtime_error);
+
   *_val = {
     .size = size, .file_offset = file_offset, .devPtr_offset = devPtr_offset, .bytes_done = 0};
 }
@@ -59,9 +61,8 @@ StreamFuture& StreamFuture::operator=(StreamFuture&& o) noexcept
 
 std::tuple<void*, std::size_t*, off_t*, off_t*, ssize_t*, CUstream> StreamFuture::get_args() const
 {
-  if (_val == nullptr) {
-    throw kvikio::CUfileException("cannot get arguments from an uninitialized StreamFuture");
-  }
+  KVIKIO_EXPECT(_val != nullptr, "cannot get arguments from an uninitialized StreamFuture");
+
   return {_devPtr_base,
           &_val->size,
           &_val->file_offset,
@@ -72,9 +73,7 @@ std::tuple<void*, std::size_t*, off_t*, off_t*, ssize_t*, CUstream> StreamFuture
 
 std::size_t StreamFuture::check_bytes_done()
 {
-  if (_val == nullptr) {
-    throw kvikio::CUfileException("cannot check bytes done on an uninitialized StreamFuture");
-  }
+  KVIKIO_EXPECT(_val != nullptr, "cannot check bytes done on an uninitialized StreamFuture");
 
   if (!_stream_synchronized) {
     _stream_synchronized = true;

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -30,17 +30,15 @@ namespace kvikio {
 
 off_t convert_size2off(std::size_t x)
 {
-  if (x >= static_cast<std::size_t>(std::numeric_limits<off_t>::max())) {
-    throw CUfileException("size_t argument too large to fit off_t");
-  }
+  KVIKIO_EXPECT(x < static_cast<std::size_t>(std::numeric_limits<off_t>::max()),
+                "size_t argument too large to fit off_t");
   return static_cast<off_t>(x);
 }
 
 ssize_t convert_size2ssize(std::size_t x)
 {
-  if (x >= static_cast<std::size_t>(std::numeric_limits<ssize_t>::max())) {
-    throw CUfileException("size_t argument too large to fit ssize_t");
-  }
+  KVIKIO_EXPECT(x < static_cast<std::size_t>(std::numeric_limits<ssize_t>::max()),
+                "size_t argument too large to fit ssize_t");
   return static_cast<ssize_t>(x);
 }
 

--- a/python/kvikio/tests/test_cufile_driver.py
+++ b/python/kvikio/tests/test_cufile_driver.py
@@ -18,6 +18,7 @@ def test_open_and_close():
     kvikio.cufile_driver.driver_close()
 
 
+@pytest.mark.cufile
 def test_property_accessor():
     """Test the method `get` and `set`"""
 

--- a/python/kvikio/tests/test_defaults.py
+++ b/python/kvikio/tests/test_defaults.py
@@ -81,7 +81,7 @@ def test_num_threads():
         assert kvikio.defaults.get("num_threads") == 4
     assert before == kvikio.defaults.get("num_threads")
 
-    with pytest.raises(ValueError, match="positive integer greater than zero"):
+    with pytest.raises(ValueError, match="positive integer"):
         kvikio.defaults.set("num_threads", 0)
     with pytest.raises(OverflowError, match="negative value"):
         kvikio.defaults.set("num_threads", -1)
@@ -97,7 +97,7 @@ def test_task_size():
         assert kvikio.defaults.get("task_size") == 4
     assert before == kvikio.defaults.get("task_size")
 
-    with pytest.raises(ValueError, match="positive integer greater than zero"):
+    with pytest.raises(ValueError, match="positive integer"):
         kvikio.defaults.set("task_size", 0)
     with pytest.raises(OverflowError, match="negative value"):
         kvikio.defaults.set("task_size", -1)
@@ -127,7 +127,7 @@ def test_bounce_buffer_size():
         assert kvikio.defaults.get("bounce_buffer_size") == 4
     assert before == kvikio.defaults.get("bounce_buffer_size")
 
-    with pytest.raises(ValueError, match="positive integer greater than zero"):
+    with pytest.raises(ValueError, match="positive integer"):
         kvikio.defaults.set("bounce_buffer_size", 0)
     with pytest.raises(OverflowError, match="negative value"):
         kvikio.defaults.set("bounce_buffer_size", -1)


### PR DESCRIPTION
This PR follows cuDF's [enhanced exception handling approach](https://github.com/rapidsai/cudf/blob/branch-25.04/cpp/include/cudf/utilities/error.hpp#L178) and adds the macros `KVIKIO_EXPECT` and `KVIKIO_FAIL` to KvikIO. 

The benefit is that the file name and line number where the exception is thrown are automatically included in the exception message. This also leads to cleaner code.

This PR does not add the stacktrace capability as in cuDF's exception handling. This feature should be added in the future.

Closes #654 