### PR TITLE
Remove libcufile-dev packages from conda dependencies now that libkvikio is a shared library.

### DIFF
--- a/conda/recipes/libkvikio/meta.yaml
+++ b/conda/recipes/libkvikio/meta.yaml
@@ -78,10 +78,9 @@ outputs:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         {% if cuda_major == "11" %}
         - cudatoolkit
-        - libcufile {{ cuda11_libcufile_run_version }}      # [linux64]
-        - libcufile-dev {{ cuda11_libcufile_run_version }}  # [linux64]
+        - libcufile {{ cuda11_libcufile_run_version }}  # [linux64]
         {% else %}
-        - libcufile-dev  # [linux]
+        - libcufile  # [linux64]
         {% endif %}
     test:
         commands:
@@ -114,7 +113,7 @@ outputs:
         - libcufile {{ cuda11_libcufile_run_version }}  # [linux64]
         {% else %}
         - cuda-cudart-dev
-        - libcufile-dev  # [linux]
+        - libcufile-dev  # [linux64]
         {% endif %}
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
@@ -123,7 +122,7 @@ outputs:
         - libcufile {{ cuda11_libcufile_run_version }}  # [linux64]
         {% else %}
         - cuda-cudart
-        - libcufile  # [linux]
+        - libcufile  # [linux64]
         {% endif %}
     about:
       home: https://rapids.ai


### PR DESCRIPTION
For a long time, `libkvikio` was a header-only library. To make it usable by consumers, we included `libcufile-dev` in its run dependencies. Now that `libkvikio` is a shared library, we do not need to do that.

Also, ARM packages of `libkvikio` were depending on `libcufile` and getting it from the `nvidia` channel, which breaks things because the version is unconstrained by `cuda-version`. We cannot include a run dependency on `libcufile` on ARM until the next CUDA major version, because we need ARM packages to work with CUDA 12.0 and `libcufile` was only introduced in CUDA 12.2+.
