### PR TITLE
Fix compilation error under openSUSE Tumbleweed

### DIFF
--- a/cpp/src/shim/libcurl.cpp
+++ b/cpp/src/shim/libcurl.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <functional>


### PR DESCRIPTION
It is not possible to compile the project under openSUSE Tumbleweed 20250224 (libstdc++6-devel-gcc14 14.2.1+git10750).

Without explicit `#include <algorithm>` I was getting the following error when running `/build.sh libcudf` in cudf project:

```
[ 34%] Built target libcurl_static
[ 34%] Building CXX object _deps/kvikio-build/CMakeFiles/kvikio.dir/src/shim/libcurl.cpp.o
/home/tomas/Development/playground/cudf/cpp/build/_deps/kvikio-src/cpp/src/shim/libcurl.cpp: In member function ‘void kvikio::CurlHandle::perform()’:
/home/tomas/Development/playground/cudf/cpp/build/_deps/kvikio-src/cpp/src/shim/libcurl.cpp:143:17: error: no matching function for call to ‘find(std::vector<int>::const_iterator, std::vector<int>::const_iterator, long int&)’
  143 |       (std::find(http_status_codes.begin(), http_status_codes.end(), http_code) !=
      |        ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14/bits/locale_facets.h:48,
                 from /usr/include/c++/14/bits/basic_ios.h:37,
                 from /usr/include/c++/14/ios:46,
                 from /usr/include/c++/14/ostream:40,
                 from /usr/include/c++/14/iostream:41,
                 from /home/tomas/Development/playground/cudf/cpp/build/_deps/kvikio-src/cpp/src/shim/libcurl.cpp:21:
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
/home/tomas/Development/playground/cudf/cpp/build/_deps/kvikio-src/cpp/src/shim/libcurl.cpp:143:17: note:   ‘__gnu_cxx::__normal_iterator<const int*, std::vector<int> >’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
  143 |       (std::find(http_status_codes.begin(), http_status_codes.end(), http_code) !=
      |        ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gmake[2]: *** [_deps/kvikio-build/CMakeFiles/kvikio.dir/build.make:345: _deps/kvikio-build/CMakeFiles/kvikio.dir/src/shim/libcurl.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2268: _deps/kvikio-build/CMakeFiles/kvikio.dir/all] Error 2
gmake: *** [Makefile:156: all] Error 2

```