### PR TITLE
Improve NVTX annotation for functions

### DIFF
--- a/cpp/include/kvikio/nvtx.hpp
+++ b/cpp/include/kvikio/nvtx.hpp
@@ -50,9 +50,29 @@ using nvtx_registered_string_type = nvtx3::registered_string_in<libkvikio_domain
   }(message)
 
 // Implementation of KVIKIO_NVTX_FUNC_RANGE()
-#define KVIKIO_NVTX_FUNC_RANGE_IMPL() NVTX3_FUNC_RANGE_IN(kvikio::libkvikio_domain)
+#define KVIKIO_NVTX_FUNC_RANGE_IMPL_0() KVIKIO_NVTX_SCOPED_RANGE_IMPL_1(__PRETTY_FUNCTION__)
+#define KVIKIO_NVTX_FUNC_RANGE_IMPL_1(payload) \
+  KVIKIO_NVTX_SCOPED_RANGE_IMPL_2(__PRETTY_FUNCTION__, payload)
+#define KVIKIO_NVTX_FUNC_RANGE_IMPL_2(payload, color) \
+  KVIKIO_NVTX_SCOPED_RANGE_IMPL_3(__PRETTY_FUNCTION__, payload, color)
+#define KVIKIO_NVTX_FUNC_RANGE_SELECTOR(_0, _1, _2, NAME, ...) NAME
+#define KVIKIO_NVTX_FUNC_RANGE_IMPL(...)                         \
+  KVIKIO_NVTX_FUNC_RANGE_SELECTOR(_0,                            \
+                                  ##__VA_ARGS__,                 \
+                                  KVIKIO_NVTX_FUNC_RANGE_IMPL_2, \
+                                  KVIKIO_NVTX_FUNC_RANGE_IMPL_1, \
+                                  KVIKIO_NVTX_FUNC_RANGE_IMPL_0) \
+  (__VA_ARGS__)
 
 // Implementation of KVIKIO_NVTX_SCOPED_RANGE(...)
+#define KVIKIO_NVTX_SCOPED_RANGE_IMPL_1(message)                             \
+  kvikio::nvtx_scoped_range_type KVIKIO_CONCAT(_kvikio_nvtx_range, __LINE__) \
+  {                                                                          \
+    nvtx3::event_attributes                                                  \
+    {                                                                        \
+      KVIKIO_REGISTER_STRING(message), kvikio::NvtxManager::default_color()  \
+    }                                                                        \
+  }
 #define KVIKIO_NVTX_SCOPED_RANGE_IMPL_3(message, payload_v, color)                                \
   kvikio::nvtx_scoped_range_type KVIKIO_CONCAT(_kvikio_nvtx_range, __LINE__)                      \
   {                                                                                               \
@@ -64,9 +84,11 @@ using nvtx_registered_string_type = nvtx3::registered_string_in<libkvikio_domain
 #define KVIKIO_NVTX_SCOPED_RANGE_IMPL_2(message, payload) \
   KVIKIO_NVTX_SCOPED_RANGE_IMPL_3(message, payload, kvikio::NvtxManager::default_color())
 #define KVIKIO_NVTX_SCOPED_RANGE_SELECTOR(_1, _2, _3, NAME, ...) NAME
-#define KVIKIO_NVTX_SCOPED_RANGE_IMPL(...)                                         \
-  KVIKIO_NVTX_SCOPED_RANGE_SELECTOR(                                               \
-    __VA_ARGS__, KVIKIO_NVTX_SCOPED_RANGE_IMPL_3, KVIKIO_NVTX_SCOPED_RANGE_IMPL_2) \
+#define KVIKIO_NVTX_SCOPED_RANGE_IMPL(...)                           \
+  KVIKIO_NVTX_SCOPED_RANGE_SELECTOR(__VA_ARGS__,                     \
+                                    KVIKIO_NVTX_SCOPED_RANGE_IMPL_3, \
+                                    KVIKIO_NVTX_SCOPED_RANGE_IMPL_2, \
+                                    KVIKIO_NVTX_SCOPED_RANGE_IMPL_1) \
   (__VA_ARGS__)
 
 // Implementation of KVIKIO_NVTX_MARKER(message, payload)
@@ -124,22 +146,39 @@ class NvtxManager {
 };
 
 /**
- * @brief Convenience macro for generating an NVTX range in the `libkvikio` domain
- * from the lifetime of a function.
+ * @brief Convenience macro for generating an NVTX range in the `libkvikio` domain from the lifetime
+ * of a function. Can be used inside a regular function or a lambda expression.
  *
- * Takes no argument. The name of the immediately enclosing function returned by `__func__` is used
- * as the message.
+ * The function name contains detailed information such as namespace, return type, parameter type,
+ * etc.
+ *
+ * @param payload (Optional) NVTX payload.
+ * @param color (Optional) NVTX color. If unspecified, a default NVTX color is used.
  *
  * Example:
  * ```
  * void some_function(){
- *    KVIKIO_NVTX_FUNC_RANGE();  // The name `some_function` is used as the message
+ *    // No argument
+ *    KVIKIO_NVTX_FUNC_RANGE();
+ *    ...
+ * }
+ *
+ * void some_function(){
+ *    // Specify payload
+ *    KVIKIO_NVTX_FUNC_RANGE(4096);
+ *    ...
+ * }
+ *
+ * void some_function(){
+ *    // Specify payload and color
+ *    auto const nvtx3::rgb color{0, 255, 0};
+ *    KVIKIO_NVTX_FUNC_RANGE(4096, color);
  *    ...
  * }
  * ```
  */
 #ifdef KVIKIO_CUDA_FOUND
-#define KVIKIO_NVTX_FUNC_RANGE() KVIKIO_NVTX_FUNC_RANGE_IMPL()
+#define KVIKIO_NVTX_FUNC_RANGE(...) KVIKIO_NVTX_FUNC_RANGE_IMPL(__VA_ARGS__)
 #else
 #define KVIKIO_NVTX_FUNC_RANGE(...) \
   do {                              \
@@ -152,7 +191,7 @@ class NvtxManager {
  *
  * @param message String literal for NVTX annotation. To improve profile-time performance, the
  * string literal is registered in NVTX.
- * @param payload NVTX payload.
+ * @param payload (Optional) NVTX payload.
  * @param color (Optional) NVTX color. If unspecified, a default NVTX color is used.
  *
  * Example:

--- a/cpp/include/kvikio/nvtx.hpp
+++ b/cpp/include/kvikio/nvtx.hpp
@@ -50,12 +50,16 @@ using nvtx_registered_string_type = nvtx3::registered_string_in<libkvikio_domain
   }(message)
 
 // Implementation of KVIKIO_NVTX_FUNC_RANGE()
+// todo: Although supported by many compilers, __PRETTY_FUNCTION__ is non-standard. Replacement may
+// be considered once reflection is standardized.
 #define KVIKIO_NVTX_FUNC_RANGE_IMPL_0() KVIKIO_NVTX_SCOPED_RANGE_IMPL_1(__PRETTY_FUNCTION__)
 #define KVIKIO_NVTX_FUNC_RANGE_IMPL_1(payload) \
   KVIKIO_NVTX_SCOPED_RANGE_IMPL_2(__PRETTY_FUNCTION__, payload)
 #define KVIKIO_NVTX_FUNC_RANGE_IMPL_2(payload, color) \
   KVIKIO_NVTX_SCOPED_RANGE_IMPL_3(__PRETTY_FUNCTION__, payload, color)
 #define KVIKIO_NVTX_FUNC_RANGE_SELECTOR(_0, _1, _2, NAME, ...) NAME
+// todo: Although supported by gcc and clang, ##__VA_ARGS__ is non-standard, and should be replaced
+// by __VA_OPT__ (since C++20) in the future.
 #define KVIKIO_NVTX_FUNC_RANGE_IMPL(...)                         \
   KVIKIO_NVTX_FUNC_RANGE_SELECTOR(_0,                            \
                                   ##__VA_ARGS__,                 \

--- a/cpp/include/kvikio/posix_io.hpp
+++ b/cpp/include/kvikio/posix_io.hpp
@@ -183,7 +183,7 @@ std::size_t posix_device_io(int fd,
 template <PartialIO PartialIOStatus>
 std::size_t posix_host_read(int fd, void* buf, std::size_t size, std::size_t file_offset)
 {
-  KVIKIO_NVTX_SCOPED_RANGE("posix_host_read()", size);
+  KVIKIO_NVTX_FUNC_RANGE(size);
   return detail::posix_host_io<IOOperationType::READ, PartialIOStatus>(
     fd, buf, size, convert_size2off(file_offset));
 }
@@ -205,7 +205,7 @@ std::size_t posix_host_read(int fd, void* buf, std::size_t size, std::size_t fil
 template <PartialIO PartialIOStatus>
 std::size_t posix_host_write(int fd, void const* buf, std::size_t size, std::size_t file_offset)
 {
-  KVIKIO_NVTX_SCOPED_RANGE("posix_host_write()", size);
+  KVIKIO_NVTX_FUNC_RANGE(size);
   return detail::posix_host_io<IOOperationType::WRITE, PartialIOStatus>(
     fd, buf, size, convert_size2off(file_offset));
 }

--- a/cpp/include/kvikio/threadpool_wrapper.hpp
+++ b/cpp/include/kvikio/threadpool_wrapper.hpp
@@ -45,7 +45,7 @@ class thread_pool_wrapper : public pool_type {
 
  private:
   inline static std::function<void()> worker_thread_init_func{[] {
-    KVIKIO_NVTX_SCOPED_RANGE("worker thread init", 0, NvtxManager::default_color());
+    KVIKIO_NVTX_FUNC_RANGE();
     // Rename the worker thread in the thread pool to improve clarity from nsys-ui.
     // Note: This NVTX feature is currently not supported by nsys-ui.
     NvtxManager::rename_current_thread("thread pool");

--- a/cpp/include/kvikio/threadpool_wrapper.hpp
+++ b/cpp/include/kvikio/threadpool_wrapper.hpp
@@ -33,7 +33,10 @@ class thread_pool_wrapper : public pool_type {
    *
    * @param nthreads The number of threads to use.
    */
-  thread_pool_wrapper(unsigned int nthreads) : pool_type{nthreads, worker_thread_init_func} {}
+  thread_pool_wrapper(unsigned int nthreads) : pool_type{nthreads, worker_thread_init_func}
+  {
+    KVIKIO_NVTX_FUNC_RANGE();
+  }
 
   /**
    * @brief Reset the number of threads in the thread pool, and invoke a pre-defined initialization
@@ -41,7 +44,11 @@ class thread_pool_wrapper : public pool_type {
    *
    * @param nthreads The number of threads to use.
    */
-  void reset(unsigned int nthreads) { pool_type::reset(nthreads, worker_thread_init_func); }
+  void reset(unsigned int nthreads)
+  {
+    KVIKIO_NVTX_FUNC_RANGE();
+    pool_type::reset(nthreads, worker_thread_init_func);
+  }
 
  private:
   inline static std::function<void()> worker_thread_init_func{[] {

--- a/cpp/src/bounce_buffer.cpp
+++ b/cpp/src/bounce_buffer.cpp
@@ -117,6 +117,7 @@ std::size_t AllocRetain::clear()
 
 AllocRetain& AllocRetain::instance()
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   static AllocRetain _instance;
   return _instance;
 }

--- a/cpp/src/buffer.cpp
+++ b/cpp/src/buffer.cpp
@@ -21,6 +21,7 @@
 #include <kvikio/buffer.hpp>
 #include <kvikio/defaults.hpp>
 #include <kvikio/error.hpp>
+#include <kvikio/nvtx.hpp>
 #include <kvikio/shim/cufile.hpp>
 #include <kvikio/shim/cufile_h_wrapper.hpp>
 #include <kvikio/utils.hpp>
@@ -32,6 +33,7 @@ void buffer_register(void const* devPtr_base,
                      int flags,
                      std::vector<int> const& errors_to_ignore)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   if (defaults::is_compat_mode_preferred()) { return; }
   CUfileError_t status = cuFileAPI::instance().BufRegister(devPtr_base, size, flags);
   if (status.err != CU_FILE_SUCCESS) {
@@ -45,18 +47,21 @@ void buffer_register(void const* devPtr_base,
 
 void buffer_deregister(void const* devPtr_base)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   if (defaults::is_compat_mode_preferred()) { return; }
   CUFILE_TRY(cuFileAPI::instance().BufDeregister(devPtr_base));
 }
 
 void memory_register(void const* devPtr, int flags, std::vector<int> const& errors_to_ignore)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto [base, nbytes, offset] = get_alloc_info(devPtr);
   buffer_register(base, nbytes, flags, errors_to_ignore);
 }
 
 void memory_deregister(void const* devPtr)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto [base, nbytes, offset] = get_alloc_info(devPtr);
   buffer_deregister(base);
 }

--- a/cpp/src/compat_mode.cpp
+++ b/cpp/src/compat_mode.cpp
@@ -22,6 +22,7 @@
 #include <kvikio/cufile/config.hpp>
 #include <kvikio/error.hpp>
 #include <kvikio/file_handle.hpp>
+#include <kvikio/nvtx.hpp>
 #include <kvikio/shim/cufile.hpp>
 
 namespace kvikio {
@@ -29,6 +30,7 @@ namespace kvikio {
 namespace detail {
 CompatMode parse_compat_mode_str(std::string_view compat_mode_str)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   // Convert to lowercase
   std::string tmp{compat_mode_str};
   std::transform(
@@ -50,6 +52,7 @@ CompatMode parse_compat_mode_str(std::string_view compat_mode_str)
 
 CompatMode CompatModeManager::infer_compat_mode_if_auto(CompatMode compat_mode) noexcept
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   if (compat_mode == CompatMode::AUTO) {
     return is_cufile_available() ? CompatMode::OFF : CompatMode::ON;
   }
@@ -84,6 +87,7 @@ CompatModeManager::CompatModeManager(std::string const& file_path,
                                      CompatMode compat_mode_requested_v,
                                      FileHandle* file_handle)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   KVIKIO_EXPECT(file_handle != nullptr,
                 "The compatibility mode manager does not have a proper owning file handle.",
                 std::invalid_argument);
@@ -127,6 +131,7 @@ CompatModeManager::CompatModeManager(std::string const& file_path,
 
 void CompatModeManager::validate_compat_mode_for_async() const
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   if (!_is_compat_mode_preferred && _is_compat_mode_preferred_for_async &&
       _compat_mode_requested == CompatMode::OFF) {
     std::string err_msg;

--- a/cpp/src/defaults.cpp
+++ b/cpp/src/defaults.cpp
@@ -33,6 +33,7 @@ namespace kvikio {
 template <>
 bool getenv_or(std::string_view env_var_name, bool default_val)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto const* env_val = std::getenv(env_var_name.data());
   if (env_val == nullptr) { return default_val; }
   try {
@@ -66,6 +67,7 @@ bool getenv_or(std::string_view env_var_name, bool default_val)
 template <>
 CompatMode getenv_or(std::string_view env_var_name, CompatMode default_val)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto* env_val = std::getenv(env_var_name.data());
   if (env_val == nullptr) { return default_val; }
   return detail::parse_compat_mode_str(env_val);
@@ -74,6 +76,7 @@ CompatMode getenv_or(std::string_view env_var_name, CompatMode default_val)
 template <>
 std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> default_val)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto* const env_val = std::getenv(env_var_name.data());
   if (env_val == nullptr) { return std::move(default_val); }
   std::string const int_str(env_val);
@@ -84,6 +87,7 @@ std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> defau
 
 unsigned int defaults::get_num_threads_from_env()
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   int const ret = getenv_or("KVIKIO_NTHREADS", 1);
   KVIKIO_EXPECT(ret > 0, "KVIKIO_NTHREADS has to be a positive integer", std::invalid_argument);
   return ret;
@@ -91,6 +95,7 @@ unsigned int defaults::get_num_threads_from_env()
 
 defaults::defaults()
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   // Determine the default value of `compat_mode`
   {
     _compat_mode = getenv_or("KVIKIO_COMPAT_MODE", CompatMode::AUTO);

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -106,7 +106,7 @@ std::size_t FileHandle::read(void* devPtr_base,
                              std::size_t devPtr_offset,
                              bool sync_default_stream)
 {
-  KVIKIO_NVTX_SCOPED_RANGE("FileHandle::read()", size);
+  KVIKIO_NVTX_FUNC_RANGE(size);
   if (get_compat_mode_manager().is_compat_mode_preferred()) {
     return detail::posix_device_read(
       _file_direct_off.fd(), devPtr_base, size, file_offset, devPtr_offset);
@@ -128,7 +128,7 @@ std::size_t FileHandle::write(void const* devPtr_base,
                               std::size_t devPtr_offset,
                               bool sync_default_stream)
 {
-  KVIKIO_NVTX_SCOPED_RANGE("FileHandle::write()", size);
+  KVIKIO_NVTX_FUNC_RANGE(size);
   _nbytes = 0;  // Invalidate the computed file size
 
   if (get_compat_mode_manager().is_compat_mode_preferred()) {
@@ -155,7 +155,7 @@ std::future<std::size_t> FileHandle::pread(void* buf,
                                            bool sync_default_stream)
 {
   auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
-  KVIKIO_NVTX_SCOPED_RANGE("FileHandle::pread()", size, nvtx_color);
+  KVIKIO_NVTX_FUNC_RANGE(size, nvtx_color);
   if (is_host_memory(buf)) {
     auto op = [this](void* hostPtr_base,
                      std::size_t size,
@@ -207,7 +207,7 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
                                             bool sync_default_stream)
 {
   auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
-  KVIKIO_NVTX_SCOPED_RANGE("FileHandle::pwrite()", size, nvtx_color);
+  KVIKIO_NVTX_FUNC_RANGE(size, nvtx_color);
   if (is_host_memory(buf)) {
     auto op = [this](void const* hostPtr_base,
                      std::size_t size,

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -38,6 +38,7 @@ FileHandle::FileHandle(std::string const& file_path,
                        CompatMode compat_mode)
   : _initialized{true}, _compat_mode_manager{file_path, flags, mode, compat_mode, this}
 {
+  KVIKIO_NVTX_FUNC_RANGE();
 }
 
 FileHandle::FileHandle(FileHandle&& o) noexcept
@@ -61,12 +62,17 @@ FileHandle& FileHandle::operator=(FileHandle&& o) noexcept
   return *this;
 }
 
-FileHandle::~FileHandle() noexcept { close(); }
+FileHandle::~FileHandle() noexcept
+{
+  KVIKIO_NVTX_FUNC_RANGE();
+  close();
+}
 
 bool FileHandle::closed() const noexcept { return !_initialized; }
 
 void FileHandle::close() noexcept
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   try {
     if (closed()) { return; }
     _cufile_handle.unregister_handle();
@@ -258,6 +264,7 @@ void FileHandle::read_async(void* devPtr_base,
                             ssize_t* bytes_read_p,
                             CUstream stream)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   get_compat_mode_manager().validate_compat_mode_for_async();
   if (get_compat_mode_manager().is_compat_mode_preferred_for_async()) {
     CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
@@ -277,6 +284,7 @@ void FileHandle::read_async(void* devPtr_base,
 StreamFuture FileHandle::read_async(
   void* devPtr_base, std::size_t size, off_t file_offset, off_t devPtr_offset, CUstream stream)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   StreamFuture ret(devPtr_base, size, file_offset, devPtr_offset, stream);
   auto [devPtr_base_, size_p, file_offset_p, devPtr_offset_p, bytes_read_p, stream_] =
     ret.get_args();
@@ -291,6 +299,7 @@ void FileHandle::write_async(void* devPtr_base,
                              ssize_t* bytes_written_p,
                              CUstream stream)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   get_compat_mode_manager().validate_compat_mode_for_async();
   if (get_compat_mode_manager().is_compat_mode_preferred_for_async()) {
     CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
@@ -310,6 +319,7 @@ void FileHandle::write_async(void* devPtr_base,
 StreamFuture FileHandle::write_async(
   void* devPtr_base, std::size_t size, off_t file_offset, off_t devPtr_offset, CUstream stream)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   StreamFuture ret(devPtr_base, size, file_offset, devPtr_offset, stream);
   auto [devPtr_base_, size_p, file_offset_p, devPtr_offset_p, bytes_written_p, stream_] =
     ret.get_args();

--- a/cpp/src/posix_io.cpp
+++ b/cpp/src/posix_io.cpp
@@ -61,7 +61,7 @@ std::size_t posix_device_read(int fd,
                               std::size_t file_offset,
                               std::size_t devPtr_offset)
 {
-  KVIKIO_NVTX_SCOPED_RANGE("posix_device_read()", size);
+  KVIKIO_NVTX_FUNC_RANGE(size);
   return detail::posix_device_io<IOOperationType::READ>(
     fd, devPtr_base, size, file_offset, devPtr_offset);
 }
@@ -72,7 +72,7 @@ std::size_t posix_device_write(int fd,
                                std::size_t file_offset,
                                std::size_t devPtr_offset)
 {
-  KVIKIO_NVTX_SCOPED_RANGE("posix_device_write()", size);
+  KVIKIO_NVTX_FUNC_RANGE(size);
   return detail::posix_device_io<IOOperationType::WRITE>(
     fd, devPtr_base, size, file_offset, devPtr_offset);
 }

--- a/cpp/src/posix_io.cpp
+++ b/cpp/src/posix_io.cpp
@@ -31,6 +31,7 @@ namespace kvikio::detail {
 
 CUstream StreamsByThread::get(CUcontext ctx, std::thread::id thd_id)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   static StreamsByThread _instance;
 
   // If no current context, we return the null/default stream
@@ -50,6 +51,7 @@ CUstream StreamsByThread::get(CUcontext ctx, std::thread::id thd_id)
 
 CUstream StreamsByThread::get()
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   CUcontext ctx{nullptr};
   CUDA_DRIVER_TRY(cudaAPI::instance().CtxGetCurrent(&ctx));
   return get(ctx, std::this_thread::get_id());

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -309,7 +309,7 @@ std::size_t callback_host_memory(char* data, std::size_t size, std::size_t nmemb
     ctx->overflow_error = true;
     return CURL_WRITEFUNC_ERROR;
   }
-  KVIKIO_NVTX_SCOPED_RANGE("RemoteHandle - callback_host_memory()", nbytes);
+  KVIKIO_NVTX_FUNC_RANGE(nbytes);
   std::memcpy(ctx->buf + ctx->offset, data, nbytes);
   ctx->offset += nbytes;
   return nbytes;
@@ -333,7 +333,7 @@ std::size_t callback_device_memory(char* data, std::size_t size, std::size_t nme
     ctx->overflow_error = true;
     return CURL_WRITEFUNC_ERROR;
   }
-  KVIKIO_NVTX_SCOPED_RANGE("RemoteHandle - callback_device_memory()", nbytes);
+  KVIKIO_NVTX_FUNC_RANGE(nbytes);
 
   ctx->bounce_buffer->write(data, nbytes);
   ctx->offset += nbytes;
@@ -343,7 +343,7 @@ std::size_t callback_device_memory(char* data, std::size_t size, std::size_t nme
 
 std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_offset)
 {
-  KVIKIO_NVTX_SCOPED_RANGE("RemoteHandle::read()", size);
+  KVIKIO_NVTX_FUNC_RANGE(size);
 
   if (file_offset + size > _nbytes) {
     std::stringstream ss;
@@ -395,7 +395,7 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
                                              std::size_t task_size)
 {
   auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
-  KVIKIO_NVTX_SCOPED_RANGE("RemoteHandle::pread()", size);
+  KVIKIO_NVTX_FUNC_RANGE(size);
   auto task = [this](void* devPtr_base,
                      std::size_t size,
                      std::size_t file_offset,

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -60,6 +60,7 @@ class BounceBufferH2D {
       _dev{convert_void2deviceptr(device_buffer)},
       _host_buffer{AllocRetain::instance().get()}
   {
+    KVIKIO_NVTX_FUNC_RANGE();
   }
 
   /**
@@ -67,6 +68,7 @@ class BounceBufferH2D {
    */
   ~BounceBufferH2D() noexcept
   {
+    KVIKIO_NVTX_FUNC_RANGE();
     try {
       flush();
     } catch (CUfileException const& e) {
@@ -85,6 +87,7 @@ class BounceBufferH2D {
    */
   void write_to_device(void const* src, std::size_t size)
   {
+    KVIKIO_NVTX_FUNC_RANGE();
     if (size > 0) {
       CUDA_DRIVER_TRY(cudaAPI::instance().MemcpyHtoDAsync(_dev + _dev_offset, src, size, _stream));
       CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(_stream));
@@ -97,6 +100,7 @@ class BounceBufferH2D {
    */
   void flush()
   {
+    KVIKIO_NVTX_FUNC_RANGE();
     write_to_device(_host_buffer.get(), _host_offset);
     _host_offset = 0;
   }
@@ -112,6 +116,7 @@ class BounceBufferH2D {
    */
   void write(char const* data, std::size_t size)
   {
+    KVIKIO_NVTX_FUNC_RANGE();
     if (_host_buffer.size() - _host_offset < size) {  // Not enough space left in the bounce buffer
       flush();
       assert(_host_offset == 0);
@@ -134,10 +139,15 @@ HttpEndpoint::HttpEndpoint(std::string url) : _url{std::move(url)} {}
 
 std::string HttpEndpoint::str() const { return _url; }
 
-void HttpEndpoint::setopt(CurlHandle& curl) { curl.setopt(CURLOPT_URL, _url.c_str()); }
+void HttpEndpoint::setopt(CurlHandle& curl)
+{
+  KVIKIO_NVTX_FUNC_RANGE();
+  curl.setopt(CURLOPT_URL, _url.c_str());
+}
 
 void S3Endpoint::setopt(CurlHandle& curl)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   curl.setopt(CURLOPT_URL, _url.c_str());
   curl.setopt(CURLOPT_AWS_SIGV4, _aws_sigv4.c_str());
   curl.setopt(CURLOPT_USERPWD, _aws_userpwd.c_str());
@@ -147,6 +157,7 @@ std::string S3Endpoint::unwrap_or_default(std::optional<std::string> aws_arg,
                                           std::string const& env_var,
                                           std::string const& err_msg)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   if (aws_arg.has_value()) { return std::move(*aws_arg); }
 
   char const* env = std::getenv(env_var.c_str());
@@ -162,6 +173,7 @@ std::string S3Endpoint::url_from_bucket_and_object(std::string const& bucket_nam
                                                    std::optional<std::string> const& aws_region,
                                                    std::optional<std::string> aws_endpoint_url)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto const endpoint_url = unwrap_or_default(std::move(aws_endpoint_url), "AWS_ENDPOINT_URL");
   std::stringstream ss;
   if (endpoint_url.empty()) {
@@ -179,6 +191,7 @@ std::string S3Endpoint::url_from_bucket_and_object(std::string const& bucket_nam
 
 std::pair<std::string, std::string> S3Endpoint::parse_s3_url(std::string const& s3_url)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   // Regular expression to match s3://<bucket>/<object>
   std::regex const pattern{R"(^s3://([^/]+)/(.+))", std::regex_constants::icase};
   std::smatch matches;
@@ -193,6 +206,7 @@ S3Endpoint::S3Endpoint(std::string url,
                        std::optional<std::string> aws_secret_access_key)
   : _url{std::move(url)}
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   // Regular expression to match http[s]://
   std::regex pattern{R"(^https?://.*)", std::regex_constants::icase};
   KVIKIO_EXPECT(std::regex_search(_url, pattern),
@@ -243,6 +257,7 @@ S3Endpoint::S3Endpoint(std::string const& bucket_name,
       std::move(aws_access_key),
       std::move(aws_secret_access_key))
 {
+  KVIKIO_NVTX_FUNC_RANGE();
 }
 
 std::string S3Endpoint::str() const { return _url; }
@@ -250,10 +265,12 @@ std::string S3Endpoint::str() const { return _url; }
 RemoteHandle::RemoteHandle(std::unique_ptr<RemoteEndpoint> endpoint, std::size_t nbytes)
   : _endpoint{std::move(endpoint)}, _nbytes{nbytes}
 {
+  KVIKIO_NVTX_FUNC_RANGE();
 }
 
 RemoteHandle::RemoteHandle(std::unique_ptr<RemoteEndpoint> endpoint)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto curl = create_curl_handle();
 
   endpoint->setopt(curl);
@@ -303,6 +320,7 @@ struct CallbackContext {
  */
 std::size_t callback_host_memory(char* data, std::size_t size, std::size_t nmemb, void* context)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto ctx                 = reinterpret_cast<CallbackContext*>(context);
   std::size_t const nbytes = size * nmemb;
   if (ctx->size < ctx->offset + nbytes) {
@@ -327,6 +345,7 @@ std::size_t callback_host_memory(char* data, std::size_t size, std::size_t nmemb
  */
 std::size_t callback_device_memory(char* data, std::size_t size, std::size_t nmemb, void* context)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto ctx                 = reinterpret_cast<CallbackContext*>(context);
   std::size_t const nbytes = size * nmemb;
   if (ctx->size < ctx->offset + nbytes) {

--- a/cpp/src/stream.cpp
+++ b/cpp/src/stream.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include <kvikio/error.hpp>
+#include <kvikio/nvtx.hpp>
 #include <kvikio/shim/cuda.hpp>
 #include <kvikio/shim/cufile.hpp>
 #include <kvikio/stream.hpp>
@@ -32,6 +33,7 @@ StreamFuture::StreamFuture(
   void* devPtr_base, std::size_t size, off_t file_offset, off_t devPtr_offset, CUstream stream)
   : _devPtr_base{devPtr_base}, _stream{stream}
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   // Notice, we allocate the arguments using malloc() as specified in the cuFile docs:
   // <https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html#cufilewriteasync>
   KVIKIO_EXPECT((_val = static_cast<ArgByVal*>(std::malloc(sizeof(ArgByVal)))) != nullptr,
@@ -61,6 +63,7 @@ StreamFuture& StreamFuture::operator=(StreamFuture&& o) noexcept
 
 std::tuple<void*, std::size_t*, off_t*, off_t*, ssize_t*, CUstream> StreamFuture::get_args() const
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   KVIKIO_EXPECT(_val != nullptr, "cannot get arguments from an uninitialized StreamFuture");
 
   return {_devPtr_base,
@@ -73,6 +76,7 @@ std::tuple<void*, std::size_t*, off_t*, off_t*, ssize_t*, CUstream> StreamFuture
 
 std::size_t StreamFuture::check_bytes_done()
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   KVIKIO_EXPECT(_val != nullptr, "cannot check bytes done on an uninitialized StreamFuture");
 
   if (!_stream_synchronized) {
@@ -88,6 +92,7 @@ std::size_t StreamFuture::check_bytes_done()
 
 StreamFuture::~StreamFuture() noexcept
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   if (_val != nullptr) {
     try {
       check_bytes_done();


### PR DESCRIPTION
## Background
Previously, to add NVTX function annotation for profiling, one of the following methods is used:
```cpp
namespace kvikio::detail {
// Method 1
void f() {
    KVIKIO_NVTX_FUNC_RANGE();
}

// Method 2
void f() {
    KVIKIO_NVTX_SCOPED_RANGE("detail::f()", 0);
}
} // end namespace kvikio::detail
```

Method 1 has the limitation that:
- `__func__` is used as the function name, which is unqualified and contains no information on namespace. Function overloads cannot be well handled.
- Users cannot specify NVTX payload or color.
- There is no way to annotate a lambda. Any lambda is simply named `operator()`.

Method 2 has the limitation that:
- Users have to manually enter the function name. Naming inconsistency has been observed across different source files.
- Users have to specify an NVTX payload value.

## This PR
This PR eliminates the limitations above to improve the annotation experience. More concretely:
- `KVIKIO_NVTX_FUNC_RANGE()` now uses fully qualified name with namespace, return type and parameter types. Function overloads can be properly handled.
- `KVIKIO_NVTX_FUNC_RANGE()` now works for lambdas. For example, for a lambda inside a function `kvikio::sample::foo()`, the name of the lambda will be: `kvikio::sample::foo::<lambda()>`
- `KVIKIO_NVTX_FUNC_RANGE()` now accepts two optional parameters: payload and color.
- `KVIKIO_NVTX_SCOPED_RANGE()` now only has one mandatory parameter, which is the message; both the payload and color have become optional.

With the flexible `KVIKIO_NVTX_FUNC_RANGE()` available, **this PR adds additional traces to many functions**.