### PR TITLE
Make page size portable by querying it at runtime

### DIFF
--- a/cpp/include/kvikio/parallel_operation.hpp
+++ b/cpp/include/kvikio/parallel_operation.hpp
@@ -156,7 +156,7 @@ std::future<std::size_t> parallel_io(F op,
                                       decltype(devPtr_offset)>);
 
   // Single-task guard
-  if (task_size >= size || page_size >= size) {
+  if (task_size >= size || get_page_size() >= size) {
     return detail::submit_task(op, buf, size, file_offset, devPtr_offset, call_idx, nvtx_color);
   }
 

--- a/cpp/include/kvikio/utils.hpp
+++ b/cpp/include/kvikio/utils.hpp
@@ -28,8 +28,7 @@
 
 namespace kvikio {
 
-// cuFile defines a page size to 4 KiB
-inline constexpr std::size_t page_size = 4096;
+std::size_t get_page_size();
 
 [[nodiscard]] off_t convert_size2off(std::size_t x);
 

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <unistd.h>
 #include <cstring>
 #include <iostream>
 #include <map>
@@ -27,6 +28,12 @@
 #include <kvikio/utils.hpp>
 
 namespace kvikio {
+
+std::size_t get_page_size()
+{
+  static auto const page_size = static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
+  return page_size;
+}
 
 off_t convert_size2off(std::size_t x)
 {


### PR DESCRIPTION
So far the parameter page size in KvikIO has been a compile-time constant (4K). On GH200, however, the page size is 64K. This PR makes it portable by querying its value at runtime.