### PR TITLE
Add support for temporary AWS credentials to access S3

### DIFF
--- a/cpp/include/kvikio/remote_handle.hpp
+++ b/cpp/include/kvikio/remote_handle.hpp
@@ -30,6 +30,7 @@
 #include <kvikio/error.hpp>
 #include <kvikio/parallel_operation.hpp>
 #include <kvikio/posix_io.hpp>
+#include <kvikio/shim/libcurl.hpp>
 #include <kvikio/utils.hpp>
 
 namespace kvikio {
@@ -92,6 +93,8 @@ class S3Endpoint : public RemoteEndpoint {
   std::string _url;
   std::string _aws_sigv4;
   std::string _aws_userpwd;
+  std::string _aws_token;
+  struct curl_slist *_curl_header_list;
 
   /**
    * @brief Unwrap an optional parameter, obtaining a default from the environment.


### PR DESCRIPTION
This PR adds the `x-amz-security-token` header which is needed when using temporary credentials (These start with `ASIA`). According to the [curl docs](https://curl.se/libcurl/c/CURLOPT_HTTPHEADER.html), the list of headers needs to be freed after use, but `S3Endpoint` currently doesn't have a destructor so I'm not sure what to do with that.
I hope this is useful for others too, looking forward to any comments!