### PR TITLE
refactor(wheels): vendor nvcomp as temporary workaround

### DIFF
--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -25,13 +25,12 @@ rapids-pip-retry install \
 # 0 really means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/5735)
 export PIP_NO_BUILD_ISOLATION=0
 
-export SKBUILD_CMAKE_ARGS="-DUSE_NVCOMP_RUNTIME_WHEEL=ON"
+export SKBUILD_CMAKE_ARGS="-DBUILD_SHARED_LIBS=ON;-DUSE_NVCOMP_RUNTIME_WHEEL=OFF;-DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE;-DCUDA_STATIC_RUNTIME=ON"
 ./ci/build_wheel.sh "${package_name}" "${package_dir}"
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 python -m auditwheel repair \
-    --exclude libnvcomp.so.4 \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     ${package_dir}/dist/*
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,7 +66,9 @@ files:
       table: project
     includes:
       - depends_on_cupy
-      - depends_on_nvcomp
+      # TODO: restore runtime dependency when we no longer vender nvcomp (when
+      # nvcomp supports Python 3.13)
+      # - depends_on_nvcomp
       - depends_on_libkvikio
       - run
   py_rapids_build_libkvikio:

--- a/python/libkvikio/CMakeLists.txt
+++ b/python/libkvikio/CMakeLists.txt
@@ -41,7 +41,17 @@ set(KvikIO_BUILD_EXAMPLES OFF)
 set(KvikIO_BUILD_TESTS OFF)
 if(USE_NVCOMP_RUNTIME_WHEEL)
   set(KvikIO_EXPORT_NVCOMP OFF)
+else()
+  # vendor nvcomp but not the entire kvikio-export set because that's huge
+  include(cmake/thirdparty/get_nvcomp.cmake)
+  include(cmake/Modules/WheelHelpers.cmake)
+  # Set the output directory so libnvcomp.so ends up in the right place
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${SKBUILD_PLATLIB_DIR}/libkvikio/lib64/)
+  install_aliased_imported_targets(
+    TARGETS nvcomp::nvcomp DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+  )
 endif()
+
 set(CUDA_STATIC_RUNTIME ON)
 
 add_subdirectory(../../cpp kvikio-cpp)

--- a/python/libkvikio/cmake/Modules/WheelHelpers.cmake
+++ b/python/libkvikio/cmake/Modules/WheelHelpers.cmake
@@ -1,0 +1,59 @@
+# =============================================================================
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+include_guard(GLOBAL)
+
+# Making libraries available inside wheels by installing the associated targets.
+function(install_aliased_imported_targets)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "install_aliased_imported_targets")
+
+  set(options "")
+  set(one_value "DESTINATION")
+  set(multi_value "TARGETS")
+  cmake_parse_arguments(_ "${options}" "${one_value}" "${multi_value}" ${ARGN})
+
+  message(VERBOSE "Installing targets '${__TARGETS}' into lib_dir '${__DESTINATION}'")
+
+  foreach(target IN LISTS __TARGETS)
+
+    if(NOT TARGET ${target})
+      message(VERBOSE "No target named ${target}")
+      continue()
+    endif()
+
+    get_target_property(alias_target ${target} ALIASED_TARGET)
+    if(alias_target)
+      set(target ${alias_target})
+    endif()
+
+    get_target_property(is_imported ${target} IMPORTED)
+    if(NOT is_imported)
+      # If the target isn't imported, install it into the wheel
+      install(TARGETS ${target} DESTINATION ${__DESTINATION})
+      message(VERBOSE "install(TARGETS ${target} DESTINATION ${__DESTINATION})")
+    else()
+      # If the target is imported, make sure it's global
+      get_target_property(type ${target} TYPE)
+      if(${type} STREQUAL "UNKNOWN_LIBRARY")
+        install(FILES $<TARGET_FILE:${target}> DESTINATION ${__DESTINATION})
+        message(VERBOSE "install(FILES $<TARGET_FILE:${target}> DESTINATION ${__DESTINATION})")
+      else()
+        install(IMPORTED_RUNTIME_ARTIFACTS ${target} DESTINATION ${__DESTINATION})
+        message(
+          VERBOSE
+          "install(IMPORTED_RUNTIME_ARTIFACTS $<TARGET_FILE:${target}> DESTINATION ${__DESTINATION})"
+        )
+      endif()
+    endif()
+  endforeach()
+endfunction()

--- a/python/libkvikio/cmake/thirdparty/get_nvcomp.cmake
+++ b/python/libkvikio/cmake/thirdparty/get_nvcomp.cmake
@@ -1,0 +1,35 @@
+# =============================================================================
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+set(KVIKIO_USE_PROPRIETARY_BINARY ON)
+
+# This function finds nvcomp and sets any additional necessary environment variables.
+function(find_and_configure_nvcomp)
+
+  include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
+  set(export_args)
+  if(KvikIO_EXPORT_NVCOMP)
+    # We're vendoring nvcomp and we only want `libnvcomp.so.4`
+    set(export_args BUILD_EXPORT_SET nvcomp)
+  endif()
+
+  rapids_cpm_nvcomp(${export_args} USE_PROPRIETARY_BINARY ${KVIKIO_USE_PROPRIETARY_BINARY})
+
+  # Per-thread default stream
+  if(TARGET nvcomp AND PER_THREAD_DEFAULT_STREAM)
+    target_compile_definitions(nvcomp PRIVATE CUDA_API_PER_THREAD_DEFAULT_STREAM)
+  endif()
+endfunction()
+
+find_and_configure_nvcomp()

--- a/python/libkvikio/pyproject.toml
+++ b/python/libkvikio/pyproject.toml
@@ -66,4 +66,5 @@ select = [
 ]
 
 # PyPI limit is 100 MiB, fail CI before we get too close to that
-max_allowed_size_compressed = '75M'
+# TODO: drop this to 75M after we re-de-vendor nvcomp
+max_allowed_size_compressed = '90M'


### PR DESCRIPTION
xref rapidsai/build-planning#120

RAPIDS is blocked on Python 3.13 support because there is no `nvcomp` release that (yet) supports Python 3.13.

This is a temporary (and wacky) workaround that re-vendors `nvcomp` into
`libkvikio` and removes the runtime dependency on the `nvcomp` wheel, removing
with it the block on Python 3.13.

Once there's an updated `nvcomp` release, we can undo this.

Notes:

I am no kind of CMake expert, and I'm sure this can be done better.

Using `kvikio-exports` as the `BUILD_EXPORT_SET` is no good because it installs
3+ copies of the same 100mb shared object and balloons the size of the wheel.
There are _two_ copies of `libnvcomp.so` as it stands, but they compress down
well enough.  If anyone has any pointers on removing the remaining `so`, I'm
all ears.  I know it's possible because the `nvcomp` wheel only has a single
`libnvcomp.so.4`, but also, this is a temporary patch and it's good enough.

I've added in the `WheelHelpers.cmake` module because it does what I want, but
if there's something simpler, we can try that, too.
