### PR TITLE
Fix benchmark code on MIG

### DIFF
--- a/python/kvikio/kvikio/benchmarks/utils.py
+++ b/python/kvikio/kvikio/benchmarks/utils.py
@@ -45,12 +45,11 @@ def pprint_sys_info() -> None:
             dev = pynvml.nvmlDeviceGetHandleByIndex(0)
 
         if dev is not None:
-            is_mig = False
-            with contextlib.suppress(pynvml.NVMLError):
+            try:
                 pynvml.nvmlDeviceGetMigMode(dev)
-                is_mig = True
-
-            if not is_mig:
+            except pynvml.NVMLError:
+                pass
+            else:
                 with contextlib.suppress(pynvml.NVMLError):
                     gpu_name = f"{pynvml.nvmlDeviceGetName(dev)} (dev #0)"
                     mem_total = format_bytes(pynvml.nvmlDeviceGetMemoryInfo(dev).total)

--- a/python/kvikio/kvikio/benchmarks/utils.py
+++ b/python/kvikio/kvikio/benchmarks/utils.py
@@ -45,11 +45,12 @@ def pprint_sys_info() -> None:
             dev = pynvml.nvmlDeviceGetHandleByIndex(0)
 
         if dev is not None:
-            try:
+            is_mig = False
+            with contextlib.suppress(pynvml.NVMLError):
                 pynvml.nvmlDeviceGetMigMode(dev)
-            except pynvml.NVMLError:
-                pass
-            else:
+                is_mig = True
+
+            if not is_mig:
                 with contextlib.suppress(pynvml.NVMLError):
                     gpu_name = f"{pynvml.nvmlDeviceGetName(dev)} (dev #0)"
                     mem_total = format_bytes(pynvml.nvmlDeviceGetMemoryInfo(dev).total)

--- a/python/kvikio/kvikio/benchmarks/utils.py
+++ b/python/kvikio/kvikio/benchmarks/utils.py
@@ -45,12 +45,9 @@ def pprint_sys_info() -> None:
             dev = pynvml.nvmlDeviceGetHandleByIndex(0)
 
         if dev is not None:
-            is_mig = False
-            with contextlib.suppress(pynvml.NVMLError):
+            try:
                 pynvml.nvmlDeviceGetMigMode(dev)
-                is_mig = True
-
-            if not is_mig:
+            except pynvml.NVMLError:
                 with contextlib.suppress(pynvml.NVMLError):
                     gpu_name = f"{pynvml.nvmlDeviceGetName(dev)} (dev #0)"
                     mem_total = format_bytes(pynvml.nvmlDeviceGetMemoryInfo(dev).total)


### PR DESCRIPTION
In UCX-Py and UCXX, we skip querying memory info on MIG devices as the approach we use on other hardware doesn't work for MIG. However KvikIO did not skip querying memory info on MIG, which causes this code to fail there.

To fix this issue, we adapt the approach used in UCX-Py and UCXX to KvikIO, which allows this code to run on MIG.

Additionally the code used one `try...except...` to handle everything from `import`ing to querying the device. With the MIG check too, this becomes kind of unwieldy for one `try...except...`. So this moves the `import` to the top-level and breaks up the `try...except...`. This makes the logic of the code and the cases it handles a bit more legible to readers 

Fixes https://github.com/rapidsai/kvikio/issues/701