### PR TITLE
Add the feature to check page cache residency information for a file

### DIFF
--- a/cpp/include/kvikio/file_utils.hpp
+++ b/cpp/include/kvikio/file_utils.hpp
@@ -162,4 +162,22 @@ int open_fd(std::string const& file_path, std::string const& flags, bool o_direc
  */
 [[nodiscard]] std::size_t get_file_size(int file_descriptor);
 
+/**
+ * @brief Obtain the page cache residency information for a given file
+ *
+ * @param file_path Path to a file.
+ * @return A pair containing the number of pages resident in the page cache and the total number of
+ * pages.
+ */
+std::pair<std::size_t, std::size_t> get_page_cache_info(std::string const& file_path);
+
+/**
+ * @brief Obtain the page cache residency information for a given file
+ *
+ * @param fd File descriptor.
+ * @return A pair containing the number of pages resident in the page cache and the total number of
+ * pages.
+ * @sa `get_page_cache_info(std::string const&)` overload.
+ */
+std::pair<std::size_t, std::size_t> get_page_cache_info(int fd);
 }  // namespace kvikio

--- a/cpp/src/file_utils.cpp
+++ b/cpp/src/file_utils.cpp
@@ -198,7 +198,10 @@ std::pair<std::size_t, std::size_t> get_page_cache_info(int fd)
   SYSCALL_CHECK(mincore(addr, file_size, is_in_page_cache.data()));
   std::size_t num_pages_in_page_cache{0u};
   for (std::size_t page_idx = 0; page_idx < is_in_page_cache.size(); ++page_idx) {
-    if (static_cast<int>(is_in_page_cache[page_idx])) { ++num_pages_in_page_cache; }
+    // The least significant bit of each byte will be set if the corresponding page is currently
+    // resident in memory, and be clear otherwise. The settings of the other bits in each byte are
+    // undefined
+    if (static_cast<int>(is_in_page_cache[page_idx]) & 0x1) { ++num_pages_in_page_cache; }
   }
 
   SYSCALL_CHECK(munmap(addr, file_size));

--- a/cpp/src/file_utils.cpp
+++ b/cpp/src/file_utils.cpp
@@ -176,6 +176,7 @@ int open_fd(std::string const& file_path, std::string const& flags, bool o_direc
 
 std::pair<std::size_t, std::size_t> get_page_cache_info(std::string const& file_path)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   std::string const flags{"r"};
   bool const o_direct{false};
   mode_t const mode{FileHandle::m644};
@@ -187,6 +188,7 @@ std::pair<std::size_t, std::size_t> get_page_cache_info(std::string const& file_
 
 std::pair<std::size_t, std::size_t> get_page_cache_info(int fd)
 {
+  KVIKIO_NVTX_FUNC_RANGE();
   auto file_size = get_file_size(fd);
 
   std::size_t offset{0u};

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -28,7 +28,6 @@
 #include <kvikio/utils.hpp>
 
 namespace kvikio {
-
 std::size_t get_page_size()
 {
   static auto const page_size = static_cast<std::size_t>(sysconf(_SC_PAGESIZE));

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -28,6 +28,7 @@
 #include <kvikio/utils.hpp>
 
 namespace kvikio {
+
 std::size_t get_page_size()
 {
   static auto const page_size = static_cast<std::size_t>(sysconf(_SC_PAGESIZE));

--- a/python/kvikio/kvikio/__init__.py
+++ b/python/kvikio/kvikio/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 # If libkvikio was installed as a wheel, we must request it to load the library symbols.
@@ -14,13 +14,14 @@ else:
 
 from kvikio._lib.defaults import CompatMode  # noqa: F401
 from kvikio._version import __git_commit__, __version__
-from kvikio.cufile import CuFile
+from kvikio.cufile import CuFile, get_page_cache_info
 from kvikio.remote_file import RemoteFile, is_remote_file_available
 
 __all__ = [
     "__git_commit__",
     "__version__",
     "CuFile",
+    "get_page_cache_info",
     "RemoteFile",
     "is_remote_file_available",
 ]

--- a/python/kvikio/kvikio/_lib/file_handle.pyx
+++ b/python/kvikio/kvikio/_lib/file_handle.pyx
@@ -178,7 +178,7 @@ cdef class CuFile:
             stream,
         ))
 
-cdef extern from "<kvikio/file_utils.hpp>" namespace "kvikio" nogil:
+cdef extern from "<kvikio/file_utils.hpp>" nogil:
     pair[size_t, size_t] cpp_get_page_cache_info_str \
         "kvikio::get_page_cache_info"(string file_path) except +
 

--- a/python/kvikio/kvikio/_lib/file_handle.pyx
+++ b/python/kvikio/kvikio/_lib/file_handle.pyx
@@ -1,11 +1,13 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 # distutils: language = c++
 # cython: language_level=3
 
+import io
+import os
 import pathlib
-from typing import Optional
+from typing import Optional, Union
 
 from posix cimport fcntl
 
@@ -175,3 +177,28 @@ cdef class CuFile:
             dev_offset,
             stream,
         ))
+
+cdef extern from "<kvikio/file_utils.hpp>" namespace "kvikio" nogil:
+    pair[size_t, size_t] cpp_get_page_cache_info_str \
+        "kvikio::get_page_cache_info"(string file_path) except +
+
+    pair[size_t, size_t] cpp_get_page_cache_info_int \
+        "kvikio::get_page_cache_info"(int fd) except +
+
+
+def get_page_cache_info(file: Union[os.PathLike, str, int, io.IOBase]) \
+        -> tuple[int, int]:
+    if isinstance(file, os.PathLike) or isinstance(file, str):
+        # file is a path or a string object
+        path_bytes = str(pathlib.Path(file)).encode()
+        return cpp_get_page_cache_info_str(path_bytes)
+    elif isinstance(file, int):
+        # file is a file descriptor
+        return cpp_get_page_cache_info_int(file)
+    elif isinstance(file, io.IOBase):
+        # file is a file object
+        # pass its file descriptor to the underlying C++ function
+        return cpp_get_page_cache_info_int(file.fileno())
+    else:
+        raise ValueError("The type of `file` must be `os.PathLike`, `str`, `int`, "
+                         "or `io.IOBase`")

--- a/python/kvikio/kvikio/cufile.py
+++ b/python/kvikio/kvikio/cufile.py
@@ -1,6 +1,8 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
+import io
+import os
 import pathlib
 from typing import Optional, Union
 
@@ -430,3 +432,29 @@ class CuFile:
         to be a multiple of 4096 bytes. When GDS isn't used, this is less critical.
         """
         return self._handle.write(buf, size, file_offset, dev_offset)
+
+
+def get_page_cache_info(
+    file: Union[os.PathLike, str, int, io.IOBase]
+) -> tuple[int, int]:
+    """Obtain the page cache residency information for a given file
+
+    Example:
+
+    .. code-block:: python
+
+       num_pages_in_page_cache, num_pages = kvikio.get_page_cache_info(my_file)
+       percent_in_page_cache = num_pages_in_page_cache / num_pages
+
+    Parameters
+    ----------
+    file: a path-like object, or string, or file descriptor, or file object
+        File to check.
+
+    Returns
+    -------
+    tuple[int, int]
+        A pair containing the number of pages resident in the page cache
+        and the total number of pages.
+    """
+    return file_handle.get_page_cache_info(file)


### PR DESCRIPTION
This PR provides a utility function `get_page_cache_info(file)` in C++ and Python to check how many pages of a file are resident in the page cache of the Linux kernel.

This PR is a byproduct of a recent investigation of an issue on GH200 system, where the sudo command that drops the page cache doesn't seem to achieve the expected effect.

This feature is functionally similar to the Linux utility program `fincore`, which is also based on the system call `mincore` used in this PR.