### PR TITLE
Update to clang 20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
               ]
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v20.1.4
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]

--- a/cpp/src/file_utils.cpp
+++ b/cpp/src/file_utils.cpp
@@ -168,7 +168,7 @@ int open_fd(std::string const& file_path, std::string const& flags, bool o_direc
 [[nodiscard]] std::size_t get_file_size(int file_descriptor)
 {
   KVIKIO_NVTX_FUNC_RANGE();
-  struct stat st {};
+  struct stat st{};
   int ret = fstat(file_descriptor, &st);
   SYSCALL_CHECK(ret, "Unable to query file size.");
   return static_cast<std::size_t>(st.st_size);

--- a/cpp/src/shim/utils.cpp
+++ b/cpp/src/shim/utils.cpp
@@ -50,7 +50,7 @@ void* load_library(std::vector<std::string> const& names, int mode)
 bool is_running_in_wsl() noexcept
 {
   try {
-    struct utsname buf {};
+    struct utsname buf{};
     int err = ::uname(&buf);
     if (err == 0) {
       std::string const name(static_cast<char*>(buf.release));


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/177

This PR updates the clang version to 20.
