### PR TITLE
Fix doc build error

### DIFF
--- a/python/kvikio/kvikio/utils.py
+++ b/python/kvikio/kvikio/utils.py
@@ -166,7 +166,7 @@ def kvikio_deprecation_notice(
         # Allow the docstring to be correctly generated for the decorated func in Sphinx
         func_doc = getattr(func, "__doc__")
         valid_docstring = "" if func_doc is None else func_doc
-        wrapper.__doc__ = "{:} {:} {:}\n\n    {:}".format(
+        wrapper.__doc__ = "{:} {:} {:}\n\n{:}".format(
             ".. deprecated::", since, msg, valid_docstring
         )
 


### PR DESCRIPTION
This PR fixes a doc build error by removing unnecessary indentations from the docstring.

The current doc build error in the CI:
> /opt/conda/envs/docs/lib/python3.13/site-packages/kvikio/utils.py:docstring of kvikio.utils.kvikio_deprecation_notice.<locals>.decorator.<locals>.wrapper:5: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]

is caused by the extra indentation, for instance, to the left of `Reset the default task size ...`
```
.. deprecated:: 25.04 Use :meth:`kvikio.defaults.set()` instead.

    Reset the default task size used for parallel IO operations.

Parameters
----------
nbytes : int
    The default task size in bytes.

```