### PR TITLE
Check whether memory resource/BAR1 are supported

### DIFF
--- a/python/kvikio/kvikio/benchmarks/utils.py
+++ b/python/kvikio/kvikio/benchmarks/utils.py
@@ -45,15 +45,15 @@ def pprint_sys_info() -> None:
             dev = pynvml.nvmlDeviceGetHandleByIndex(0)
 
         if dev is not None:
+            gpu_name = f"{pynvml.nvmlDeviceGetName(dev)} (dev #0)"
             try:
-                pynvml.nvmlDeviceGetMigMode(dev)
-            except pynvml.NVMLError:
-                with contextlib.suppress(pynvml.NVMLError):
-                    gpu_name = f"{pynvml.nvmlDeviceGetName(dev)} (dev #0)"
-                    mem_total = format_bytes(pynvml.nvmlDeviceGetMemoryInfo(dev).total)
-                    bar1_total = format_bytes(
-                        pynvml.nvmlDeviceGetBAR1MemoryInfo(dev).bar1Total
-                    )
+                mem_total = format_bytes(pynvml.nvmlDeviceGetMemoryInfo(dev).total)
+            except pynvml.NVMLError_NotSupported:
+                mem_total = "Device has no memory resource"
+            try:
+                bar1_total = pynvml.nvmlDeviceGetBAR1MemoryInfo(handle).bar1Total
+            except pynvml.NVMLError_NotSupported:
+                bar1_total = "Device has no BAR1 support"
 
     if version == (0, 0):
         libcufile_version = "unknown (earlier than cuFile 1.8)"


### PR DESCRIPTION
After further discussions with @jakirkham, we believe this is a more appropriate way to determine whether the device has a memory resource (i.e., dedicated memory) than relying on MIG-related checks as done previously in https://github.com/rapidsai/kvikio/pull/703, this will also align more to https://github.com/rapidsai/ucxx/pull/424. Additionally, check that BAR1 is supported and report appropriately.