### PR TITLE
Add an overload getenv_or that supports env var alias. Add new env var KVIKIO_NUM_THREADS. Fix UB.

### DIFF
--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -62,7 +62,7 @@ std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> defau
  * @brief Get the environment variable value from a candidate list
  *
  * @tparam T Type of the environment variable value
- * @param env_var_names Name of the environment variable
+ * @param env_var_names Candidate list containing the names of environment variable
  * @param default_val Default value of the environment variable, if none of the candidates has been
  * found
  * @return A tuple of (`env_var_name`, `result`, `has_found`), where:
@@ -73,10 +73,8 @@ std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> defau
  *
  * @throws std::invalid_argument if:
  *   - `env_var_names` is empty
- *   - An environment variable from `env_var_names` has an empty value, e.g. by setting `export
- * KVIKIO_NTHREADS=`
  *   - Multiple candidates have been set at the same time
- *   - An invalid value is given
+ *   - An invalid value is given, e.g. value that cannot be converted to type T
  */
 template <typename T>
 std::tuple<std::string_view, T, bool> getenv_or(

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -92,9 +92,6 @@ std::tuple<std::string_view, T, bool> getenv_or(
   for (auto const& env_var_name : env_var_names) {
     auto const* env_val = std::getenv(env_var_name.data());
     if (env_val == nullptr) { continue; }
-    KVIKIO_EXPECT(std::strlen(env_val) != 0,
-                  std::string{env_var_name} + " must not have an empty value.",
-                  std::invalid_argument);
     KVIKIO_EXPECT(
       has_already_been_set == false,
       "Environment variable " + std::string{env_var_name} + " has already been set by its alias.",
@@ -104,15 +101,9 @@ std::tuple<std::string_view, T, bool> getenv_or(
     env_val_target       = env_val;
   }
 
-  if (env_val_target.empty()) { return {env_val_target, default_val, false}; }
+  if (env_name_target.empty()) { return {env_name_target, default_val, false}; }
 
-  std::stringstream sstream(env_val_target.data());
-  T res;
-  sstream >> res;
-  KVIKIO_EXPECT(
-    !sstream.fail(),
-    std::string{"Unknown config value "} + env_name_target.data() + "=" + env_val_target.data(),
-    std::invalid_argument);
+  auto res = getenv_or<T>(env_name_target, default_val);
   return {env_name_target, res, true};
 }
 

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -63,18 +63,19 @@ std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> defau
  *
  * @tparam T Type of the environment variable value
  * @param env_var_names Name of the environment variable
- * @param default_val Default value of the environment variable, if none of the alias has been found
+ * @param default_val Default value of the environment variable, if none of the candidates has been
+ * found
  * @return A tuple of (`env_var_name`, `result`, `has_found`), where:
- *   - If the environment variable is not set by any of the alias, `has_found` is false, and
- * `result` is the `default_val`.
- *   - If the environment variable is set by `env_var_name`, `has_found` is true, and `result` is
- * the set value.
+ *   - If the environment variable is not set by any of the candidates, `has_found` will be false,
+ * `result` be `default_val`, and `env_var_name` be empty.
+ *   - If the environment variable is set by `env_var_name`, then `has_found` will be true, and
+ * `result` be the set value.
  *
  * @throws std::invalid_argument if:
  *   - `env_var_names` is empty
  *   - An environment variable from `env_var_names` has an empty value, e.g. by setting `export
  * KVIKIO_NTHREADS=`
- *   - Multiple alias have been set
+ *   - Multiple candidates have been set at the same time
  *   - An invalid value is given
  */
 template <typename T>
@@ -94,10 +95,10 @@ std::tuple<std::string_view, T, bool> getenv_or(
     KVIKIO_EXPECT(std::strlen(env_val) != 0,
                   std::string{env_var_name} + " must not have an empty value.",
                   std::invalid_argument);
-    KVIKIO_EXPECT(has_already_been_set == false,
-                  "Environment variable " + std::string{env_var_name} +
-                    " has already been set using its alias.",
-                  std::invalid_argument);
+    KVIKIO_EXPECT(
+      has_already_been_set == false,
+      "Environment variable " + std::string{env_var_name} + " has already been set by its alias.",
+      std::invalid_argument);
     has_already_been_set = true;
     env_name_target      = env_var_name;
     env_val_target       = env_val;

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -69,11 +69,12 @@ std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> defau
  *   - If the environment variable is not set by any of the candidates, `has_found` will be false,
  * `result` be `default_val`, and `env_var_name` be empty.
  *   - If the environment variable is set by `env_var_name`, then `has_found` will be true, and
- * `result` be the set value.
+ * `result` be the set value. If more than one candidates have been set with the same value,
+ * `env_var_name` will be assigned the last candidate.
  *
  * @throws std::invalid_argument if:
  *   - `env_var_names` is empty
- *   - Multiple candidates have been set at the same time
+ *   - More than one candidates have been set with different values
  *   - An invalid value is given, e.g. value that cannot be converted to type T
  */
 template <typename T>

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -72,7 +72,7 @@ std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> defau
  * found
  * @return A tuple of (`env_var_name`, `result`, `has_found`), where:
  *   - If the environment variable is not set by any of the candidates, `has_found` will be false,
- * `result` be `default_val`, and `env_var_name` be empty.
+ * `result` will be `default_val`, and `env_var_name` will be empty.
  *   - If the environment variable is set by `env_var_name`, then `has_found` will be true, and
  * `result` be the set value. If more than one candidates have been set with the same value,
  * `env_var_name` will be assigned the last candidate.

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -24,10 +24,10 @@
 #include <string>
 
 #include <kvikio/compat_mode.hpp>
+#include <kvikio/error.hpp>
 #include <kvikio/http_status_codes.hpp>
 #include <kvikio/shim/cufile.hpp>
 #include <kvikio/threadpool_wrapper.hpp>
-#include "kvikio/error.hpp"
 
 /**
  * @brief KvikIO namespace.

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -59,16 +59,23 @@ template <>
 std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> default_val);
 
 /**
- * @brief
+ * @brief Get the environment variable value from a candidate list
  *
- * @tparam T
- * @param env_var_names
- * @param default_val
+ * @tparam T Type of the environment variable value
+ * @param env_var_names Name of the environment variable
+ * @param default_val Default value of the environment variable, if none of the alias has been found
  * @return A tuple of (`env_var_name`, `result`, `has_found`), where:
  *   - If the environment variable is not set by any of the alias, `has_found` is false, and
  * `result` is the `default_val`.
  *   - If the environment variable is set by `env_var_name`, `has_found` is true, and `result` is
  * the set value.
+ *
+ * @throws std::invalid_argument if:
+ *   - `env_var_names` is empty
+ *   - An environment variable from `env_var_names` has an empty value, e.g. by setting `export
+ * KVIKIO_NTHREADS=`
+ *   - Multiple alias have been set
+ *   - An invalid value is given
  */
 template <typename T>
 std::tuple<std::string_view, T, bool> getenv_or(

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -79,8 +79,8 @@ std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> defau
  *
  * @throws std::invalid_argument if:
  *   - `env_var_names` is empty.
- *   - The environment variable is not defined to be string type and is set to an empty value. In
- *     other words, string-type environment variables are allowed to hold an empty value.
+ *   - The environment variable is not defined to be string type and is assigned an empty value (in
+ *     other words, string-type environment variables are allowed to hold an empty value).
  *   - More than one candidates have been set with different values.
  *   - An invalid value is given, e.g. value that cannot be converted to type T.
  */

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -82,7 +82,6 @@ template <typename T>
 std::tuple<std::string_view, T, bool> getenv_or(
   std::initializer_list<std::string_view> env_var_names, T default_val)
 {
-  KVIKIO_NVTX_FUNC_RANGE();
   KVIKIO_EXPECT(env_var_names.size() > 0,
                 "`env_var_names` must contain at least one environment variable name.",
                 std::invalid_argument);
@@ -93,7 +92,7 @@ std::tuple<std::string_view, T, bool> getenv_or(
     auto const* env_val = std::getenv(env_var_name.data());
     if (env_val == nullptr) { continue; }
     KVIKIO_EXPECT(
-      has_already_been_set == false,
+      !has_already_been_set,
       "Environment variable " + std::string{env_var_name} + " has already been set by its alias.",
       std::invalid_argument);
     has_already_been_set = true;

--- a/cpp/src/defaults.cpp
+++ b/cpp/src/defaults.cpp
@@ -28,6 +28,7 @@
 #include <kvikio/error.hpp>
 #include <kvikio/http_status_codes.hpp>
 #include <kvikio/shim/cufile.hpp>
+#include <string_view>
 
 namespace kvikio {
 template <>
@@ -88,9 +89,13 @@ std::vector<int> getenv_or(std::string_view env_var_name, std::vector<int> defau
 unsigned int defaults::get_num_threads_from_env()
 {
   KVIKIO_NVTX_FUNC_RANGE();
-  int const ret = getenv_or("KVIKIO_NTHREADS", 1);
-  KVIKIO_EXPECT(ret > 0, "KVIKIO_NTHREADS has to be a positive integer", std::invalid_argument);
-  return ret;
+
+  auto const [env_var_name, num_threads, _] =
+    getenv_or({"KVIKIO_NTHREADS", "KVIKIO_NUM_THREADS"}, 1);
+  KVIKIO_EXPECT(num_threads > 0,
+                std::string{env_var_name} + " has to be a positive integer",
+                std::invalid_argument);
+  return num_threads;
 }
 
 defaults::defaults()
@@ -182,6 +187,10 @@ void defaults::set_thread_pool_nthreads(unsigned int nthreads)
     nthreads > 0, "number of threads must be a positive integer", std::invalid_argument);
   thread_pool().reset(nthreads);
 }
+
+unsigned int defaults::num_threads() { return thread_pool_nthreads(); }
+
+void defaults::set_num_threads(unsigned int nthreads) { set_thread_pool_nthreads(nthreads); }
 
 std::size_t defaults::task_size() { return instance()->_task_size; }
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -72,7 +72,7 @@ endfunction()
 
 kvikio_add_test(NAME BASIC_IO_TEST SOURCES test_basic_io.cpp)
 
-kvikio_add_test(NAME DEFAULTS_TEST SOURCES test_defaults.cpp)
+kvikio_add_test(NAME DEFAULTS_TEST SOURCES test_defaults.cpp utils/env.cpp)
 
 kvikio_add_test(NAME ERROR_TEST SOURCES test_error.cpp)
 

--- a/cpp/tests/test_defaults.cpp
+++ b/cpp/tests/test_defaults.cpp
@@ -100,10 +100,9 @@ TEST(DefaultsTest, alias_for_getenv_or)
   {
     kvikio::test::EnvVarContext env_var_ctx{
       {{"KVIKIO_TEST_ALIAS_1", "10"}, {"KVIKIO_TEST_ALIAS_2", "20"}}};
-    EXPECT_THAT(
-      [=] { kvikio::getenv_or({"KVIKIO_TEST_ALIAS_1", "KVIKIO_TEST_ALIAS_2"}, 123); },
-      ThrowsMessage<std::invalid_argument>(HasSubstr(
-        "Environment variable KVIKIO_TEST_ALIAS_2 has already been set using its alias")));
+    EXPECT_THAT([=] { kvikio::getenv_or({"KVIKIO_TEST_ALIAS_1", "KVIKIO_TEST_ALIAS_2"}, 123); },
+                ThrowsMessage<std::invalid_argument>(HasSubstr(
+                  "Environment variable KVIKIO_TEST_ALIAS_2 has already been set by its alias")));
   }
 
   // Env var has invalid value

--- a/cpp/tests/utils/env.cpp
+++ b/cpp/tests/utils/env.cpp
@@ -23,21 +23,22 @@
 
 namespace kvikio::test {
 EnvVarContext::EnvVarContext(
-  std::initializer_list<std::pair<std::string, std::string>> env_var_entries)
+  std::initializer_list<std::pair<std::string_view, std::string_view>> env_var_entries)
 {
   for (auto const& [key, current_value] : env_var_entries) {
     EnvVarState env_var_state;
-    if (auto const res = std::getenv(key.c_str()); res != nullptr) {
+    if (auto const res = std::getenv(key.data()); res != nullptr) {
       env_var_state.existed_before = true;
       env_var_state.previous_value = res;
     }
-    SYSCALL_CHECK(setenv(key.c_str(), current_value.c_str(), 1 /* allow overwrite */));
-    if (_env_var_map.find(key) != _env_var_map.end()) {
+    SYSCALL_CHECK(setenv(key.data(), current_value.data(), 1 /* allow overwrite */));
+    std::string key_str{key};
+    if (_env_var_map.find(key_str) != _env_var_map.end()) {
       std::stringstream ss;
       ss << "Environment variable " << key << " has already been set in this context.";
       KVIKIO_FAIL(ss.str());
     }
-    _env_var_map.insert({key, std::move(env_var_state)});
+    _env_var_map.insert({std::move(key_str), std::move(env_var_state)});
   }
 }
 

--- a/cpp/tests/utils/env.hpp
+++ b/cpp/tests/utils/env.hpp
@@ -45,7 +45,8 @@ class EnvVarContext {
    * @param env_var_entries User-specified environment variables. Each entry includes the variable
    * name and value.
    */
-  EnvVarContext(std::initializer_list<std::pair<std::string, std::string>> env_var_entries);
+  EnvVarContext(
+    std::initializer_list<std::pair<std::string_view, std::string_view>> env_var_entries);
 
   /**
    * @brief Restore the environment variables to previous values


### PR DESCRIPTION
This PR performs the following items:
- Add a new overload `kvikio::getenv_or` that supports env var alias, i.e. multiple different env vars referring to the same property.
- Add new env var `KVIKIO_NUM_THREADS` as the alias of `KVIKIO_NTHREADS`, and add new C++ API `num_threads`/`set_thread_pool_nthreads` as the alias of existing `thread_pool_nthreads`/`set_thread_pool_nthreads`. This makes C++ and Python API (i.e. `kvikio.defaults.get("num_threads")`) consistent.
- Fix a well-hidden UB related to string temporaries and `std::initializer_list`.