### PR TITLE
Fix unit test UB resulting from incorrect initialization

### DIFF
--- a/cpp/tests/test_defaults.cpp
+++ b/cpp/tests/test_defaults.cpp
@@ -92,7 +92,7 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // Non-string env var has an empty value
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS", ""}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS", ""}};
     EXPECT_THAT(
       [=] { kvikio::getenv_or({"KVIKIO_TEST_ALIAS"}, 123); },
       ThrowsMessage<std::invalid_argument>(HasSubstr("unknown config value KVIKIO_TEST_ALIAS=")));
@@ -100,8 +100,8 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // Non-string env var and alias have an empty value
   {
-    kvikio::test::EnvVarContext env_var_ctx{
-      {{"KVIKIO_TEST_ALIAS_1", ""}, {"KVIKIO_TEST_ALIAS_2", ""}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS_1", ""},
+                                            {"KVIKIO_TEST_ALIAS_2", ""}};
     EXPECT_THAT(
       [=] { kvikio::getenv_or({"KVIKIO_TEST_ALIAS_1", "KVIKIO_TEST_ALIAS_2"}, 123); },
       ThrowsMessage<std::invalid_argument>(HasSubstr("unknown config value KVIKIO_TEST_ALIAS_2=")));
@@ -109,7 +109,7 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // String env var has an empty value
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS", ""}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS", ""}};
     auto const [env_var_name, result, has_found] =
       kvikio::getenv_or({"KVIKIO_TEST_ALIAS"}, std::string{"abc"});
     EXPECT_EQ(env_var_name, "KVIKIO_TEST_ALIAS");
@@ -119,8 +119,8 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // String env var and alias have an empty value
   {
-    kvikio::test::EnvVarContext env_var_ctx{
-      {{"KVIKIO_TEST_ALIAS_1", ""}, {"KVIKIO_TEST_ALIAS_2", ""}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS_1", ""},
+                                            {"KVIKIO_TEST_ALIAS_2", ""}};
     auto const [env_var_name, result, has_found] =
       kvikio::getenv_or({"KVIKIO_TEST_ALIAS_1", "KVIKIO_TEST_ALIAS_2"}, std::string{"abc"});
     EXPECT_EQ(env_var_name, "KVIKIO_TEST_ALIAS_2");
@@ -130,9 +130,8 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // Env var has already been set by its alias with the same value
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS_1", "10"},
-                                             {"KVIKIO_TEST_ALIAS_2", "10"},
-                                             {"KVIKIO_TEST_ALIAS_3", "10"}}};
+    kvikio::test::EnvVarContext env_var_ctx{
+      {"KVIKIO_TEST_ALIAS_1", "10"}, {"KVIKIO_TEST_ALIAS_2", "10"}, {"KVIKIO_TEST_ALIAS_3", "10"}};
     auto const [env_var_name, result, has_found] =
       kvikio::getenv_or({"KVIKIO_TEST_ALIAS_1", "KVIKIO_TEST_ALIAS_2", "KVIKIO_TEST_ALIAS_3"}, 123);
     EXPECT_EQ(env_var_name, std::string_view{"KVIKIO_TEST_ALIAS_3"});
@@ -142,8 +141,8 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // Env var has already been set by its alias with a different value
   {
-    kvikio::test::EnvVarContext env_var_ctx{
-      {{"KVIKIO_TEST_ALIAS_1", "10"}, {"KVIKIO_TEST_ALIAS_2", "20"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS_1", "10"},
+                                            {"KVIKIO_TEST_ALIAS_2", "20"}};
     EXPECT_THAT([=] { kvikio::getenv_or({"KVIKIO_TEST_ALIAS_1", "KVIKIO_TEST_ALIAS_2"}, 123); },
                 ThrowsMessage<std::invalid_argument>(HasSubstr(
                   "Environment variable KVIKIO_TEST_ALIAS_2 (20) has already been set by its alias "
@@ -152,7 +151,7 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // Env var has invalid value
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS", "abc"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS", "abc"}};
     EXPECT_THAT([=] { kvikio::getenv_or({"KVIKIO_TEST_ALIAS"}, 123); },
                 ThrowsMessage<std::invalid_argument>(
                   HasSubstr("unknown config value KVIKIO_TEST_ALIAS=abc")));
@@ -160,7 +159,7 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // 1st alias has a set value
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS_1", "654.321"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS_1", "654.321"}};
     auto const [env_var_name, result, has_found] =
       kvikio::getenv_or({"KVIKIO_TEST_ALIAS_1", "KVIKIO_TEST_ALIAS_2"}, 123.456);
     EXPECT_EQ(env_var_name, std::string_view{"KVIKIO_TEST_ALIAS_1"});
@@ -170,7 +169,7 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // 2nd alias has a set value
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS_2", "654.321"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS_2", "654.321"}};
     auto const [env_var_name, result, has_found] =
       kvikio::getenv_or({"KVIKIO_TEST_ALIAS_1", "KVIKIO_TEST_ALIAS_2"}, 123.456);
     EXPECT_EQ(env_var_name, std::string_view{"KVIKIO_TEST_ALIAS_2"});
@@ -189,14 +188,14 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // Special type: bool
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS", "yes"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS", "yes"}};
     auto const [env_var_name, result, has_found] = kvikio::getenv_or({"KVIKIO_TEST_ALIAS"}, false);
     EXPECT_EQ(env_var_name, std::string_view{"KVIKIO_TEST_ALIAS"});
     EXPECT_TRUE(result);
     EXPECT_TRUE(has_found);
   }
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS", "OFF"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS", "OFF"}};
     auto const [env_var_name, result, has_found] = kvikio::getenv_or({"KVIKIO_TEST_ALIAS"}, false);
     EXPECT_EQ(env_var_name, std::string_view{"KVIKIO_TEST_ALIAS"});
     EXPECT_FALSE(result);
@@ -205,7 +204,7 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // Special type: CompatMode
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS", "yes"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS", "yes"}};
     auto const [env_var_name, result, has_found] =
       kvikio::getenv_or({"KVIKIO_TEST_ALIAS"}, kvikio::CompatMode::AUTO);
     EXPECT_EQ(env_var_name, std::string_view{"KVIKIO_TEST_ALIAS"});
@@ -213,7 +212,7 @@ TEST(DefaultsTest, alias_for_getenv_or)
     EXPECT_TRUE(has_found);
   }
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS", "FALSE"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS", "FALSE"}};
     auto const [env_var_name, result, has_found] =
       kvikio::getenv_or({"KVIKIO_TEST_ALIAS"}, kvikio::CompatMode::AUTO);
     EXPECT_EQ(env_var_name, std::string_view{"KVIKIO_TEST_ALIAS"});
@@ -221,7 +220,7 @@ TEST(DefaultsTest, alias_for_getenv_or)
     EXPECT_TRUE(has_found);
   }
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS", "aUtO"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS", "aUtO"}};
     auto const [env_var_name, result, has_found] =
       kvikio::getenv_or({"KVIKIO_TEST_ALIAS"}, kvikio::CompatMode::ON);
     EXPECT_EQ(env_var_name, std::string_view{"KVIKIO_TEST_ALIAS"});
@@ -231,7 +230,7 @@ TEST(DefaultsTest, alias_for_getenv_or)
 
   // Special type: std::vector<int>
   {
-    kvikio::test::EnvVarContext env_var_ctx{{{"KVIKIO_TEST_ALIAS", "109, 108, 107"}}};
+    kvikio::test::EnvVarContext env_var_ctx{{"KVIKIO_TEST_ALIAS", "109, 108, 107"}};
     auto const [env_var_name, result, has_found] =
       kvikio::getenv_or({"KVIKIO_TEST_ALIAS"}, std::vector<int>{111, 112, 113});
     EXPECT_EQ(env_var_name, std::string_view{"KVIKIO_TEST_ALIAS"});

--- a/cpp/tests/test_remote_handle.cpp
+++ b/cpp/tests/test_remote_handle.cpp
@@ -17,15 +17,14 @@
 #include <gtest/gtest.h>
 #include <kvikio/remote_handle.hpp>
 
-#include <unordered_map>
 #include "utils/env.hpp"
 
 TEST(RemoteHandleTest, s3_endpoint_constructor)
 {
-  kvikio::test::EnvVarContext env_var_ctx{{{"AWS_DEFAULT_REGION", "my_aws_default_region"},
-                                           {"AWS_ACCESS_KEY_ID", "my_aws_access_key_id"},
-                                           {"AWS_SECRET_ACCESS_KEY", "my_aws_secrete_access_key"},
-                                           {"AWS_ENDPOINT_URL", "https://my_aws_endpoint_url"}}};
+  kvikio::test::EnvVarContext env_var_ctx{{"AWS_DEFAULT_REGION", "my_aws_default_region"},
+                                          {"AWS_ACCESS_KEY_ID", "my_aws_access_key_id"},
+                                          {"AWS_SECRET_ACCESS_KEY", "my_aws_secrete_access_key"},
+                                          {"AWS_ENDPOINT_URL", "https://my_aws_endpoint_url"}};
   std::string url        = "https://my_aws_endpoint_url/bucket_name/object_name";
   std::string aws_region = "my_aws_region";
   // Use the overload where the full url and the optional aws_region are specified.


### PR DESCRIPTION
KvikIO unit test has a utility class `EnvVarContext` class, introduced in https://github.com/rapidsai/kvikio/pull/700, and slightly improved in https://github.com/rapidsai/kvikio/pull/735. It has been identified that this class was incorrectly initialized, resulting in UB: it causes the unit test failure in C++20, which by fluke was not observed in C++17. This PR fixes this error. Specifically, the constructor of `EnvVarContext` is:
```
EnvVarContext(std::initializer_list<std::pair<std::string_view, std::string_view>> env_var_entries);
```
There are several ways of instantiation:
```
// Direct initialization
EnvVarContext env_var_ctx({{"env_1", "v1"}, {"env_2", "v2"}});

// Direct list initialization
EnvVarContext env_var_ctx{{"env_1", "v1"}, {"env_2", "v2"}};

// Copy list initialization
EnvVarContext env_var_ctx = {{"env_1", "v1"}, {"env_2", "v2"}};
```
The erroneous instantiation performed is:
```
// Extra pair of braces
// {}: brace-enclosed initializer list
// {{"env_1", "v1"}, {"env_2", "v2"}}: one element of type pair<std::string_view, std::string_view>
// {"env_1", "v1"}: first
// {"env_2", "v2"}: second
EnvVarContext env_var_ctx{{{"env_1", "v1"}, {"env_2", "v2"}}};
``` 
As a result, the initializer list only has 1 pair, with the key being `{"env_1", "v1"}` and value being `{"env_2", "v2"}`. For the key, for instance, the 5-th overload (https://en.cppreference.com/w/cpp/string/basic_string_view/basic_string_view.html) of the constructor was used, where `first` points to "env_1" and `last` points to "v1". Since the two iterators do not form a valid range, UB ensues.
