### PR TITLE
Only use cufile on x86

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -18,6 +18,10 @@ sccache --zero-stats
 RAPIDS_PACKAGE_VERSION=$(rapids-generate-version)
 export RAPIDS_PACKAGE_VERSION
 
+RAPIDS_ARTIFACTS_DIR=${RAPIDS_ARTIFACTS_DIR:-"${PWD}/artifacts"}
+mkdir -p "${RAPIDS_ARTIFACTS_DIR}"
+export RAPIDS_ARTIFACTS_DIR
+
 # populates `RATTLER_CHANNELS` array and `RATTLER_ARGS` array
 source rapids-rattler-channel-string
 

--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -59,7 +59,7 @@ cache:
     host:
       - cuda-version =${{ cuda_version }}
       - libcurl ${{ libcurl_version }}
-      - if: linux and x86_64
+      - if: (linux and x86_64) or (linux and aarch64 and cuda_version >= "12.2")
         then:
         - libcufile-dev
       - libnuma

--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -59,7 +59,9 @@ cache:
     host:
       - cuda-version =${{ cuda_version }}
       - libcurl ${{ libcurl_version }}
-      - libcufile-dev
+      - if: linux and x86_64
+        then:
+        - libcufile-dev
       - libnuma
 
 outputs:
@@ -85,7 +87,9 @@ outputs:
         - libcurl ${{ libcurl_version }}
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
-        - libcufile-dev
+        - if: linux and x86_64
+          then:
+          - libcufile-dev
       ignore_run_exports:
         by_name:
           - cuda-version
@@ -117,7 +121,9 @@ outputs:
         - ${{ pin_subpackage("libkvikio", exact=True) }}
         - cuda-version =${{ cuda_version }}
         - cuda-cudart-dev
-        - libcufile-dev
+        - if: linux and x86_64
+          then:
+          - libcufile-dev
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - cuda-cudart


### PR DESCRIPTION
This is a temporary patch for the problem that cufile is not available on arm before CUDA 12.2, which results in these libkvikio packages not currently being installable on (for example) CUDA 12.0 arm systems. We should follow this PR up with a fix to actually build separate packages for older and newer CUDA versions, but this quick fix should unblock other work today.