### PR TITLE
Set compiler versions in context

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -26,33 +26,13 @@ export RAPIDS_ARTIFACTS_DIR
 source rapids-rattler-channel-string
 
 # Construct the extra variants according to the architecture
-if [[ "$(arch)" == "x86_64" ]]; then
-    cat > variants.yaml << EOF
-    c_compiler_version:
-      - 13
-
-    cxx_compiler_version:
-      - 13
-
-    cuda_version:
-      - ${RAPIDS_CUDA_VERSION}
+cat > variants.yaml << EOF
+cuda_version:
+  - ${RAPIDS_CUDA_VERSION}
 EOF
-else
-    cat > variants.yaml << EOF
-    zip_keys:
-    - [c_compiler_version, cxx_compiler_version, cuda_version]
-
-    c_compiler_version:
-    - 12
-    - 13
-
-    cxx_compiler_version:
-    - 12
-    - 13
-
-    cuda_version:
-    - 12.1 # The last version to not support cufile
-    - ${RAPIDS_CUDA_VERSION}
+if [[ "$(arch)" == "aarch64" ]]; then
+  cat >> variants.yaml << EOF
+  - 12.1 # The last version to not support cufile
 EOF
 fi
 

--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -10,6 +10,8 @@ context:
   # 3. Linux aarch64 with CUDA < 12.2, which does not use libcufile
   # Each case has different cuda-version constraints as expressed below
   should_use_cufile: ${{ x86_64 or (aarch64 and cuda_version >= "12.2") }}
+  c_compiler_version: ${{ 13 if should_use_cufile else 12 }}
+  cxx_compiler_version: ${{ c_compiler_version }}
   # When reverting, instances of cuda_key_string can be replaced with cuda_major
   cuda_key_string: ${{ cuda_version | replace(".", "_") }}
   #cuda_version: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[:2] | join(".") }}


### PR DESCRIPTION
Simplify the logic necessary to handle compiler versions by folding it into the context.