### PR TITLE
add docs on CI workflow inputs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,15 +9,21 @@ on:
   workflow_dispatch:
     inputs:
       branch:
+        description: |
+          branch: git branch the workflow run targets.
+          Required even when 'sha' is provided because it is also used for organizing artifacts.
         required: true
         type: string
       date:
+        description: "date: Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
         required: true
         type: string
       sha:
+        description: "sha: full git commit SHA to check out"
         required: true
         type: string
       build_type:
+        description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,15 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       branch:
+        description: |
+          branch: git branch the workflow run targets.
+          Required even when 'sha' is provided because it is also used for organizing artifacts.
         required: true
         type: string
       date:
+        description: "date: Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
         required: true
         type: string
       sha:
+        description: "sha: full git commit SHA to check out"
         required: true
         type: string
       build_type:
+        description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/shared-workflows/issues/376

* adds descriptions for all inputs to workflows triggered by `workflow_dispatch`

## Notes for Reviewers

### Motivation

The input descriptions show up in the UI when you go to trigger these workflows. Like this:

![image](https://github.com/user-attachments/assets/fc62d1ff-39eb-47c7-9a21-57aab959e64f)

I'm hoping that will make it easier for developers to manually trigger workflows. Inspired by being asked multiple times "what format is `date` supposed to be in?".