### PR TITLE
Fix a case sensitivity bug in S3 remote I/O

### DIFF
--- a/python/kvikio/kvikio/remote_file.py
+++ b/python/kvikio/kvikio/remote_file.py
@@ -130,12 +130,12 @@ class RemoteFile:
             The size of the file. If None, KvikIO will ask the server
             for the file size.
         """
-        url = url.lower()
-        if url.startswith("http://") or url.startswith("https://"):
+        url_lowercase = url.lower()
+        if url_lowercase.startswith("http://") or url_lowercase.startswith("https://"):
             return RemoteFile(
                 _get_remote_module().RemoteFile.open_s3_from_http_url(url, nbytes)
             )
-        if url.startswith("s3://"):
+        if url_lowercase.startswith("s3://"):
             return RemoteFile(
                 _get_remote_module().RemoteFile.open_s3_from_s3_url(url, nbytes)
             )

--- a/python/kvikio/kvikio/remote_file.py
+++ b/python/kvikio/kvikio/remote_file.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import functools
+import urllib.parse
 from typing import Optional
 
 from kvikio.cufile import IOFuture
@@ -130,12 +131,12 @@ class RemoteFile:
             The size of the file. If None, KvikIO will ask the server
             for the file size.
         """
-        url_lowercase = url.lower()
-        if url_lowercase.startswith("http://") or url_lowercase.startswith("https://"):
+        parsed_result = urllib.parse.urlparse(url.lower())
+        if parsed_result.scheme in ("http", "https"):
             return RemoteFile(
                 _get_remote_module().RemoteFile.open_s3_from_http_url(url, nbytes)
             )
-        if url_lowercase.startswith("s3://"):
+        if parsed_result.scheme == "s3":
             return RemoteFile(
                 _get_remote_module().RemoteFile.open_s3_from_s3_url(url, nbytes)
             )

--- a/python/kvikio/tests/test_s3_io.py
+++ b/python/kvikio/tests/test_s3_io.py
@@ -80,8 +80,8 @@ def s3_context(s3_base, bucket, files=None):
 
 
 def test_read_access(s3_base):
-    bucket_name = "bucket"
-    object_name = "data"
+    bucket_name = "Bucket"
+    object_name = "Data"
     data = b"file content"
     with s3_context(
         s3_base=s3_base, bucket=bucket_name, files={object_name: bytes(data)}
@@ -118,8 +118,8 @@ def test_read_access(s3_base):
 @pytest.mark.parametrize("tasksize", [99, 999])
 @pytest.mark.parametrize("buffer_size", [101, 1001])
 def test_read(s3_base, xp, size, nthreads, tasksize, buffer_size):
-    bucket_name = "test_read"
-    object_name = "a1"
+    bucket_name = "Test_Read"
+    object_name = "Aa1"
     a = xp.arange(size)
     with s3_context(
         s3_base=s3_base, bucket=bucket_name, files={object_name: bytes(a)}
@@ -150,8 +150,8 @@ def test_read(s3_base, xp, size, nthreads, tasksize, buffer_size):
     ],
 )
 def test_read_with_file_offset(s3_base, xp, start, end):
-    bucket_name = "test_read_with_file_offset"
-    object_name = "a1"
+    bucket_name = "Test_Read_With_File_Offset"
+    object_name = "Aa1"
     a = xp.arange(end, dtype=xp.int64)
     with s3_context(
         s3_base=s3_base, bucket=bucket_name, files={object_name: bytes(a)}

--- a/python/kvikio/tests/test_s3_io.py
+++ b/python/kvikio/tests/test_s3_io.py
@@ -80,7 +80,7 @@ def s3_context(s3_base, bucket, files=None):
 
 
 def test_read_access(s3_base):
-    bucket_name = "Bucket"
+    bucket_name = "bucket"
     object_name = "Data"
     data = b"file content"
     with s3_context(
@@ -118,7 +118,7 @@ def test_read_access(s3_base):
 @pytest.mark.parametrize("tasksize", [99, 999])
 @pytest.mark.parametrize("buffer_size", [101, 1001])
 def test_read(s3_base, xp, size, nthreads, tasksize, buffer_size):
-    bucket_name = "Test_Read"
+    bucket_name = "test_read"
     object_name = "Aa1"
     a = xp.arange(size)
     with s3_context(
@@ -150,7 +150,7 @@ def test_read(s3_base, xp, size, nthreads, tasksize, buffer_size):
     ],
 )
 def test_read_with_file_offset(s3_base, xp, start, end):
-    bucket_name = "Test_Read_With_File_Offset"
+    bucket_name = "test_read_with_file_offset"
     object_name = "Aa1"
     a = xp.arange(end, dtype=xp.int64)
     with s3_context(


### PR DESCRIPTION
AWS S3 object key name is case sensitive. Current implementation of `open_s3_url` converts all the letters of URL to lowercase before passing it to the wrapped C++ library. As a result, if the object key name contains any capital letter, the following error will occur:
```
RuntimeError: KvikIO failure at: /home/coder/kvikio/cpp/src/shim/libcurl.cpp:176: curl_easy_perform() error (The requested URL returned error: 404)
```
This PR fixes this issue by forwarding the user-provided URL as-is.