### PR TITLE
Fix remote I/O file size overflow in Python binding

### DIFF
--- a/python/kvikio/kvikio/_lib/remote_handle.pyx
+++ b/python/kvikio/kvikio/_lib/remote_handle.pyx
@@ -36,7 +36,7 @@ cdef extern from "<kvikio/remote_handle.hpp>" nogil:
             unique_ptr[cpp_RemoteEndpoint] endpoint, size_t nbytes
         ) except +
         cpp_RemoteHandle(unique_ptr[cpp_RemoteEndpoint] endpoint) except +
-        int nbytes() except +
+        size_t nbytes() except +
         const cpp_RemoteEndpoint& endpoint() except +
         size_t read(
             void* buf,


### PR DESCRIPTION
KvikIO remote I/O interface requires users to provide a buffer to read the remote data into. The following pattern is often used:
```python
import cupy as cp

# Create a remote handle from the URL
remote_handle = kvikio.RemoteFile.open_s3_url(url)

# Query the remote file size and preallocate the user-provided buffer
buf = cp.empty(remote_handle.nbytes(), dtype=cp.int8)

# Read into the buffer
fut = remote_handle.pread(buf)
fut.get()
```
Currently in Cython, the `extern` method `nbytes()` (remote file size) is given a return type of `int`, whereas its initial return type in the C++ library is `std::size_t`. The `int` here is interpreted as the `int` in C++ as opposed to the variable-length `int` in Python. Consequently, integer overflow occurs when reading from a large-size file, in which case `nbytes()` returns negative values.
This PR fixes this bug.