### PR TITLE
Remove CUDA 11 workarounds

### DIFF
--- a/cpp/src/shim/cufile.cpp
+++ b/cpp/src/shim/cufile.cpp
@@ -27,17 +27,7 @@ namespace kvikio {
 #ifdef KVIKIO_CUFILE_FOUND
 cuFileAPI::cuFileAPI()
 {
-  // CUDA versions before CUDA 11.7.1 did not ship libcufile.so.0, so this is
-  // a workaround that adds support for all prior versions of libcufile.
-  void* lib = load_library({"libcufile.so.0",
-                            "libcufile.so.1.3.0" /* 11.7.0 */,
-                            "libcufile.so.1.2.1" /* 11.6.2, 11.6.1 */,
-                            "libcufile.so.1.2.0" /* 11.6.0 */,
-                            "libcufile.so.1.1.1" /* 11.5.1 */,
-                            "libcufile.so.1.1.0" /* 11.5.0 */,
-                            "libcufile.so.1.0.2" /* 11.4.4, 11.4.3, 11.4.2 */,
-                            "libcufile.so.1.0.1" /* 11.4.1 */,
-                            "libcufile.so.1.0.0" /* 11.4.0 */});
+  void* lib = load_library({"libcufile.so.0"});
   get_symbol(HandleRegister, lib, KVIKIO_STRINGIFY(cuFileHandleRegister));
   get_symbol(HandleDeregister, lib, KVIKIO_STRINGIFY(cuFileHandleDeregister));
   get_symbol(Read, lib, KVIKIO_STRINGIFY(cuFileRead));
@@ -79,21 +69,6 @@ cuFileAPI::cuFileAPI()
     get_symbol(StreamRegister, lib, KVIKIO_STRINGIFY(cuFileStreamRegister));
     get_symbol(StreamDeregister, lib, KVIKIO_STRINGIFY(cuFileStreamDeregister));
   }
-
-  // cuFile is supposed to open and close the driver automatically but
-  // because of a bug in cuFile v1.4 (CUDA v11.8) it sometimes segfaults:
-  // <https://github.com/rapidsai/kvikio/issues/159>.
-  if (version < 1050) { driver_open(); }
-}
-
-// Notice, we have to close the driver at program exit (if we opened it) even though we are
-// not allowed to call CUDA after main[1]. This is because, cuFile will segfault if the
-// driver isn't closed on program exit i.e. we are doomed if we do, doomed if we don't, but
-// this seems to be the lesser of two evils.
-// [1] <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#initialization>
-cuFileAPI::~cuFileAPI()
-{
-  if (version < 1050) { driver_close(); }
 }
 #else
 cuFileAPI::cuFileAPI() { KVIKIO_FAIL("KvikIO not compiled with cuFile.h", std::runtime_error); }


### PR DESCRIPTION
As part of https://github.com/rapidsai/kvikio/issues/768, remove CUDA 11 workarounds that should not anymore be necessary given CUDA 11 support is being dropped.