### PR TITLE
Use libnvcomp conda package

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -19,12 +19,12 @@ dependencies:
 - libcufile-dev
 - libcurl>=8.5.0,<9.0a0
 - libnuma
+- libnvcomp==4.2.0.11
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0
 - numpy>=1.23,<3.0a0
 - numpydoc
-- nvcomp==4.2.0.11
 - packaging
 - pre-commit
 - pytest

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - libcufile-dev
 - libcurl>=8.5.0,<9.0a0
 - libnuma
-- libnvcomp==4.2.0.11
+- libnvcomp-dev==4.2.0.11
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -19,12 +19,12 @@ dependencies:
 - libcufile-dev
 - libcurl>=8.5.0,<9.0a0
 - libnuma
+- libnvcomp==4.2.0.11
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0
 - numpy>=1.23,<3.0a0
 - numpydoc
-- nvcomp==4.2.0.11
 - packaging
 - pre-commit
 - pytest

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - libcufile-dev
 - libcurl>=8.5.0,<9.0a0
 - libnuma
-- libnvcomp==4.2.0.11
+- libnvcomp-dev==4.2.0.11
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/recipes/kvikio/recipe.yaml
+++ b/conda/recipes/kvikio/recipe.yaml
@@ -66,7 +66,7 @@ requirements:
     - cython >=3.0.0
     - libcurl ${{ libcurl_version }}
     - libkvikio =${{ version }}
-    - libnvcomp ${{ nvcomp_version }}
+    - libnvcomp-dev ${{ nvcomp_version }}
     - pip
     - python =${{ py_version }}
     - rapids-build-backend >=0.3.0,<0.4.0.dev0
@@ -76,7 +76,6 @@ requirements:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cupy >=12.0.0
     - libkvikio =${{ version }}
-    - libnvcomp ${{ nvcomp_version }}
     # See https://github.com/zarr-developers/numcodecs/pull/475
     - numcodecs !=0.12.0
     - numpy >=1.23,<3.0a0
@@ -90,7 +89,6 @@ requirements:
       - cuda-version
       - libcurl
       - libkvikio
-      - libnvcomp
 
 tests:
   - python:

--- a/conda/recipes/kvikio/recipe.yaml
+++ b/conda/recipes/kvikio/recipe.yaml
@@ -66,7 +66,7 @@ requirements:
     - cython >=3.0.0
     - libcurl ${{ libcurl_version }}
     - libkvikio =${{ version }}
-    - nvcomp ${{ nvcomp_version }}
+    - libnvcomp ${{ nvcomp_version }}
     - pip
     - python =${{ py_version }}
     - rapids-build-backend >=0.3.0,<0.4.0.dev0
@@ -76,10 +76,10 @@ requirements:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cupy >=12.0.0
     - libkvikio =${{ version }}
+    - libnvcomp ${{ nvcomp_version }}
     # See https://github.com/zarr-developers/numcodecs/pull/475
     - numcodecs !=0.12.0
     - numpy >=1.23,<3.0a0
-    - nvcomp ${{ nvcomp_version }}
     - packaging
     - python
     - zarr >=2.0.0,<4.0.0a0
@@ -90,7 +90,7 @@ requirements:
       - cuda-version
       - libcurl
       - libkvikio
-      - nvcomp
+      - libnvcomp
 
 tests:
   - python:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,7 +13,7 @@ files:
       - cuda
       - cuda_version
       - depends_on_cupy
-      - depends_on_nvcomp
+      - depends_on_libnvcomp
       - docs
       - py_version
       - rapids_build_skbuild
@@ -69,7 +69,7 @@ files:
       # TODO: restore runtime dependency when we no longer vendor nvcomp
       # (when nvcomp supports Python 3.13)
       # https://github.com/rapidsai/build-planning/issues/171
-      # - depends_on_nvcomp
+      # - depends_on_libnvcomp
       - depends_on_libkvikio
       - run
   py_rapids_build_libkvikio:
@@ -220,29 +220,11 @@ dependencies:
           - matrix: # All CUDA 12 versions
             packages:
               - cupy-cuda12x>=12.0.0
-  depends_on_nvcomp:
+  depends_on_libnvcomp:
     common:
       - output_types: conda
         packages:
-          - libnvcomp==4.2.0.11
-    specific:
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              use_cuda_wheels: "true"
-            packages:
-              - nvidia-nvcomp-cu12==4.2.0.11
-          # if use_cuda_wheels=false is provided, do not add dependencies on any CUDA wheels
-          # (e.g. for DLFW and pip devcontainers)
-          - matrix:
-              use_cuda_wheels: "false"
-            packages:
-          # if no matching matrix selectors passed, list the unsuffixed packages
-          # (just as a source of documentation, as this populates pyproject.toml in source control)
-          - matrix:
-            packages:
-              - nvidia-nvcomp==4.2.0.11
+          - libnvcomp-dev==4.2.0.11
   depends_on_libkvikio:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -224,7 +224,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - nvcomp==4.2.0.11
+          - libnvcomp==4.2.0.11
     specific:
       - output_types: [requirements, pyproject]
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ files:
     includes:
       - depends_on_cupy
       # TODO: restore runtime dependency when we no longer vendor nvcomp
-      # (when nvcomp supports Python 3.13)
+      # (when nvcomp ships C++ wheels)
       # https://github.com/rapidsai/build-planning/issues/171
       # - depends_on_libnvcomp
       - depends_on_libkvikio


### PR DESCRIPTION
The `nvcomp` conda package is being split into a C++ package `libnvcomp` and a Python bindings package `nvcomp`. We want to use the C++ package only, so we are adopting `libnvcomp`.
