### PR TITLE
Support file size query for S3 presigned URL

### DIFF
--- a/cpp/include/kvikio/remote_handle.hpp
+++ b/cpp/include/kvikio/remote_handle.hpp
@@ -63,7 +63,7 @@ class RemoteEndpoint {
   virtual std::string str() const = 0;
 
   /**
-   * @brief Get the file size.
+   * @brief Get the size of the remote file.
    *
    * @return The file size
    */
@@ -84,15 +84,10 @@ class HttpEndpoint : public RemoteEndpoint {
    * @param url The full http url to the remote file.
    */
   HttpEndpoint(std::string url);
+
   ~HttpEndpoint() override = default;
   void setopt(CurlHandle& curl) override;
   std::string str() const override;
-
-  /**
-   * @brief Get the file size.
-   *
-   * @return The file size
-   */
   std::size_t get_file_size() override;
 };
 
@@ -200,18 +195,15 @@ class S3Endpoint : public RemoteEndpoint {
              std::optional<std::string> aws_session_token     = std::nullopt);
 
   ~S3Endpoint() override;
-
   void setopt(CurlHandle& curl) override;
   std::string str() const override;
-
-  /**
-   * @brief Get the file size.
-   *
-   * @return The file size
-   */
   std::size_t get_file_size() override;
 };
 
+/**
+ * @brief A remote endpoint using AWS's S3 protocol and expecting a presigned URL. File access via
+ * this type of URL is time-limited and does not require AWS credentials.
+ */
 class S3EndpointWithPresignedUrl : public RemoteEndpoint {
  private:
   std::string _url;
@@ -220,15 +212,8 @@ class S3EndpointWithPresignedUrl : public RemoteEndpoint {
   explicit S3EndpointWithPresignedUrl(std::string presigned_url);
 
   ~S3EndpointWithPresignedUrl() override = default;
-
   void setopt(CurlHandle& curl) override;
   std::string str() const override;
-
-  /**
-   * @brief Get the file size.
-   *
-   * @return The file size
-   */
   std::size_t get_file_size() override;
 };
 
@@ -267,7 +252,8 @@ class RemoteHandle {
   /**
    * @brief Get the file size.
    *
-   * Note, this is very fast, no communication needed.
+   * Note, this is usually very fast, and involves retrieving only the header data, or at most only
+   * a small amount of body data.
    *
    * @return The number of bytes.
    */

--- a/cpp/include/kvikio/remote_handle.hpp
+++ b/cpp/include/kvikio/remote_handle.hpp
@@ -84,16 +84,16 @@ class HttpEndpoint : public RemoteEndpoint {
    * @param url The full http url to the remote file.
    */
   HttpEndpoint(std::string url);
-  virtual ~HttpEndpoint() override = default;
-  virtual void setopt(CurlHandle& curl) override;
-  virtual std::string str() const override;
+  ~HttpEndpoint() override = default;
+  void setopt(CurlHandle& curl) override;
+  std::string str() const override;
 
   /**
    * @brief Get the file size.
    *
    * @return The file size
    */
-  virtual std::size_t get_file_size() override;
+  std::size_t get_file_size() override;
 };
 
 /**
@@ -199,17 +199,17 @@ class S3Endpoint : public RemoteEndpoint {
              std::optional<std::string> aws_endpoint_url      = std::nullopt,
              std::optional<std::string> aws_session_token     = std::nullopt);
 
-  virtual ~S3Endpoint() override;
+  ~S3Endpoint() override;
 
-  virtual void setopt(CurlHandle& curl) override;
-  virtual std::string str() const override;
+  void setopt(CurlHandle& curl) override;
+  std::string str() const override;
 
   /**
    * @brief Get the file size.
    *
    * @return The file size
    */
-  virtual std::size_t get_file_size() override;
+  std::size_t get_file_size() override;
 };
 
 class S3EndpointWithPresignedUrl : public RemoteEndpoint {
@@ -219,17 +219,17 @@ class S3EndpointWithPresignedUrl : public RemoteEndpoint {
  public:
   explicit S3EndpointWithPresignedUrl(std::string presigned_url);
 
-  virtual ~S3EndpointWithPresignedUrl() override = default;
+  ~S3EndpointWithPresignedUrl() override = default;
 
-  virtual void setopt(CurlHandle& curl) override;
-  virtual std::string str() const override;
+  void setopt(CurlHandle& curl) override;
+  std::string str() const override;
 
   /**
    * @brief Get the file size.
    *
    * @return The file size
    */
-  virtual std::size_t get_file_size() override;
+  std::size_t get_file_size() override;
 };
 
 /**

--- a/cpp/include/kvikio/remote_handle.hpp
+++ b/cpp/include/kvikio/remote_handle.hpp
@@ -252,7 +252,8 @@ class RemoteHandle {
   /**
    * @brief Get the file size.
    *
-   * Note, this is very fast, no communication needed.
+   * Note, the file size is retrieved at construction so this method is very fast, no communication
+   * needed.
    *
    * @return The number of bytes.
    */

--- a/cpp/include/kvikio/remote_handle.hpp
+++ b/cpp/include/kvikio/remote_handle.hpp
@@ -252,8 +252,7 @@ class RemoteHandle {
   /**
    * @brief Get the file size.
    *
-   * Note, this is usually very fast, and involves retrieving only the header data, or at most only
-   * a small amount of body data.
+   * Note, this is very fast, no communication needed.
    *
    * @return The number of bytes.
    */

--- a/cpp/include/kvikio/remote_handle.hpp
+++ b/cpp/include/kvikio/remote_handle.hpp
@@ -18,12 +18,8 @@
 #include <cassert>
 #include <cstddef>
 #include <cstring>
-#include <iostream>
 #include <memory>
 #include <optional>
-#include <regex>
-#include <sstream>
-#include <stdexcept>
 #include <string>
 
 #include <kvikio/defaults.hpp>
@@ -48,6 +44,8 @@ class CurlHandle;  // Prototype
  */
 class RemoteEndpoint {
  public:
+  virtual ~RemoteEndpoint() = default;
+
   /**
    * @brief Set needed connection options on a curl handle.
    *
@@ -64,7 +62,12 @@ class RemoteEndpoint {
    */
   virtual std::string str() const = 0;
 
-  virtual ~RemoteEndpoint() = default;
+  /**
+   * @brief Get the file size.
+   *
+   * @return The file size
+   */
+  virtual std::size_t get_file_size() = 0;
 };
 
 /**
@@ -81,9 +84,16 @@ class HttpEndpoint : public RemoteEndpoint {
    * @param url The full http url to the remote file.
    */
   HttpEndpoint(std::string url);
-  void setopt(CurlHandle& curl) override;
-  std::string str() const override;
-  ~HttpEndpoint() override = default;
+  virtual ~HttpEndpoint() override = default;
+  virtual void setopt(CurlHandle& curl) override;
+  virtual std::string str() const override;
+
+  /**
+   * @brief Get the file size.
+   *
+   * @return The file size
+   */
+  virtual std::size_t get_file_size() override;
 };
 
 /**
@@ -189,9 +199,37 @@ class S3Endpoint : public RemoteEndpoint {
              std::optional<std::string> aws_endpoint_url      = std::nullopt,
              std::optional<std::string> aws_session_token     = std::nullopt);
 
-  void setopt(CurlHandle& curl) override;
-  std::string str() const override;
-  ~S3Endpoint() override;
+  virtual ~S3Endpoint() override;
+
+  virtual void setopt(CurlHandle& curl) override;
+  virtual std::string str() const override;
+
+  /**
+   * @brief Get the file size.
+   *
+   * @return The file size
+   */
+  virtual std::size_t get_file_size() override;
+};
+
+class S3EndpointWithPresignedUrl : public RemoteEndpoint {
+ private:
+  std::string _url;
+
+ public:
+  explicit S3EndpointWithPresignedUrl(std::string presigned_url);
+
+  virtual ~S3EndpointWithPresignedUrl() override = default;
+
+  virtual void setopt(CurlHandle& curl) override;
+  virtual std::string str() const override;
+
+  /**
+   * @brief Get the file size.
+   *
+   * @return The file size
+   */
+  virtual std::size_t get_file_size() override;
 };
 
 /**

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -342,7 +342,7 @@ std::string S3EndpointWithPresignedUrl::str() const { return _url; }
 
 namespace {
 /**
- * @brief
+ * @brief Callback for the `CURLOPT_HEADERFUNCTION` parameter in libcurl
  *
  * The header callback is called once for each header and only complete header lines are passed on
  * to the callback. The provided header line is not null-terminated.

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -352,8 +352,8 @@ namespace {
  * @param num_bytes The size of new data received
  * @param userdata User-defined data
  * @return The number of bytes consumed by the callback
- * @exception std::invalid_argument if the server does not know the file size, thereby the
- * content-range header in the HTTP message having "*" as the file size.
+ * @exception std::invalid_argument if the server does not know the file size, thereby using "*" as
+ * the filler text in the content-range header of the HTTP message.
  */
 std::size_t callback_header(char* data, std::size_t size, std::size_t num_bytes, void* userdata)
 {

--- a/python/kvikio/kvikio/_lib/remote_handle.pyx
+++ b/python/kvikio/kvikio/_lib/remote_handle.pyx
@@ -31,6 +31,10 @@ cdef extern from "<kvikio/remote_handle.hpp>" nogil:
     pair[string, string] cpp_parse_s3_url \
         "kvikio::S3Endpoint::parse_s3_url"(string url) except +
 
+    cdef cppclass cpp_S3EndpointWithPresignedUrl "kvikio::S3EndpointWithPresignedUrl" \
+                                                 (cpp_RemoteEndpoint):
+        cpp_S3EndpointWithPresignedUrl(string presigned_url) except +
+
     cdef cppclass cpp_RemoteHandle "kvikio::RemoteHandle":
         cpp_RemoteHandle(
             unique_ptr[cpp_RemoteEndpoint] endpoint, size_t nbytes
@@ -137,6 +141,18 @@ cdef class RemoteFile:
         return RemoteFile._from_endpoint(
             cast_to_remote_endpoint(
                 make_unique[cpp_S3Endpoint](bucket_and_object)
+            ),
+            nbytes
+        )
+
+    @staticmethod
+    def open_s3_from_http_presigned_url(
+        presigned_url: str,
+        nbytes: Optional[int],
+    ):
+        return RemoteFile._from_endpoint(
+            cast_to_remote_endpoint(
+                make_unique[cpp_S3EndpointWithPresignedUrl](_to_string(presigned_url))
             ),
             nbytes
         )

--- a/python/kvikio/kvikio/remote_file.py
+++ b/python/kvikio/kvikio/remote_file.py
@@ -142,6 +142,28 @@ class RemoteFile:
             )
         raise ValueError(f"Unsupported protocol: {url}")
 
+    @classmethod
+    def open_s3_presigned_url(
+        cls,
+        presigned_url: str,
+        nbytes: Optional[int] = None,
+    ) -> RemoteFile:
+        """Open a AWS S3 file from a presigned URL.
+
+        Parameters
+        ----------
+        presigned_url
+            Presigned URL to the remote file.
+        nbytes
+            The size of the file. If None, KvikIO will ask the server
+            for the file size.
+        """
+        return RemoteFile(
+            _get_remote_module().RemoteFile.open_s3_from_http_presigned_url(
+                presigned_url, nbytes
+            )
+        )
+
     def close(self) -> None:
         """Close the file"""
         pass


### PR DESCRIPTION
## Background

Knowing the size of the remote file before reading is important in remote I/O, as it allows users to pre-allocate buffer to avoid expensive on-the-fly reallocation. Currently in KvikIO this is not possible for AWS S3 presigned URL, which is a special link generated by data owner to grant time-limited access without using AWS credentials.

As is described in #585, file size query in KvikIO results in the HTTP 403 (forbidden) status code. This is because the query method is based on the `HEAD` request, and AWS S3 does not allow `HEAD` for presigned URL.

## Proposed solution

This PR provides a solution. The idea is to send a `GET` request (instead of `HEAD`) with a 1-byte range, so that we can still obtain the header information at a negligible cost. Since the `content-length` header is now at a fixed value of 1, we instead extract the file size value from `content-range`.

This PR adds a new C++ endpoint `S3EndpointWithPresignedUrl` and Python API `kvikio.RemoteFile.open_s3_presigned_url(url)`.

## Result

The following code now works properly without 403 error:

```python
import kvikio
import cupy

presigned_url = "<long_url_generated_by_data_owner>"
remote_file = kvikio.RemoteFile.open_s3_presigned_url(presigned_url)
print("--> file size: {:}".format(remote_file.nbytes()))

buf = cupy.zeros(remote_file.nbytes() // 8)
fut = remote_file.pread(buf)
read_size = fut.get()

print("--> read_size: {:}", read_size)
print(buf)
```

## Limitation

This PR is tested manually using a presigned URL. In a future PR, we need to add unit tests using `boto`.

Closes #585 