### PR TITLE
Remove more nvcomp packaging for conda

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -19,7 +19,6 @@ dependencies:
 - libcufile-dev
 - libcurl>=8.5.0,<9.0a0
 - libnuma
-- libnvcomp-dev==4.2.0.11
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -19,7 +19,6 @@ dependencies:
 - libcufile-dev
 - libcurl>=8.5.0,<9.0a0
 - libnuma
-- libnvcomp-dev==4.2.0.11
 - moto>=4.0.8
 - ninja
 - numcodecs !=0.12.0

--- a/conda/recipes/kvikio/conda_build_config.yaml
+++ b/conda/recipes/kvikio/conda_build_config.yaml
@@ -18,6 +18,3 @@ c_stdlib_version:
 
 libcurl_version:
   - "==8.5.0"
-
-nvcomp_version:
-  - "=4.2.0.11"

--- a/conda/recipes/kvikio/recipe.yaml
+++ b/conda/recipes/kvikio/recipe.yaml
@@ -66,7 +66,6 @@ requirements:
     - cython >=3.0.0
     - libcurl ${{ libcurl_version }}
     - libkvikio =${{ version }}
-    - libnvcomp-dev ${{ nvcomp_version }}
     - pip
     - python =${{ py_version }}
     - rapids-build-backend >=0.4.0,<0.5.0.dev0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,7 +13,6 @@ files:
       - cuda
       - cuda_version
       - depends_on_cupy
-      - depends_on_libnvcomp
       - docs
       - py_version
       - rapids_build_skbuild
@@ -66,10 +65,6 @@ files:
       table: project
     includes:
       - depends_on_cupy
-      # TODO: restore runtime dependency when we no longer vendor nvcomp
-      # (when nvcomp ships C++ wheels)
-      # https://github.com/rapidsai/build-planning/issues/171
-      # - depends_on_libnvcomp
       - depends_on_libkvikio
       - run
   py_rapids_build_libkvikio:
@@ -220,11 +215,6 @@ dependencies:
           - matrix: # All CUDA 12 versions
             packages:
               - cupy-cuda12x>=12.0.0
-  depends_on_libnvcomp:
-    common:
-      - output_types: conda
-        packages:
-          - libnvcomp-dev==4.2.0.11
   depends_on_libkvikio:
     common:
       - output_types: conda

--- a/python/kvikio/pyproject.toml
+++ b/python/kvikio/pyproject.toml
@@ -111,9 +111,6 @@ skip = [
 [tool.mypy]
 ignore_missing_imports = true
 
-[project.entry-points."numcodecs.codecs"]
-nvcomp_batch = "kvikio.nvcomp_codec:NvCompBatchCodec"
-
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"


### PR DESCRIPTION
Follow-up to #798 and #801.

After libcudf wheels vendor libnvcomp, we can finalize removal of nvcomp from kvikio.
