### PR TITLE
Fix an S3 parsing bug in the open function. Improve regex usage

### DIFF
--- a/cpp/src/hdfs.cpp
+++ b/cpp/src/hdfs.cpp
@@ -29,7 +29,7 @@ WebHdfsEndpoint::WebHdfsEndpoint(std::string url) : RemoteEndpoint{RemoteEndpoin
 {
   // todo: Use libcurl URL API for more secure and idiomatic parsing.
   // Split the URL into two parts: one without query and one with.
-  std::regex const pattern{R"(^([^?]+)\?([^#]*))"};
+  std::regex static const pattern{R"(^([^?]+)\?([^#]*))"};
   // Regex meaning:
   // ^: From the start of the line
   // [^?]+: Matches non-question-mark characters one or more times. The question mark ushers in the
@@ -51,7 +51,7 @@ WebHdfsEndpoint::WebHdfsEndpoint(std::string url) : RemoteEndpoint{RemoteEndpoin
   {
     // Extract user name if provided. In WebHDFS, user name is specified as the key=value pair in
     // the query
-    std::regex const pattern{R"(user.name=([^&]+))"};
+    std::regex static const pattern{R"(user.name=([^&]+))"};
     // Regex meaning:
     // [^&]+: Matches the non-ampersand character one or more times. The ampersand delimits
     // different parameters.
@@ -104,7 +104,7 @@ std::size_t WebHdfsEndpoint::get_file_size()
   KVIKIO_EXPECT(http_status_code == 200, "HTTP response is not successful.");
 
   // The response is in JSON format. The file size is given by `"length":<file_size>`.
-  std::regex const pattern{R"("length"\s*:\s*(\d+)[^\d])"};
+  std::regex static const pattern{R"("length"\s*:\s*(\d+)[^\d])", std::regex_constants::icase};
   // Regex meaning:
   // \s*: Matches the space character zero or more times.
   // \d+: Matches the digit one or more times.
@@ -132,9 +132,9 @@ void WebHdfsEndpoint::setup_range_request(CurlHandle& curl,
 bool WebHdfsEndpoint::is_url_valid(std::string const& url) noexcept
 {
   try {
-    std::regex const pattern(R"(^https?://[^/]+:\d+/webhdfs/v1/.+$)", std::regex_constants::icase);
-    std::smatch match_result;
-    return std::regex_match(url, match_result, pattern);
+    std::regex static const pattern(R"(^https?://[^/]+:\d+/webhdfs/v1/.+$)",
+                                    std::regex_constants::icase);
+    return std::regex_match(url, pattern);
   } catch (...) {
     return false;
   }

--- a/cpp/src/http_status_codes.cpp
+++ b/cpp/src/http_status_codes.cpp
@@ -31,13 +31,13 @@ std::vector<int> parse_http_status_codes(std::string_view env_var_name,
                                          std::string const& status_codes)
 {
   // Ensure `status_codes` consists only of 3-digit integers separated by commas, allowing spaces.
-  std::regex const check_pattern(R"(^\s*\d{3}\s*(\s*,\s*\d{3}\s*)*$)");
+  std::regex static const check_pattern(R"(^\s*\d{3}\s*(\s*,\s*\d{3}\s*)*$)");
   KVIKIO_EXPECT(std::regex_match(status_codes, check_pattern),
                 std::string{env_var_name} + ": invalid format, expected comma-separated integers.",
                 std::invalid_argument);
 
   // Match every integer in `status_codes`.
-  std::regex const number_pattern(R"(\d+)");
+  std::regex static const number_pattern(R"(\d+)");
 
   // For each match, we push_back `std::stoi(match.str())` into `ret`.
   std::vector<int> ret;

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -320,7 +320,7 @@ std::pair<std::string, std::string> S3Endpoint::parse_s3_url(std::string const& 
 {
   KVIKIO_NVTX_FUNC_RANGE();
   // Regular expression to match s3://<bucket>/<object>
-  std::regex const pattern{R"(^s3://([^/]+)/(.+))", std::regex_constants::icase};
+  std::regex static const pattern{R"(^s3://([^/]+)/(.+))", std::regex_constants::icase};
   std::smatch matches;
   if (std::regex_match(s3_url, matches, pattern)) { return {matches[1].str(), matches[2].str()}; }
   KVIKIO_FAIL("Input string does not match the expected S3 URL format.", std::invalid_argument);
@@ -336,7 +336,7 @@ S3Endpoint::S3Endpoint(std::string url,
 {
   KVIKIO_NVTX_FUNC_RANGE();
   // Regular expression to match http[s]://
-  std::regex pattern{R"(^https?://.*)", std::regex_constants::icase};
+  std::regex static const pattern{R"(^https?://.*)", std::regex_constants::icase};
   KVIKIO_EXPECT(std::regex_search(_url, pattern),
                 "url must start with http:// or https://",
                 std::invalid_argument);
@@ -434,9 +434,8 @@ bool S3Endpoint::is_url_valid(std::string const& url) noexcept
       if (!parsed_url.path.has_value()) { return false; }
 
       // Check whether the S3 object key exists
-      std::regex const pattern(R"(^/[^/]+$)", std::regex::icase);
-      std::smatch match_result;
-      return std::regex_search(parsed_url.path.value(), match_result, pattern);
+      std::regex static const pattern(R"(^/.+$)");
+      return std::regex_search(parsed_url.path.value(), pattern);
     } else if ((parsed_url.scheme == "http") || (parsed_url.scheme == "https")) {
       return url_has_aws_s3_http_format(url) && !S3EndpointWithPresignedUrl::is_url_valid(url);
     }
@@ -485,7 +484,7 @@ std::size_t callback_header(char* data, std::size_t size, std::size_t num_bytes,
   // Content-Range: <unit> <range>/<size>
   // Content-Range: <unit> <range>/*
   // Content-Range: <unit> */<size>
-  std::regex const pattern(R"(Content-Range:[^/]+/(.*))", std::regex::icase);
+  std::regex static const pattern(R"(Content-Range:[^/]+/(.*))", std::regex::icase);
   std::smatch match_result;
   bool found = std::regex_search(header_line, match_result, pattern);
   if (found) {

--- a/cpp/tests/test_remote_handle.cpp
+++ b/cpp/tests/test_remote_handle.cpp
@@ -37,6 +37,7 @@ class RemoteHandleTest : public testing::Test {
     _sample_urls = {
       // Endpoint type: S3
       {"s3://bucket-name/object-key-name", kvikio::RemoteEndpointType::S3},
+      {"s3://bucket-name/object-key-name-dir/object-key-name-file", kvikio::RemoteEndpointType::S3},
       {"https://bucket-name.s3.region-code.amazonaws.com/object-key-name",
        kvikio::RemoteEndpointType::S3},
       {"https://s3.region-code.amazonaws.com/bucket-name/object-key-name",


### PR DESCRIPTION
AWS S3 provides a non-standard S3 scheme for internal use (such as for AWS CLI). The URL takes the form `s3://<bucket-name>/<object-name>`, where `<object-name>` may contain `/` characters indicating subdirectories.

The newly added `open` function for remote I/O currently uses an incorrect regular expression, causing object names containing subdirectories to be rejected. This PR fixes this bug.

This PR also improves the usage of regular expression by making the pattern constant `static`.