### PR TITLE
Add a conda C++ CPU-only build

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -28,6 +28,9 @@ source rapids-rattler-channel-string
 # Construct the extra variants according to the architecture
 if [[ "$(arch)" == "x86_64" ]]; then
     cat > variants.yaml << EOF
+    zip_keys:
+    - [cuda_version, supports_cuda]
+
     c_compiler_version:
       - 14
 
@@ -35,25 +38,37 @@ if [[ "$(arch)" == "x86_64" ]]; then
       - 14
 
     cuda_version:
-      - "-1"
+      - 0
       - ${RAPIDS_CUDA_VERSION%.*}
+
+    supports_cuda:
+      - false
+      - true
 EOF
 else
     cat > variants.yaml << EOF
     zip_keys:
-    - [c_compiler_version, cxx_compiler_version, cuda_version]
+    - [c_compiler_version, cxx_compiler_version, cuda_version, supports_cuda]
 
     c_compiler_version:
+    - 12
     - 12
     - 14
 
     cxx_compiler_version:
     - 12
+    - 12
     - 14
 
     cuda_version:
+    - 0
     - 12.1 # The last version to not support cufile
     - ${RAPIDS_CUDA_VERSION%.*}
+
+    supports_cuda:
+    - False
+    - True
+    - True
 EOF
 fi
 

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -35,6 +35,7 @@ if [[ "$(arch)" == "x86_64" ]]; then
       - 14
 
     cuda_version:
+      - "-1"
       - ${RAPIDS_CUDA_VERSION%.*}
 EOF
 else

--- a/conda/recipes/kvikio/recipe.yaml
+++ b/conda/recipes/kvikio/recipe.yaml
@@ -65,7 +65,7 @@ requirements:
     - cuda-version =${{ cuda_version }}
     - cython >=3.0.0
     - libcurl ${{ libcurl_version }}
-    - libkvikio =${{ version }}=*cuda*
+    - libkvikio =${{ version }}
     - pip
     - python =${{ py_version }}
     - rapids-build-backend >=0.4.0,<0.5.0.dev0
@@ -74,7 +74,7 @@ requirements:
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cupy >=13.6.0
-    - libkvikio =${{ version }}=*cuda*
+    - libkvikio =${{ version }}
     - numpy >=1.23,<3.0a0
     - packaging
     - python

--- a/conda/recipes/kvikio/recipe.yaml
+++ b/conda/recipes/kvikio/recipe.yaml
@@ -65,7 +65,7 @@ requirements:
     - cuda-version =${{ cuda_version }}
     - cython >=3.0.0
     - libcurl ${{ libcurl_version }}
-    - libkvikio =${{ version }}
+    - libkvikio =${{ version }}=*cuda*
     - pip
     - python =${{ py_version }}
     - rapids-build-backend >=0.4.0,<0.5.0.dev0
@@ -74,7 +74,7 @@ requirements:
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cupy >=13.6.0
-    - libkvikio =${{ version }}
+    - libkvikio =${{ version }}=*cuda*
     - numpy >=1.23,<3.0a0
     - packaging
     - python

--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -11,12 +11,12 @@ context:
   # Each case has different cuda-version constraints as expressed below
   should_use_cufile: ${{ x86_64 or (aarch64 and cuda_version >= "12.2") }}
   # When reverting, instances of cuda_key_string can be replaced with cuda_major
-  cuda_key_string: ${{ cuda_version | replace(".", "_") }}
+  cuda_key_string: ${{ ("cuda" + (cuda_version | replace(".", "_"))) if supports_cuda else "cpu" }}
   #cuda_version: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[:2] | join(".") }}
   #cuda_major: '${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}'
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   head_rev: '${{ git.head_rev(".")[:8] }}'
-  cmake_args: ${{ "" if cuda_version > "0" else "--cmake-args=\\\"-DKvikIO_CUDA_SUPPORT=OFF \\\"" }}
+  cmake_args: ${{ "" if supports_cuda else "--cmake-args=\\\"-DKvikIO_CUDA_SUPPORT=OFF \\\"" }}
 
 recipe:
   name: libkvikio-split
@@ -62,13 +62,13 @@ cache:
       - cmake ${{ cmake_version }}
       - ninja
       - ${{ stdlib("c") }}
-      - if: cuda_version >= "0"
+      - if: supports_cuda
         then:
         - ${{ compiler("cuda") }}
         - cuda-version =${{ cuda_version }}
     host:
       - libcurl ==${{ libcurl_version }}
-      - if: cuda_version >= "0"
+      - if: supports_cuda
         then:
         - cuda-version =${{ cuda_version }}
         - if: should_use_cufile
@@ -84,7 +84,7 @@ outputs:
       script:
         content: |
           cmake --install cpp/build
-      string: cuda${{ cuda_key_string }}_${{ date_string }}_${{ head_rev }}
+      string: ${{ cuda_key_string }}_${{ date_string }}_${{ head_rev }}
       dynamic_linking:
         overlinking_behavior: "error"
       prefix_detection:
@@ -95,12 +95,12 @@ outputs:
         - cmake ${{ cmake_version }}
         - ${{ compiler("c") }}
       host:
-        - if: cuda_version >= "0"
+        - if: supports_cuda
           then:
           - cuda-version =${{ cuda_version }}
         - libcurl ==${{ libcurl_version }}
       run:
-        - if: cuda_version >= "0"
+        - if: supports_cuda
           then:
           - if: x86_64
             then:
@@ -116,7 +116,7 @@ outputs:
             - libcufile-dev
       ignore_run_exports:
         by_name:
-          - if: cuda_version >= "0"
+          - if: supports_cuda
             then:
             - cuda-version
             - if: should_use_cufile
@@ -134,7 +134,7 @@ outputs:
       name: libkvikio-tests
       version: ${{ version }}
     build:
-      string: cuda${{ cuda_key_string }}_${{ date_string }}_${{ head_rev }}
+      string: ${{ cuda_key_string }}_${{ date_string }}_${{ head_rev }}
       dynamic_linking:
         overlinking_behavior: "error"
       script:
@@ -147,7 +147,7 @@ outputs:
       host:
         - ${{ pin_subpackage("libkvikio", exact=True) }}
         - libcurl ==${{ libcurl_version }}
-        - if: cuda_version >= "0"
+        - if: supports_cuda
           then:
           - cuda-version =${{ cuda_version }}
           - cuda-cudart-dev
@@ -155,7 +155,7 @@ outputs:
             then:
             - libcufile-dev
       run:
-        - if: cuda_version >= "0"
+        - if: supports_cuda
           then:
           - if: x86_64
             then:
@@ -169,7 +169,7 @@ outputs:
           - cuda-cudart
       ignore_run_exports:
         by_name:
-          - if: cuda_version >= "0"
+          - if: supports_cuda
             then:
             - cuda-cudart
             - cuda-version

--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -37,11 +37,11 @@ cache:
         export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
         set +x
 
+        ./build.sh -v -n libkvikio ${{ cmake_args }}
       secrets:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
         - AWS_SESSION_TOKEN
-        ./build.sh -v -n libkvikio ${{ cmake_args }}
       env:
         CMAKE_C_COMPILER_LAUNCHER: ${{ env.get("CMAKE_C_COMPILER_LAUNCHER") }}
         CMAKE_CUDA_COMPILER_LAUNCHER: ${{ env.get("CMAKE_CUDA_COMPILER_LAUNCHER") }}

--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -114,6 +114,10 @@ outputs:
           - if: should_use_cufile
             then:
             - libcufile-dev
+      run_constraints:
+        - if: not supports_cuda
+          then:
+          - cuda-version <0
       ignore_run_exports:
         by_name:
           - if: supports_cuda

--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -16,6 +16,7 @@ context:
   #cuda_major: '${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}'
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   head_rev: '${{ git.head_rev(".")[:8] }}'
+  cmake_args: ${{ "" if cuda_version > "0" else "--cmake-args=\\\"-DKvikIO_CUDA_SUPPORT=OFF \\\"" }}
 
 recipe:
   name: libkvikio-split
@@ -36,11 +37,11 @@ cache:
         export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
         set +x
 
-        ./build.sh -v -n libkvikio
       secrets:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
         - AWS_SESSION_TOKEN
+        ./build.sh -v -n libkvikio ${{ cmake_args }}
       env:
         CMAKE_C_COMPILER_LAUNCHER: ${{ env.get("CMAKE_C_COMPILER_LAUNCHER") }}
         CMAKE_CUDA_COMPILER_LAUNCHER: ${{ env.get("CMAKE_CUDA_COMPILER_LAUNCHER") }}
@@ -58,18 +59,22 @@ cache:
     build:
       - ${{ compiler("c") }}
       - ${{ compiler("cxx") }}
-      - ${{ compiler("cuda") }}
-      - cuda-version =${{ cuda_version }}
       - cmake ${{ cmake_version }}
       - ninja
       - ${{ stdlib("c") }}
-    host:
-      - cuda-version =${{ cuda_version }}
-      - libcurl ==${{ libcurl_version }}
-      - if: should_use_cufile
+      - if: cuda_version >= "0"
         then:
-        - libcufile-dev
-      - libnuma
+        - ${{ compiler("cuda") }}
+        - cuda-version =${{ cuda_version }}
+    host:
+      - libcurl ==${{ libcurl_version }}
+      - if: cuda_version >= "0"
+        then:
+        - cuda-version =${{ cuda_version }}
+        - if: should_use_cufile
+          then:
+          - libcufile-dev
+        - libnuma
 
 outputs:
   - package:
@@ -90,27 +95,33 @@ outputs:
         - cmake ${{ cmake_version }}
         - ${{ compiler("c") }}
       host:
-        - cuda-version =${{ cuda_version }}
+        - if: cuda_version >= "0"
+          then:
+          - cuda-version =${{ cuda_version }}
         - libcurl ==${{ libcurl_version }}
       run:
-        - if: x86_64
+        - if: cuda_version >= "0"
           then:
-          - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
-          else:
-          - if: aarch64 and cuda_version >= "12.2"
+          - if: x86_64
             then:
-            - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="12.2.0a0") }}
+            - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
             else:
-            - ${{ pin_compatible("cuda-version", upper_bound="12.2.0a0", lower_bound="12.0") }}
-        - if: should_use_cufile
-          then:
-          - libcufile-dev
-      ignore_run_exports:
-        by_name:
-          - cuda-version
+            - if: aarch64 and cuda_version >= "12.2"
+              then:
+              - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="12.2.0a0") }}
+              else:
+              - ${{ pin_compatible("cuda-version", upper_bound="12.2.0a0", lower_bound="12.0") }}
           - if: should_use_cufile
             then:
-            - libcufile
+            - libcufile-dev
+      ignore_run_exports:
+        by_name:
+          - if: cuda_version >= "0"
+            then:
+            - cuda-version
+            - if: should_use_cufile
+              then:
+              - libcufile
     tests:
       - script:
           - test -f $PREFIX/include/kvikio/file_handle.hpp
@@ -135,31 +146,37 @@ outputs:
         - ${{ compiler("c") }}
       host:
         - ${{ pin_subpackage("libkvikio", exact=True) }}
-        - cuda-version =${{ cuda_version }}
-        - cuda-cudart-dev
         - libcurl ==${{ libcurl_version }}
-        - if: should_use_cufile
+        - if: cuda_version >= "0"
           then:
-          - libcufile-dev
-      run:
-        - if: x86_64
-          then:
-          - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
-          else:
-          - if: aarch64 and cuda_version >= "12.2"
-            then:
-            - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="12.2.0a0") }}
-            else:
-            - ${{ pin_compatible("cuda-version", upper_bound="12.2.0a0", lower_bound="12.0") }}
-        - cuda-cudart
-      ignore_run_exports:
-        by_name:
-          - cuda-cudart
-          - cuda-version
-          - libnuma
+          - cuda-version =${{ cuda_version }}
+          - cuda-cudart-dev
           - if: should_use_cufile
             then:
-            - libcufile
+            - libcufile-dev
+      run:
+        - if: cuda_version >= "0"
+          then:
+          - if: x86_64
+            then:
+            - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
+            else:
+            - if: aarch64 and cuda_version >= "12.2"
+              then:
+              - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="12.2.0a0") }}
+              else:
+              - ${{ pin_compatible("cuda-version", upper_bound="12.2.0a0", lower_bound="12.0") }}
+          - cuda-cudart
+      ignore_run_exports:
+        by_name:
+          - if: cuda_version >= "0"
+            then:
+            - cuda-cudart
+            - cuda-version
+            - libnuma
+            - if: should_use_cufile
+              then:
+              - libcufile
     about:
       homepage: ${{ load_from_file("python/libkvikio/pyproject.toml").project.urls.Homepage }}
       license: ${{ load_from_file("python/libkvikio/pyproject.toml").project.license.text }}

--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -171,6 +171,10 @@ outputs:
               else:
               - ${{ pin_compatible("cuda-version", upper_bound="12.2.0a0", lower_bound="12.0") }}
           - cuda-cudart
+      run_constraints:
+        - if: not supports_cuda
+          then:
+          - cuda-version <0
       ignore_run_exports:
         by_name:
           - if: supports_cuda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -19,6 +19,11 @@ files:
       - run
       - test_cpp
       - test_python
+  build_cpp_nocuda:
+    output: none
+    includes:
+      - build-universal
+      - build-cpp
   test_cpp:
     output: none
     includes:
@@ -128,7 +133,6 @@ dependencies:
       - output_types: conda
         packages:
           - c-compiler
-          - cuda-nvcc
           - cxx-compiler
           - libcurl>=8.5.0,<9.0a0
     specific:
@@ -205,6 +209,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
+          - cuda-nvcc
           - libcufile-dev
           - libnuma
   depends_on_cupy:


### PR DESCRIPTION
We should decide what suitable constraints on the CPU-only package are. I don't think there is ever a reason to support installing the CPU-only package into an environment with CUDA since the CUDA-enabled package's functionality is a strict superset, so I've added a `run_constraints` on `cuda-version<0` on the CPU package. `__cuda<0` is too strong of a restriction since it would prevent creating an environment to test CPU-only kvikio on a machine with CUDA drivers installed on the host.

Resolves #736 and #485