### PR TITLE
Fix CUDA 13 handling of libcufile on aarch64

### DIFF
--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -93,7 +93,7 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - libcurl ==${{ libcurl_version }}
       run:
-        - if: x86_64
+        - if: x86_64 or (aarch64 and cuda_version >= "13.0")
           then:
           - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
           else:


### PR DESCRIPTION
Fixes an issue where CUDA 13 packages named like `linux-aarch64/libkvikio-25.10.00a43-cuda13_0_250916_b69d9aea.conda` were getting dependencies on `cuda-version >=12.2.0a0,<14.0a0`, which allowed them to be used in CUDA 12 environments. That is not desired and could cause problems.
