### PR TITLE
add file size recording to span attrs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SHARED_ACTIONS_REPO: rapidsai/shared-actions
+  SHARED_ACTIONS_REF: add-file-size-recording
+
 jobs:
   pr-builder:
     needs:


### PR DESCRIPTION
Experimental testing here. The idea is to automatically capture file sizes on each build, such that tracking and reporting are more automated.