### PR TITLE
Simplify async validation condition

### DIFF
--- a/cpp/src/compat_mode_manager.cpp
+++ b/cpp/src/compat_mode_manager.cpp
@@ -94,8 +94,7 @@ CompatModeManager::CompatModeManager(std::string const& file_path,
 void CompatModeManager::validate_compat_mode_for_async() const
 {
   KVIKIO_NVTX_FUNC_RANGE();
-  if (!_is_compat_mode_preferred && _is_compat_mode_preferred_for_async &&
-      _compat_mode_requested == CompatMode::OFF) {
+  if (_is_compat_mode_preferred_for_async && _compat_mode_requested == CompatMode::OFF) {
     std::string err_msg;
     if (!is_stream_api_available()) { err_msg += "Missing the cuFile stream api."; }
 


### PR DESCRIPTION
The current condition has a redundant clause. If the requested compat mode is `CompatMode::OFF`, then `_is_compat_mode_preferred` is always false. All of the fallback conditions that are checked in the constructor that could result in `_is_compat_mode_preferred` being true only hold when the user requests `CompatMode::AUTO`.