### PR TITLE
Make parameter name more consistent for S3 utility functions

### DIFF
--- a/python/kvikio/kvikio/_lib/remote_handle.pyx
+++ b/python/kvikio/kvikio/_lib/remote_handle.pyx
@@ -194,7 +194,7 @@ cdef class RemoteFile:
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_endpoint_url: Optional[str] = None,
-        session_token: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
     ):
         cdef pair[string, string] bucket_and_object_names = _to_string_pair(
             bucket_name, object_name
@@ -209,7 +209,7 @@ cdef class RemoteFile:
         cdef optional[string] cpp_aws_endpoint_url = _to_optional_string(
             aws_endpoint_url
         )
-        cdef optional[string] cpp_aws_session_token = _to_optional_string(session_token)
+        cdef optional[string] cpp_aws_session_token = _to_optional_string(aws_session_token)
         cdef unique_ptr[cpp_RemoteEndpoint] cpp_endpoint
 
         with nogil:
@@ -236,7 +236,7 @@ cdef class RemoteFile:
         aws_region_name: Optional[str] = None,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
-        session_token: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
     ):
         cdef string cpp_url = _to_string(url)
         cdef optional[string] cpp_aws_region = _to_optional_string(aws_region_name)
@@ -247,7 +247,7 @@ cdef class RemoteFile:
             _to_optional_string(aws_secret_access_key)
         )
         cdef optional[string] cpp_aws_session_token = _to_optional_string(
-            session_token
+            aws_session_token
         )
         cdef unique_ptr[cpp_RemoteEndpoint] cpp_endpoint
 
@@ -275,7 +275,7 @@ cdef class RemoteFile:
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_endpoint_url: Optional[str] = None,
-        session_token: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
     ):
         cdef string cpp_url = _to_string(url)
         cdef pair[string, string] bucket_and_object_names
@@ -290,7 +290,7 @@ cdef class RemoteFile:
             aws_endpoint_url
         )
         cdef optional[string] cpp_aws_session_token = _to_optional_string(
-            session_token
+            aws_session_token
         )
         cdef unique_ptr[cpp_RemoteEndpoint] cpp_endpoint
 

--- a/python/kvikio/kvikio/remote_file.py
+++ b/python/kvikio/kvikio/remote_file.py
@@ -139,7 +139,7 @@ class RemoteFile:
         - ``AWS_DEFAULT_REGION`` (or region_name parameter)
         - ``AWS_ACCESS_KEY_ID`` (or access_key_id parameter)
         - ``AWS_SECRET_ACCESS_KEY`` (or secret_access_key parameter)
-        - ``AWS_SESSION_TOKEN`` (or session_token parameter, when using
+        - ``AWS_SESSION_TOKEN`` (or aws_session_token parameter, when using
           temporary credentials)
 
         Additionally, to overwrite the AWS endpoint, set `AWS_ENDPOINT_URL`
@@ -196,7 +196,7 @@ class RemoteFile:
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_endpoint_url: Optional[str] = None,
-        session_token: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
     ) -> RemoteFile:
         """Open a AWS S3 file from an URL.
 
@@ -210,7 +210,7 @@ class RemoteFile:
         - ``AWS_DEFAULT_REGION`` (or region_name parameter)
         - ``AWS_ACCESS_KEY_ID`` (or access_key_id parameter)
         - ``AWS_SECRET_ACCESS_KEY`` (or secret_access_key parameter)
-        - ``AWS_SESSION_TOKEN`` (or session_token parameter, when using
+        - ``AWS_SESSION_TOKEN`` (or aws_session_token parameter, when using
           temporary credentials)
 
         Additionally, if `url` is a S3 url, it is possible to overwrite the AWS endpoint
@@ -252,7 +252,7 @@ class RemoteFile:
                     aws_region_name,
                     aws_access_key_id,
                     aws_secret_access_key,
-                    session_token,
+                    aws_session_token,
                 )
             )
         if parsed_result.scheme == "s3":
@@ -264,7 +264,7 @@ class RemoteFile:
                     aws_access_key_id,
                     aws_secret_access_key,
                     aws_endpoint_url,
-                    session_token,
+                    aws_session_token,
                 )
             )
         raise ValueError(f"Unsupported protocol: {url}")


### PR DESCRIPTION
This small PR adds `aws_` prefix to the parameter `session_token` to make the parameter names more consistent for S3 utility functions.