### PR TITLE
Restore isort for Cython files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,13 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--config-root=python/", "--resolve-all-configs"]
+        files: python/.*
+        types: [cython]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.1
     hooks:

--- a/python/kvikio/pyproject.toml
+++ b/python/kvikio/pyproject.toml
@@ -56,6 +56,39 @@ zarr = [
 [project.urls]
 Homepage = "https://github.com/rapidsai/kvikio"
 
+[tool.isort]
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+combine_as_imports = true
+order_by_type = true
+known_first_party = [
+    "kvikio",
+]
+default_section = "THIRDPARTY"
+sections = [
+    "FUTURE",
+    "STDLIB",
+    "THIRDPARTY",
+    "FIRSTPARTY",
+    "LOCALFOLDER",
+]
+skip = [
+    "thirdparty",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".tox",
+    ".venv",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "__init__.py",
+]
+
 [tool.mypy]
 ignore_missing_imports = true
 


### PR DESCRIPTION
Ruff does not yet support Cython, so restore isort only for Cython.

Issue: https://github.com/rapidsai/build-planning/issues/130