### PR TITLE
refactored update-version.sh to handle new branching strategy

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -120,7 +120,16 @@ find .devcontainer/ -type f -name devcontainer.json -print0 | while IFS= read -r
     sed_runner "s@rapids-\${localWorkspaceFolderBasename}-[0-9.]*@rapids-\${localWorkspaceFolderBasename}-${NEXT_SHORT_TAG}@g" "${filename}"
 done
 
-# The example of a downstream project
+# Update downstream example GIT_TAG based on context
+if [[ "${RUN_CONTEXT}" == "main" ]]; then
+    # In main context, convert any release/X.Y references to main
+    sed_runner "s|GIT_TAG release/[^[:space:]]*|GIT_TAG main|g" "cpp/examples/downstream/cmake/get_kvikio.cmake"
+elif [[ "${RUN_CONTEXT}" == "release" ]]; then
+    # In release context, convert main to release/X.Y
+    sed_runner "s|GIT_TAG main|GIT_TAG release/${NEXT_SHORT_TAG}|g" "cpp/examples/downstream/cmake/get_kvikio.cmake"
+fi
+
+# The example of a downstream project - update version number
 sed_runner "s/find_and_configure_kvikio(.*)/find_and_configure_kvikio(\"${NEXT_SHORT_TAG}\")/g" "cpp/examples/downstream/cmake/get_kvikio.cmake"
 
 # Java files

--- a/cpp/examples/downstream/cmake/get_kvikio.cmake
+++ b/cpp/examples/downstream/cmake/get_kvikio.cmake
@@ -13,7 +13,7 @@ function(find_and_configure_kvikio MIN_VERSION)
     VERSION ${MIN_VERSION}
             GIT_REPOSITORY
             https://github.com/rapidsai/kvikio.git
-    GIT_TAG release/${MIN_VERSION}
+    GIT_TAG main
     GIT_SHALLOW
       TRUE
       SOURCE_SUBDIR


### PR DESCRIPTION
## Description
This PR supports handling the new main branch strategy outlined below:

* [RSN 47 - Changes to RAPIDS branching strategy in 25.12](https://docs.rapids.ai/notices/rsn0047/)

The `update-version.sh` script should now supports two modes controlled via  `CLI` params or `ENV` vars:

CLI arguments: `--run-context=main|release`
ENV var `RAPIDS_RUN_CONTEXT=main|release`

xref: https://github.com/rapidsai/build-planning/issues/224