### PR TITLE
Add devcontainer fallback for C++ test location

### DIFF
--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -12,8 +12,12 @@ devcontainers_test_location="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../cpp
 
 if [[ -d "${installed_test_location}" ]]; then
     cd "${installed_test_location}"
+    # Conda packages install binaries directly in this directory
+    examples_dir="."
 elif [[ -d "${devcontainers_test_location}" ]]; then
     cd "${devcontainers_test_location}"
+    # Devcontainer builds install binaries in an examples subdirectory
+    examples_dir="examples"
 else
     echo "Error: Test location not found. Searched:" >&2
     echo "  - ${installed_test_location}" >&2
@@ -22,8 +26,8 @@ else
 fi
 
 # Run basic tests
-./BASIC_IO_EXAMPLE
-./BASIC_NO_CUDA_EXAMPLE
+${examples_dir}/BASIC_IO_EXAMPLE
+${examples_dir}/BASIC_NO_CUDA_EXAMPLE
 
 # Run gtests
 ctest --no-tests=error --output-on-failure "$@"


### PR DESCRIPTION
## Summary
- Update `run_ctests.sh` to first try the installed test location (CI/conda environments) and fall back to the build directory (devcontainer environments)
- Enables testing in devcontainers with `test-kvikio-cpp`

xref: https://github.com/rapidsai/devcontainers/pull/630