### PR TITLE
Use CUDA batch memory copy API wherever possible

### DIFF
--- a/cpp/include/kvikio/detail/posix_io.hpp
+++ b/cpp/include/kvikio/detail/posix_io.hpp
@@ -243,12 +243,12 @@ std::size_t posix_device_io(int fd_direct_off,
       // unaligned DIO path).
       nbytes_io = static_cast<std::size_t>(posix_host_io<IOOperationType::READ, PartialIO::YES>(
         fd_direct_off, bounce_buffer.get(), nbytes_requested, cur_file_offset, fd_direct_on));
-      KVIKIO_CUDA_DRIVER_TRY(
-        cudaAPI::instance().MemcpyHtoDAsync(devPtr, bounce_buffer.get(), nbytes_io, stream));
+      KVIKIO_CUDA_DRIVER_TRY(cudaAPI::cuda_memcpy_async(
+        devPtr, convert_void2deviceptr(bounce_buffer.get()), nbytes_io, stream));
       KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
     } else {  // Is a write operation
-      KVIKIO_CUDA_DRIVER_TRY(
-        cudaAPI::instance().MemcpyDtoHAsync(bounce_buffer.get(), devPtr, nbytes_requested, stream));
+      KVIKIO_CUDA_DRIVER_TRY(cudaAPI::cuda_memcpy_async(
+        convert_void2deviceptr(bounce_buffer.get()), devPtr, nbytes_requested, stream));
       KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
       posix_host_io<IOOperationType::WRITE, PartialIO::NO>(
         fd_direct_off, bounce_buffer.get(), nbytes_requested, cur_file_offset, fd_direct_on);

--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -117,6 +117,23 @@ class cudaAPI {
   void operator=(cudaAPI const&) = delete;
 
   KVIKIO_EXPORT static cudaAPI& instance();
+
+  /**
+   * @brief Copy memory asynchronously, preferring the batched API when available.
+   *
+   * Uses `cuMemcpyBatchAsync` with stream-ordered source access when the CUDA driver supports it
+   * (CUDA >= 12.8); otherwise falls back to `cuMemcpyAsync`.
+   *
+   * @param dst Destination device pointer.
+   * @param src Source device pointer (may alias host-registered memory under UVA).
+   * @param size Number of bytes to copy.
+   * @param stream CUDA stream for ordering.
+   * @return CUresult from the underlying driver call.
+   */
+  static CUresult cuda_memcpy_async(CUdeviceptr dst,
+                                    CUdeviceptr src,
+                                    size_t ByteCount,
+                                    CUstream hStream);
 };
 
 /**
@@ -127,19 +144,5 @@ class cudaAPI {
  * @return The boolean answer
  */
 bool is_cuda_available();
-
-/**
- * @brief Copy memory asynchronously, preferring the batched API when available.
- *
- * Uses `cuMemcpyBatchAsync` with stream-ordered source access when the CUDA driver supports it
- * (CUDA >= 12.8); otherwise falls back to `cuMemcpyAsync`.
- *
- * @param dst Destination device pointer.
- * @param src Source device pointer (may alias host-registered memory under UVA).
- * @param size Number of bytes to copy.
- * @param stream CUDA stream for ordering.
- * @return CUresult from the underlying driver call.
- */
-CUresult cuda_memcpy_async(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount, CUstream hStream);
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -132,8 +132,8 @@ class cudaAPI {
    */
   static CUresult cuda_memcpy_async(CUdeviceptr dst,
                                     CUdeviceptr src,
-                                    size_t ByteCount,
-                                    CUstream hStream);
+                                    std::size_t size,
+                                    CUstream stream);
 };
 
 /**

--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -86,6 +86,7 @@ class cudaAPI {
   decltype(cuMemHostUnregister)* MemHostUnregister{nullptr};
   decltype(cuMemcpyHtoDAsync)* MemcpyHtoDAsync{nullptr};
   decltype(cuMemcpyDtoHAsync)* MemcpyDtoHAsync{nullptr};
+  decltype(cuMemcpyAsync)* MemcpyAsync{nullptr};
 
   detail::AnyCallable MemcpyBatchAsync{};
 
@@ -126,5 +127,19 @@ class cudaAPI {
  * @return The boolean answer
  */
 bool is_cuda_available();
+
+/**
+ * @brief Copy memory asynchronously, preferring the batched API when available.
+ *
+ * Uses `cuMemcpyBatchAsync` with stream-ordered source access when the CUDA driver supports it
+ * (CUDA >= 12.8); otherwise falls back to `cuMemcpyAsync`.
+ *
+ * @param dst Destination device pointer.
+ * @param src Source device pointer (may alias host-registered memory under UVA).
+ * @param size Number of bytes to copy.
+ * @param stream CUDA stream for ordering.
+ * @return CUresult from the underlying driver call.
+ */
+CUresult cuda_memcpy_async(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount, CUstream hStream);
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -119,15 +119,16 @@ class cudaAPI {
   KVIKIO_EXPORT static cudaAPI& instance();
 
   /**
-   * @brief Copy memory asynchronously, preferring the batched API when available for non-default
-   * stream.
+   * @brief Asynchronous memcpy that prefers `cuMemcpyBatchAsync` when supported.
    *
-   * Uses `cuMemcpyBatchAsync` with stream-ordered source access when the CUDA driver supports it
-   * (CUDA >= 12.8) for non-default stream; otherwise falls back to `cuMemcpyAsync`.
+   * Dispatches to `cuMemcpyBatchAsync` with `CU_MEMCPY_SRC_ACCESS_ORDER_STREAM`
+   * on CUDA >= 12.8 when `stream` is non-default; otherwise falls back to
+   * `cuMemcpyAsync`. The fallback is mandatory on the default (NULL) stream,
+   * which `cuMemcpyBatchAsync` rejects.
    *
-   * @param dst Destination device pointer.
-   * @param src Source device pointer (may alias host-registered memory under UVA).
-   * @param size Number of bytes to copy.
+   * @param dst    Destination pointer (host or device under UVA).
+   * @param src    Source pointer (host or device under UVA).
+   * @param size   Number of bytes to copy.
    * @param stream CUDA stream for ordering.
    * @return CUresult from the underlying driver call.
    */

--- a/cpp/include/kvikio/shim/cuda.hpp
+++ b/cpp/include/kvikio/shim/cuda.hpp
@@ -119,10 +119,11 @@ class cudaAPI {
   KVIKIO_EXPORT static cudaAPI& instance();
 
   /**
-   * @brief Copy memory asynchronously, preferring the batched API when available.
+   * @brief Copy memory asynchronously, preferring the batched API when available for non-default
+   * stream.
    *
    * Uses `cuMemcpyBatchAsync` with stream-ordered source access when the CUDA driver supports it
-   * (CUDA >= 12.8); otherwise falls back to `cuMemcpyAsync`.
+   * (CUDA >= 12.8) for non-default stream; otherwise falls back to `cuMemcpyAsync`.
    *
    * @param dst Destination device pointer.
    * @param src Source device pointer (may alias host-registered memory under UVA).

--- a/cpp/src/detail/posix_io.cpp
+++ b/cpp/src/detail/posix_io.cpp
@@ -56,8 +56,11 @@ std::size_t posix_device_read_aligned(int fd_direct_off,
 
     std::size_t nbytes_processed = std::min(nbytes_expected, nbytes_io - prefix);
 
-    KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().MemcpyHtoDAsync(
-      devPtr, static_cast<std::byte*>(bounce_buffer.get()) + prefix, nbytes_processed, stream));
+    KVIKIO_CUDA_DRIVER_TRY(cudaAPI::cuda_memcpy_async(
+      devPtr,
+      convert_void2deviceptr(static_cast<std::byte*>(bounce_buffer.get()) + prefix),
+      nbytes_processed,
+      stream));
     KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
 
     cur_file_offset += nbytes_processed;

--- a/cpp/src/mmap.cpp
+++ b/cpp/src/mmap.cpp
@@ -21,6 +21,7 @@
 #include <kvikio/error.hpp>
 #include <kvikio/file_utils.hpp>
 #include <kvikio/mmap.hpp>
+#include <kvikio/shim/cuda.hpp>
 #include <kvikio/utils.hpp>
 
 namespace kvikio {
@@ -192,50 +193,19 @@ void read_impl(void* dst_buf,
 
   PushAndPopContext c(ctx);
   CUstream stream = detail::StreamCachePerThreadAndContext::get();
-
-  auto h2d_batch_cpy_sync =
-    [](CUdeviceptr dst_devptr, CUdeviceptr src_devptr, std::size_t size, CUstream stream) {
-#if CUDA_VERSION >= 12080
-      if (cudaAPI::instance().MemcpyBatchAsync) {
-        CUmemcpyAttributes attrs{};
-        std::size_t attrs_idxs[] = {0};
-        attrs.srcAccessOrder     = CUmemcpySrcAccessOrder_enum::CU_MEMCPY_SRC_ACCESS_ORDER_STREAM;
-        KVIKIO_CUDA_DRIVER_TRY(
-          cudaAPI::instance().MemcpyBatchAsync(&dst_devptr,
-                                               &src_devptr,
-                                               &size,
-                                               static_cast<std::size_t>(1) /* count */,
-                                               &attrs,
-                                               attrs_idxs,
-                                               static_cast<std::size_t>(1) /* num_attrs */,
-#if CUDA_VERSION < 13000
-                                               static_cast<std::size_t*>(nullptr),
-#endif
-                                               stream));
-      } else {
-        // Fall back to the conventional H2D copy if the batch copy API is not available.
-        KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().MemcpyHtoDAsync(
-          dst_devptr, reinterpret_cast<void*>(src_devptr), size, stream));
-      }
-#else
-      KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().MemcpyHtoDAsync(
-        dst_devptr, reinterpret_cast<void*>(src_devptr), size, stream));
-#endif
-      KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
-    };
-
   auto dst_devptr = convert_void2deviceptr(dst);
   CUdeviceptr src_devptr{};
   if (detail::is_ats_available()) {
     perform_prefault(src, size);
     src_devptr = convert_void2deviceptr(src);
-    h2d_batch_cpy_sync(dst_devptr, src_devptr, size, stream);
   } else {
     auto bounce_buffer = CudaPinnedBounceBufferPool::instance().get();
     std::memcpy(bounce_buffer.get(), src, size);
     src_devptr = convert_void2deviceptr(bounce_buffer.get());
-    h2d_batch_cpy_sync(dst_devptr, src_devptr, size, stream);
   }
+
+  KVIKIO_CUDA_DRIVER_TRY(cudaAPI::cuda_memcpy_async(dst_devptr, src_devptr, size, stream));
+  KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
 }
 
 }  // namespace detail

--- a/cpp/src/mmap.cpp
+++ b/cpp/src/mmap.cpp
@@ -193,20 +193,51 @@ void read_impl(void* dst_buf,
 
   PushAndPopContext c(ctx);
   CUstream stream = detail::StreamCachePerThreadAndContext::get();
+
+  auto h2d_batch_cpy_sync =
+    [](CUdeviceptr dst_devptr, CUdeviceptr src_devptr, std::size_t size, CUstream stream) {
+#if CUDA_VERSION >= 12080
+      if (cudaAPI::instance().MemcpyBatchAsync) {
+        CUmemcpyAttributes attrs{};
+        std::size_t attrs_idxs[] = {0};
+        attrs.srcAccessOrder     = CUmemcpySrcAccessOrder_enum::CU_MEMCPY_SRC_ACCESS_ORDER_STREAM;
+        KVIKIO_CUDA_DRIVER_TRY(
+          cudaAPI::instance().MemcpyBatchAsync(&dst_devptr,
+                                               &src_devptr,
+                                               &size,
+                                               static_cast<std::size_t>(1) /* count */,
+                                               &attrs,
+                                               attrs_idxs,
+                                               static_cast<std::size_t>(1) /* num_attrs */,
+#if CUDA_VERSION < 13000
+                                               static_cast<std::size_t*>(nullptr),
+#endif
+                                               stream));
+      } else {
+        // Fall back to the conventional H2D copy if the batch copy API is not available.
+        KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().MemcpyHtoDAsync(
+          dst_devptr, reinterpret_cast<void*>(src_devptr), size, stream));
+      }
+#else
+      KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().MemcpyHtoDAsync(
+        dst_devptr, reinterpret_cast<void*>(src_devptr), size, stream));
+#endif
+    };
+
   auto dst_devptr = convert_void2deviceptr(dst);
   CUdeviceptr src_devptr{};
   if (detail::is_ats_available()) {
     perform_prefault(src, size);
     src_devptr = convert_void2deviceptr(src);
     KVIKIO_CUDA_DRIVER_TRY(cudaAPI::cuda_memcpy_async(dst_devptr, src_devptr, size, stream));
+    KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
   } else {
     auto bounce_buffer = CudaPinnedBounceBufferPool::instance().get();
     std::memcpy(bounce_buffer.get(), src, size);
     src_devptr = convert_void2deviceptr(bounce_buffer.get());
     KVIKIO_CUDA_DRIVER_TRY(cudaAPI::cuda_memcpy_async(dst_devptr, src_devptr, size, stream));
+    KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
   }
-
-  KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
 }
 
 }  // namespace detail

--- a/cpp/src/mmap.cpp
+++ b/cpp/src/mmap.cpp
@@ -198,13 +198,14 @@ void read_impl(void* dst_buf,
   if (detail::is_ats_available()) {
     perform_prefault(src, size);
     src_devptr = convert_void2deviceptr(src);
+    KVIKIO_CUDA_DRIVER_TRY(cudaAPI::cuda_memcpy_async(dst_devptr, src_devptr, size, stream));
   } else {
     auto bounce_buffer = CudaPinnedBounceBufferPool::instance().get();
     std::memcpy(bounce_buffer.get(), src, size);
     src_devptr = convert_void2deviceptr(bounce_buffer.get());
+    KVIKIO_CUDA_DRIVER_TRY(cudaAPI::cuda_memcpy_async(dst_devptr, src_devptr, size, stream));
   }
 
-  KVIKIO_CUDA_DRIVER_TRY(cudaAPI::cuda_memcpy_async(dst_devptr, src_devptr, size, stream));
   KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(stream));
 }
 

--- a/cpp/src/mmap.cpp
+++ b/cpp/src/mmap.cpp
@@ -193,37 +193,6 @@ void read_impl(void* dst_buf,
 
   PushAndPopContext c(ctx);
   CUstream stream = detail::StreamCachePerThreadAndContext::get();
-
-  auto h2d_batch_cpy_sync =
-    [](CUdeviceptr dst_devptr, CUdeviceptr src_devptr, std::size_t size, CUstream stream) {
-#if CUDA_VERSION >= 12080
-      if (cudaAPI::instance().MemcpyBatchAsync) {
-        CUmemcpyAttributes attrs{};
-        std::size_t attrs_idxs[] = {0};
-        attrs.srcAccessOrder     = CUmemcpySrcAccessOrder_enum::CU_MEMCPY_SRC_ACCESS_ORDER_STREAM;
-        KVIKIO_CUDA_DRIVER_TRY(
-          cudaAPI::instance().MemcpyBatchAsync(&dst_devptr,
-                                               &src_devptr,
-                                               &size,
-                                               static_cast<std::size_t>(1) /* count */,
-                                               &attrs,
-                                               attrs_idxs,
-                                               static_cast<std::size_t>(1) /* num_attrs */,
-#if CUDA_VERSION < 13000
-                                               static_cast<std::size_t*>(nullptr),
-#endif
-                                               stream));
-      } else {
-        // Fall back to the conventional H2D copy if the batch copy API is not available.
-        KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().MemcpyHtoDAsync(
-          dst_devptr, reinterpret_cast<void*>(src_devptr), size, stream));
-      }
-#else
-      KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().MemcpyHtoDAsync(
-        dst_devptr, reinterpret_cast<void*>(src_devptr), size, stream));
-#endif
-    };
-
   auto dst_devptr = convert_void2deviceptr(dst);
   CUdeviceptr src_devptr{};
   if (detail::is_ats_available()) {

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -86,7 +86,7 @@ class BounceBufferH2D {
     KVIKIO_NVTX_FUNC_RANGE();
     if (size > 0) {
       KVIKIO_CUDA_DRIVER_TRY(
-        cudaAPI::instance().MemcpyHtoDAsync(_dev + _dev_offset, src, size, _stream));
+        cudaAPI::cuda_memcpy_async(_dev + _dev_offset, convert_void2deviceptr(src), size, _stream));
       KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(_stream));
       _dev_offset += size;
     }

--- a/cpp/src/shim/cuda.cpp
+++ b/cpp/src/shim/cuda.cpp
@@ -78,7 +78,10 @@ bool is_cuda_available()
   return true;
 }
 
-CUresult cuda_memcpy_async(CUdeviceptr dst, CUdeviceptr src, std::size_t size, CUstream stream)
+CUresult cudaAPI::cuda_memcpy_async(CUdeviceptr dst,
+                                    CUdeviceptr src,
+                                    std::size_t size,
+                                    CUstream stream)
 {
 #if CUDA_VERSION >= 12080
   if (cudaAPI::instance().MemcpyBatchAsync) {

--- a/cpp/src/shim/cuda.cpp
+++ b/cpp/src/shim/cuda.cpp
@@ -23,6 +23,7 @@ cudaAPI::cudaAPI()
   get_symbol(MemHostUnregister, lib, KVIKIO_STRINGIFY(cuMemHostUnregister));
   get_symbol(MemcpyHtoDAsync, lib, KVIKIO_STRINGIFY(cuMemcpyHtoDAsync));
   get_symbol(MemcpyDtoHAsync, lib, KVIKIO_STRINGIFY(cuMemcpyDtoHAsync));
+  get_symbol(MemcpyAsync, lib, KVIKIO_STRINGIFY(cuMemcpyAsync));
   get_symbol(PointerGetAttribute, lib, KVIKIO_STRINGIFY(cuPointerGetAttribute));
   get_symbol(PointerGetAttributes, lib, KVIKIO_STRINGIFY(cuPointerGetAttributes));
   get_symbol(CtxPushCurrent, lib, KVIKIO_STRINGIFY(cuCtxPushCurrent));
@@ -75,6 +76,33 @@ bool is_cuda_available()
     return false;
   }
   return true;
+}
+
+CUresult cuda_memcpy_async(CUdeviceptr dst, CUdeviceptr src, std::size_t size, CUstream stream)
+{
+#if CUDA_VERSION >= 12080
+  if (cudaAPI::instance().MemcpyBatchAsync) {
+    CUmemcpyAttributes attrs{.srcAccessOrder =
+                               CUmemcpySrcAccessOrder_enum::CU_MEMCPY_SRC_ACCESS_ORDER_STREAM};
+    std::size_t attrs_idxs[] = {0};
+    return cudaAPI::instance().MemcpyBatchAsync(&dst,
+                                                &src,
+                                                &size,
+                                                static_cast<std::size_t>(1) /* count */,
+                                                &attrs,
+                                                attrs_idxs,
+                                                static_cast<std::size_t>(1) /* num_attrs */,
+#if CUDA_VERSION < 13000
+                                                static_cast<std::size_t*>(nullptr),
+#endif
+                                                stream);
+  } else {
+    // Fall back to the conventional memory copy if the batch copy API is not available.
+    return cudaAPI::instance().MemcpyAsync(dst, src, size, stream);
+  }
+#else
+  return cudaAPI::instance().MemcpyAsync(dst, src, size, stream);
+#endif
 }
 
 }  // namespace kvikio

--- a/cpp/src/shim/cuda.cpp
+++ b/cpp/src/shim/cuda.cpp
@@ -84,7 +84,7 @@ CUresult cudaAPI::cuda_memcpy_async(CUdeviceptr dst,
                                     CUstream stream)
 {
 #if CUDA_VERSION >= 12080
-  if (cudaAPI::instance().MemcpyBatchAsync) {
+  if (cudaAPI::instance().MemcpyBatchAsync && stream != nullptr) {
     CUmemcpyAttributes attrs{.srcAccessOrder =
                                CUmemcpySrcAccessOrder_enum::CU_MEMCPY_SRC_ACCESS_ORDER_STREAM};
     std::size_t attrs_idxs[] = {0};


### PR DESCRIPTION
The use of CUDA batched memory copy for general CPU-GPU copy is recommended by the driver team, as it avoids certain limitations in the traditional memory copy API, such as unexpected device-wide synchronizations. This PR replaces `cuMemcpyHtoDAsync` and `cuMemcpyDtoHAsync` with `cuMemcpyBatchAsync`.