### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-nvcc
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - doxygen=1.9.1

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-nvcc
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - doxygen=1.9.1

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-nvcc
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - doxygen=1.9.1

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-nvcc
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - doxygen=1.9.1

--- a/conda/recipes/kvikio/recipe.yaml
+++ b/conda/recipes/kvikio/recipe.yaml
@@ -90,7 +90,7 @@ requirements:
     - scikit-build-core>=0.11.0
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - libkvikio =${{ version }}
     - numpy >=1.23,<3.0
     - packaging

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -279,18 +279,18 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - &cupy_unsuffixed cupy>=13.6.0
+          - &cupy_unsuffixed cupy>=13.6.0,!=14.0.0,!=14.1.0
     specific:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
           - matrix:
               cuda: "13.*"
             packages:
-              - &cupy_cu13 cupy-cuda13x>=13.6.0
+              - &cupy_cu13 cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
           - matrix:
             packages:
               - *cupy_cu13

--- a/python/kvikio/kvikio/benchmarks/utils.py
+++ b/python/kvikio/kvikio/benchmarks/utils.py
@@ -20,7 +20,7 @@ has_cuda_core_system = False
 with contextlib.suppress(ImportError):
     from cuda.core import system
 
-    has_cuda_core_system = system.CUDA_BINDINGS_IS_NVML_COMPATIBLE
+    has_cuda_core_system = system.CUDA_BINDINGS_NVML_IS_COMPATIBLE
 
 
 def drop_vm_cache() -> None:

--- a/python/kvikio/pyproject.toml
+++ b/python/kvikio/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "libkvikio==26.6.*,>=0.0.0a0",
     "numpy>=1.23,<3.0",
     "packaging",

--- a/python/kvikio/tests/conftest.py
+++ b/python/kvikio/tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/python/kvikio/tests/conftest.py
+++ b/python/kvikio/tests/conftest.py
@@ -21,13 +21,14 @@ def command_server(conn: Connection) -> None:
         cmd, cwd, verbose = conn.recv()
         # Run command
         res: subprocess.CompletedProcess = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=cwd,
+            text=True,
         )  # type: ignore
-        if verbose:
-            print(f"{cwd}$ " + " ".join(res.args))
-            print(res.stdout.decode(), end="")
-        # Send return code back to client
-        conn.send(res.returncode)
+        # Send process result back to client.
+        conn.send((res.args, cwd, res.returncode, res.stdout, res.stderr))
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -49,7 +50,18 @@ def run_cmd():
 
     def run_cmd(cmd: Iterable[str], cwd, verbose=True):
         client_conn.send((cmd, cwd, verbose))
-        return client_conn.recv()
+        args, cwd, returncode, stdout, stderr = client_conn.recv()
+
+        if verbose or returncode != 0:
+            print(f"{cwd}$ " + " ".join(args))
+            if stdout:
+                print("--- stdout ---")
+                print(stdout, end="" if stdout.endswith("\n") else "\n")
+            if stderr:
+                print("--- stderr ---")
+                print(stderr, end="" if stderr.endswith("\n") else "\n")
+
+        return returncode
 
     yield run_cmd
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.

See the linked issue for details.
