### PR TITLE
PERF: Avoid duplicate HEAD requests for file size with S3 endpoint

### DIFF
--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -672,7 +672,9 @@ RemoteHandle RemoteHandle::open(std::string url,
   }
 
   if (nbytes.has_value()) { return RemoteHandle(std::move(endpoint), nbytes.value()); }
-  if (probed_nbytes.has_value()) { return RemoteHandle(std::move(endpoint), probed_nbytes.value()); }
+  if (probed_nbytes.has_value()) {
+    return RemoteHandle(std::move(endpoint), probed_nbytes.value());
+  }
   return RemoteHandle(std::move(endpoint));
 }
 

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -625,6 +625,7 @@ RemoteHandle RemoteHandle::open(std::string url,
   };
 
   std::unique_ptr<RemoteEndpoint> endpoint;
+  std::optional<std::size_t> probed_nbytes;
 
   if (remote_endpoint_type == RemoteEndpointType::AUTO) {
     // Try each allowed type in the order of allowlist
@@ -634,8 +635,8 @@ RemoteHandle RemoteHandle::open(std::string url,
         if (endpoint == nullptr) { continue; }
         if (type == RemoteEndpointType::S3) {
           // Check connectivity for the credential-based S3 endpoint, and throw an exception if
-          // failed
-          endpoint->get_file_size();
+          // failed. Reuse this size when constructing the handle to avoid a second HEAD request.
+          probed_nbytes = endpoint->get_file_size();
         }
       } catch (...) {
         // If the credential-based S3 endpoint cannot be used to access the URL, try using S3 public
@@ -643,7 +644,8 @@ RemoteHandle RemoteHandle::open(std::string url,
         if (type == RemoteEndpointType::S3 &&
             std::find(allow_list->begin(), allow_list->end(), RemoteEndpointType::S3_PUBLIC) !=
               allow_list->end()) {
-          endpoint = std::make_unique<S3PublicEndpoint>(url);
+          endpoint      = std::make_unique<S3PublicEndpoint>(url);
+          probed_nbytes = std::nullopt;
         } else {
           throw;
         }
@@ -669,8 +671,9 @@ RemoteHandle RemoteHandle::open(std::string url,
                   std::runtime_error);
   }
 
-  return nbytes.has_value() ? RemoteHandle(std::move(endpoint), nbytes.value())
-                            : RemoteHandle(std::move(endpoint));
+  if (nbytes.has_value()) { return RemoteHandle(std::move(endpoint), nbytes.value()); }
+  if (probed_nbytes.has_value()) { return RemoteHandle(std::move(endpoint), probed_nbytes.value()); }
+  return RemoteHandle(std::move(endpoint));
 }
 
 RemoteHandle::RemoteHandle(std::unique_ptr<RemoteEndpoint> endpoint, std::size_t nbytes)

--- a/cpp/tests/test_remote_handle.cpp
+++ b/cpp/tests/test_remote_handle.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -70,9 +70,9 @@ class RemoteHandleTest : public testing::Test {
           // kvikio::RemoteEndpointType::S3 in AUTO mode, this prevents querying the file size and
           // sending requests to the server, thus allowing us to use dummy URLs for testing.
           // For kvikio::RemoteEndpointType::S3 with AUTO, RemoteHandle::open sends a HEAD request
-          // as a connectivity check (and reuses that size when nbytes is not provided). It will fail
-          // on the syntactically valid dummy URL, and kvikio::RemoteEndpointType::S3_PUBLIC will
-          // then be used as the endpoint.
+          // as a connectivity check (and reuses that size when nbytes is not provided). It will
+          // fail on the syntactically valid dummy URL, and kvikio::RemoteEndpointType::S3_PUBLIC
+          // will then be used as the endpoint.
           auto remote_handle =
             kvikio::RemoteHandle::open(url, kvikio::RemoteEndpointType::AUTO, std::nullopt, 1);
           EXPECT_EQ(remote_handle.remote_endpoint_type(), expected_endpoint_type);

--- a/cpp/tests/test_remote_handle.cpp
+++ b/cpp/tests/test_remote_handle.cpp
@@ -67,12 +67,12 @@ class RemoteHandleTest : public testing::Test {
         // Test unified interface
         {
           // Here we pass the 1-byte argument to RemoteHandle::open. For all endpoints except
-          // kvikio::RemoteEndpointType::S3, this prevents the endpoint constructor from querying
-          // the file size and sending requests to the server, thus allowing us to use dummy URLs
-          // for testing purpose.
-          // For kvikio::RemoteEndpointType::S3, RemoteHandle::open sends HEAD request as a
-          // connectivity check and will fail on the syntactically valid dummy URL. The
-          // kvikio::RemoteEndpointType::S3_PUBLIC will then be used as the endpoint.
+          // kvikio::RemoteEndpointType::S3 in AUTO mode, this prevents querying the file size and
+          // sending requests to the server, thus allowing us to use dummy URLs for testing.
+          // For kvikio::RemoteEndpointType::S3 with AUTO, RemoteHandle::open sends a HEAD request
+          // as a connectivity check (and reuses that size when nbytes is not provided). It will fail
+          // on the syntactically valid dummy URL, and kvikio::RemoteEndpointType::S3_PUBLIC will
+          // then be used as the endpoint.
           auto remote_handle =
             kvikio::RemoteHandle::open(url, kvikio::RemoteEndpointType::AUTO, std::nullopt, 1);
           EXPECT_EQ(remote_handle.remote_endpoint_type(), expected_endpoint_type);


### PR DESCRIPTION
Our S3 implementaiton made two HEAD requests on S3 urls in "AUTO" mode (the only mode that's exposed to libcudf users).

1. A first HEAD request to test S3 credentials
2. A second HEAD request to get the file size

We can avoid the second HEAD request by reusing the response to the first HEAD request when we go to actually open the file.

Closes #973

Here's an screenshot of an nsys profile showing the single `get_file_size()` / `HEAD` request on this script:

```python
import pylibcudf as plc


sources = plc.io.types.SourceInfo(["s3://rapids-tpch/scale-10/nation/part.0.parquet"])
options = plc.io.parquet.ParquetReaderOptions.builder(sources).build()
table = plc.io.parquet.read_parquet(options)
```

<img width="1430" height="196" alt="image" src="https://github.com/user-attachments/assets/9f770d5c-249e-4187-90f0-2185274a42e6" />
