### PR TITLE
Limit concurrency to counterintuitively improve overall performance for host buffer (libcurl multi poll-based backend 4/n)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -168,6 +168,7 @@ set(SOURCES
     "src/file_utils.cpp"
     "src/logger.cpp"
     "src/mmap.cpp"
+    "src/detail/concurrent_request_limiter.cpp"
     "src/detail/env.cpp"
     "src/detail/event.cpp"
     "src/detail/nvtx.cpp"

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -136,6 +136,7 @@ class defaults {
   RemoteIOBackend _remote_io_backend;
   unsigned int _remote_io_num_reactors;
   RemoteReactorDispatch _remote_io_reactor_dispatch;
+  std::size_t _remote_io_max_concurrent_requests;
 
   static unsigned int get_num_threads_from_env();
 
@@ -491,6 +492,23 @@ class defaults {
    * @return The reactor dispatch policy.
    */
   [[nodiscard]] static RemoteReactorDispatch remote_io_reactor_dispatch();
+
+  /**
+   * @brief Maximum number of concurrent in-flight requests across all reactor threads under the
+   * `MULTI_POLL` remote I/O backend.
+   *
+   * One `pread()` of a large file is split into many sub-range requests (one libcurl easy handle
+   * each). This bounds how many of them are attached to the reactors' multi handles at once, summed
+   * across all reactor threads. The bound is what keeps the backend from fanning out thousands of
+   * simultaneous connections and collapsing throughput.
+   *
+   * Controlled by `KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS`. Must be a non-negative integer; 0
+   * means unlimited. Defaults to 256. Ignored when the active backend is not `MULTI_POLL`
+   * (`EASY_THREADPOOL` is already bounded by `KVIKIO_NTHREADS`).
+   *
+   * @return The configured concurrent-request ceiling, or 0 for unlimited.
+   */
+  [[nodiscard]] static std::size_t remote_io_max_concurrent_requests();
 };
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/defaults.hpp
+++ b/cpp/include/kvikio/defaults.hpp
@@ -499,10 +499,13 @@ class defaults {
    *
    * One `pread()` of a large file is split into many sub-range requests (one libcurl easy handle
    * each). This bounds how many of them are attached to the reactors' multi handles at once, summed
-   * across all reactor threads. The bound is what keeps the backend from fanning out thousands of
-   * simultaneous connections and collapsing throughput.
+   * across all reactor threads.
    *
-   * Controlled by `KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS`. Must be a non-negative integer; 0
+   * The budget is divided into an equal private share per reactor, so the effective total is
+   * approximate: it rounds down when the value is not a multiple of the reactor count, and up when
+   * it is smaller than the reactor count (each reactor is floored to at least 1).
+   *
+   * Controlled by `KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS`. Must be a non-negative integer. 0
    * means unlimited. Defaults to 256. Ignored when the active backend is not `MULTI_POLL`
    * (`EASY_THREADPOOL` is already bounded by `KVIKIO_NTHREADS`).
    *

--- a/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
+++ b/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+
+namespace kvikio::detail {
+
+/**
+ * @brief Non-blocking counting limiter that bounds the number of concurrent in-flight requests.
+ *
+ * Used by the `MULTI_POLL` remote I/O backend to cap the total number of HTTP range requests
+ * (libcurl easy handles) that are simultaneously attached to the reactors' multi handles, across
+ * all reactor threads. Without such a bound, one `pread()` of a large file fans out to one request
+ * per sub-range (e.g. thousands at once), which overwhelms the network path and collapses
+ * throughput. A single process-wide instance is owned by `MultiReactorPool`.
+ *
+ * The limiter never blocks. A caller that cannot acquire a slot is expected to defer its work and
+ * retry later, so the reactor thread is free to keep driving the requests it already admitted
+ * (which is what eventually frees slots). `try_acquire()` and `release()` are thread-safe and may
+ * be called from different threads, including a release from a completion callback running on
+ * another thread.
+ *
+ * A `_max` of 0 means unlimited. To keep the acquire/release pairing uniform at every call site,
+ * the limiter still counts in the unlimited case (`try_acquire()` always succeeds), so callers
+ * always pair a successful `try_acquire()` with exactly one `release()` regardless of
+ * configuration.
+ */
+class ConcurrentRequestLimiter {
+ public:
+  /**
+   * @brief Construct a limiter with the given ceiling.
+   *
+   * @param max_concurrent_requests Maximum number of slots that may be held at once. 0 means
+   * unlimited.
+   */
+  explicit ConcurrentRequestLimiter(std::size_t max_concurrent_requests) noexcept;
+
+  ConcurrentRequestLimiter(ConcurrentRequestLimiter const&)            = delete;
+  ConcurrentRequestLimiter& operator=(ConcurrentRequestLimiter const&) = delete;
+  ConcurrentRequestLimiter(ConcurrentRequestLimiter&&)                 = delete;
+  ConcurrentRequestLimiter& operator=(ConcurrentRequestLimiter&&)      = delete;
+
+  /**
+   * @brief Try to reserve one slot without blocking.
+   *
+   * @return `true` if a slot was reserved (the caller must later call `release()` exactly once), or
+   * `false` if the limiter is already at its ceiling. Always returns `true` when unlimited.
+   */
+  [[nodiscard]] bool try_acquire() noexcept;
+
+  /**
+   * @brief Return one previously reserved slot. Must be paired one-to-one with a successful
+   * `try_acquire()`.
+   */
+  void release() noexcept;
+
+  /**
+   * @brief Whether this limiter imposes no ceiling.
+   */
+  [[nodiscard]] bool unlimited() const noexcept;
+
+ private:
+  std::size_t const _max;  // 0 means unlimited.
+  std::atomic<std::size_t> _count{0};
+};
+
+}  // namespace kvikio::detail

--- a/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
+++ b/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
@@ -18,7 +18,7 @@ namespace kvikio::detail {
  * own limiter, sized to a private share of the global budget
  * (`KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS / num_reactors`).
  *
- * The limiter does not blocks. A caller that cannot acquire a slot is expected to defer its work
+ * The limiter does not block. A caller that cannot acquire a slot is expected to defer its work
  * and retry later, so the reactor thread is free to keep driving the requests it already admitted.
  * `try_acquire()` and `release()` are thread-safe, though in the current `MultiPollReactor`
  * implementation all call sites run on the same I/O thread. Callers are expected to pair a

--- a/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
+++ b/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
@@ -12,25 +12,19 @@ namespace kvikio::detail {
 /**
  * @brief Non-blocking counting limiter that bounds the number of concurrent in-flight requests.
  *
- * Used by the `MULTI_POLL` remote I/O backend to cap the number of HTTP range requests (libcurl
- * easy handles) that a reactor keeps simultaneously attached to its multi handle. Without such a
- * bound, one `pread()` of a large file fans out to one request per sub-range (e.g. thousands at
- * once), which overwhelms the network path and collapses throughput. Each `MultiPollReactor` owns
- * its own limiter, sized to a private share of the global budget
- * (`KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS / num_reactors`); per-reactor shares avoid a single
- * shared admission gate, which would otherwise starve reactors and stall the pipeline under heavy
- * re-admission churn.
+ * Used by the `MULTI_POLL` remote I/O backend to cap the number of HTTP range requests that a
+ * reactor keeps simultaneously attached to its multi handle. Without such a bound, one `pread()`
+ * of a large file may submit too many requests which overwhelms the network. Each reactor owns its
+ * own limiter, sized to a private share of the global budget
+ * (`KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS / num_reactors`).
  *
- * The limiter never blocks. A caller that cannot acquire a slot is expected to defer its work and
- * retry later, so the reactor thread is free to keep driving the requests it already admitted
- * (which is what eventually frees slots). `try_acquire()` and `release()` are thread-safe so that
- * `release()` may run on a different thread than `try_acquire()`, for example a release from a
- * completion callback (used by the device-buffer path).
+ * The limiter does not blocks. A caller that cannot acquire a slot is expected to defer its work
+ * and retry later, so the reactor thread is free to keep driving the requests it already admitted.
+ * `try_acquire()` and `release()` are thread-safe, though in the current `MultiPollReactor`
+ * implementation all call sites run on the same I/O thread. Callers are expected to pair a
+ * successful `try_acquire()` with exactly one `release()`.
  *
- * A `_max` of 0 means unlimited. To keep the acquire/release pairing uniform at every call site,
- * the limiter still counts in the unlimited case (`try_acquire()` always succeeds), so callers
- * always pair a successful `try_acquire()` with exactly one `release()` regardless of
- * configuration.
+ * A `_max_concurrent_requests` of 0 means unlimited.
  */
 class ConcurrentRequestLimiter {
  public:
@@ -50,8 +44,8 @@ class ConcurrentRequestLimiter {
   /**
    * @brief Try to reserve one slot without blocking.
    *
-   * @return `true` if a slot was reserved (the caller must later call `release()` exactly once), or
-   * `false` if the limiter is already at its ceiling. Always returns `true` when unlimited.
+   * @return `true` if a slot was reserved, and the caller must later call `release()` exactly once,
+   * or `false` if the limiter is already at its ceiling. Always returns `true` when unlimited.
    */
   [[nodiscard]] bool try_acquire() noexcept;
 
@@ -67,7 +61,7 @@ class ConcurrentRequestLimiter {
   [[nodiscard]] bool unlimited() const noexcept;
 
  private:
-  std::size_t const _max;  // 0 means unlimited.
+  std::size_t const _max_concurrent_requests;  // 0 means unlimited.
   std::atomic<std::size_t> _count{0};
 };
 

--- a/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
+++ b/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <optional>
 
 namespace kvikio::detail {
 
@@ -24,17 +25,17 @@ namespace kvikio::detail {
  * implementation all call sites run on the same I/O thread. Callers are expected to pair a
  * successful `try_acquire()` with exactly one `release()`.
  *
- * A `_max_concurrent_requests` of 0 means unlimited.
+ * A `_max_concurrent_requests` of `std::nullopt` means unlimited.
  */
 class ConcurrentRequestLimiter {
  public:
   /**
    * @brief Construct a limiter with the given ceiling.
    *
-   * @param max_concurrent_requests Maximum number of slots that may be held at once. 0 means
-   * unlimited.
+   * @param max_concurrent_requests Maximum number of slots that may be held at once. `std::nullopt`
+   * means unlimited.
    */
-  explicit ConcurrentRequestLimiter(std::size_t max_concurrent_requests) noexcept;
+  explicit ConcurrentRequestLimiter(std::optional<std::size_t> max_concurrent_requests) noexcept;
 
   ConcurrentRequestLimiter(ConcurrentRequestLimiter const&)            = delete;
   ConcurrentRequestLimiter& operator=(ConcurrentRequestLimiter const&) = delete;
@@ -61,7 +62,7 @@ class ConcurrentRequestLimiter {
   [[nodiscard]] bool unlimited() const noexcept;
 
  private:
-  std::size_t const _max_concurrent_requests;  // 0 means unlimited.
+  std::optional<std::size_t> const _max_concurrent_requests;  // std::nullopt means unlimited.
   std::atomic<std::size_t> _count{0};
 };
 

--- a/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
+++ b/cpp/include/kvikio/detail/concurrent_request_limiter.hpp
@@ -12,17 +12,20 @@ namespace kvikio::detail {
 /**
  * @brief Non-blocking counting limiter that bounds the number of concurrent in-flight requests.
  *
- * Used by the `MULTI_POLL` remote I/O backend to cap the total number of HTTP range requests
- * (libcurl easy handles) that are simultaneously attached to the reactors' multi handles, across
- * all reactor threads. Without such a bound, one `pread()` of a large file fans out to one request
- * per sub-range (e.g. thousands at once), which overwhelms the network path and collapses
- * throughput. A single process-wide instance is owned by `MultiReactorPool`.
+ * Used by the `MULTI_POLL` remote I/O backend to cap the number of HTTP range requests (libcurl
+ * easy handles) that a reactor keeps simultaneously attached to its multi handle. Without such a
+ * bound, one `pread()` of a large file fans out to one request per sub-range (e.g. thousands at
+ * once), which overwhelms the network path and collapses throughput. Each `MultiPollReactor` owns
+ * its own limiter, sized to a private share of the global budget
+ * (`KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS / num_reactors`); per-reactor shares avoid a single
+ * shared admission gate, which would otherwise starve reactors and stall the pipeline under heavy
+ * re-admission churn.
  *
  * The limiter never blocks. A caller that cannot acquire a slot is expected to defer its work and
  * retry later, so the reactor thread is free to keep driving the requests it already admitted
- * (which is what eventually frees slots). `try_acquire()` and `release()` are thread-safe and may
- * be called from different threads, including a release from a completion callback running on
- * another thread.
+ * (which is what eventually frees slots). `try_acquire()` and `release()` are thread-safe so that
+ * `release()` may run on a different thread than `try_acquire()`, for example a release from a
+ * completion callback (used by the device-buffer path).
  *
  * A `_max` of 0 means unlimited. To keep the acquire/release pairing uniform at every call site,
  * the limiter still counts in the unlimited case (`try_acquire()` always succeeds), so callers

--- a/cpp/include/kvikio/detail/multi_poll_reactor.hpp
+++ b/cpp/include/kvikio/detail/multi_poll_reactor.hpp
@@ -17,6 +17,7 @@
 
 #include <curl/curl.h>
 
+#include <kvikio/detail/concurrent_request_limiter.hpp>
 #include <kvikio/detail/remote_callback.hpp>
 #include <kvikio/remote_handle.hpp>
 #include <kvikio/shim/libcurl.hpp>
@@ -227,12 +228,28 @@ class MultiReactorPool {
    */
   void signal_death(std::exception_ptr eptr) noexcept;
 
+  /**
+   * @brief The process-wide limiter bounding concurrent in-flight requests across all reactors.
+   *
+   * Reactors consult this in their submission stage: a request is admitted only after a successful
+   * `try_acquire()`, and the slot is released once the request leaves the in-flight set. Exposed as
+   * an accessor (rather than the reactor reaching a member directly) so a future device-buffer
+   * change can route to a per-`CUcontext` limiter via an overload without touching reactor code.
+   *
+   * @return Reference to the limiter.
+   */
+  [[nodiscard]] ConcurrentRequestLimiter& concurrent_request_limiter() noexcept
+  {
+    return _request_limiter;
+  }
+
  private:
   MultiReactorPool();
   ~MultiReactorPool() noexcept;
 
   std::vector<std::unique_ptr<MultiPollReactor>> _reactors;
   RemoteReactorDispatch _dispatch;
+  ConcurrentRequestLimiter _request_limiter;
   // Round-robin counter. Incremented per pread (PER_PREAD) or per chunk (PER_CHUNK).
   std::atomic<std::size_t> _next_reactor_counter{0};
   std::atomic<bool> _dead{false};

--- a/cpp/include/kvikio/detail/multi_poll_reactor.hpp
+++ b/cpp/include/kvikio/detail/multi_poll_reactor.hpp
@@ -110,8 +110,7 @@ class MultiPollReactor {
    * the pool is a leaked singleton that owns this reactor by `unique_ptr`.
    * @param max_concurrent_requests This reactor's private share of the total concurrent-request
    * budget (the global cap divided across reactors). 0 means unlimited. Each reactor enforces its
-   * own share against its own inbox, so there is no shared admission gate to contend on or hand off
-   * across reactor threads.
+   * own share against its own inbox.
    */
   MultiPollReactor(MultiReactorPool* pool, std::size_t max_concurrent_requests);
   ~MultiPollReactor() noexcept;
@@ -155,8 +154,6 @@ class MultiPollReactor {
   void fail_all_pending(std::exception_ptr eptr);
 
   MultiReactorPool* _pool;
-  // This reactor's private share of the concurrent-request budget. Enforced against this reactor's
-  // own inbox only, so admission needs no cross-reactor coordination.
   ConcurrentRequestLimiter _request_limiter;
   CURLM* _curl_multi{nullptr};
   std::thread _io_thread;

--- a/cpp/include/kvikio/detail/multi_poll_reactor.hpp
+++ b/cpp/include/kvikio/detail/multi_poll_reactor.hpp
@@ -11,6 +11,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -109,10 +110,10 @@ class MultiPollReactor {
    * propagate pool-wide death state. The pool must outlive the reactor, which is guaranteed because
    * the pool is a leaked singleton that owns this reactor by `unique_ptr`.
    * @param max_concurrent_requests This reactor's private share of the total concurrent-request
-   * budget (the global cap divided across reactors). 0 means unlimited. Each reactor enforces its
-   * own share against its own inbox.
+   * budget (the global cap divided across reactors). `std::nullopt` means unlimited. Each reactor
+   * enforces its own share against its own inbox.
    */
-  MultiPollReactor(MultiReactorPool* pool, std::size_t max_concurrent_requests);
+  MultiPollReactor(MultiReactorPool* pool, std::optional<std::size_t> max_concurrent_requests);
   ~MultiPollReactor() noexcept;
   MultiPollReactor(MultiPollReactor const&)            = delete;
   MultiPollReactor& operator=(MultiPollReactor const&) = delete;

--- a/cpp/include/kvikio/detail/multi_poll_reactor.hpp
+++ b/cpp/include/kvikio/detail/multi_poll_reactor.hpp
@@ -108,8 +108,12 @@ class MultiPollReactor {
    * @param pool Non-owning back-pointer to the pool that owns this reactor. Used to observe and
    * propagate pool-wide death state. The pool must outlive the reactor, which is guaranteed because
    * the pool is a leaked singleton that owns this reactor by `unique_ptr`.
+   * @param max_concurrent_requests This reactor's private share of the total concurrent-request
+   * budget (the global cap divided across reactors). 0 means unlimited. Each reactor enforces its
+   * own share against its own inbox, so there is no shared admission gate to contend on or hand off
+   * across reactor threads.
    */
-  explicit MultiPollReactor(MultiReactorPool* pool);
+  MultiPollReactor(MultiReactorPool* pool, std::size_t max_concurrent_requests);
   ~MultiPollReactor() noexcept;
   MultiPollReactor(MultiPollReactor const&)            = delete;
   MultiPollReactor& operator=(MultiPollReactor const&) = delete;
@@ -151,6 +155,9 @@ class MultiPollReactor {
   void fail_all_pending(std::exception_ptr eptr);
 
   MultiReactorPool* _pool;
+  // This reactor's private share of the concurrent-request budget. Enforced against this reactor's
+  // own inbox only, so admission needs no cross-reactor coordination.
+  ConcurrentRequestLimiter _request_limiter;
   CURLM* _curl_multi{nullptr};
   std::thread _io_thread;
   std::mutex _submit_mutex;
@@ -228,28 +235,12 @@ class MultiReactorPool {
    */
   void signal_death(std::exception_ptr eptr) noexcept;
 
-  /**
-   * @brief The process-wide limiter bounding concurrent in-flight requests across all reactors.
-   *
-   * Reactors consult this in their submission stage: a request is admitted only after a successful
-   * `try_acquire()`, and the slot is released once the request leaves the in-flight set. Exposed as
-   * an accessor (rather than the reactor reaching a member directly) so a future device-buffer
-   * change can route to a per-`CUcontext` limiter via an overload without touching reactor code.
-   *
-   * @return Reference to the limiter.
-   */
-  [[nodiscard]] ConcurrentRequestLimiter& concurrent_request_limiter() noexcept
-  {
-    return _request_limiter;
-  }
-
  private:
   MultiReactorPool();
   ~MultiReactorPool() noexcept;
 
   std::vector<std::unique_ptr<MultiPollReactor>> _reactors;
   RemoteReactorDispatch _dispatch;
-  ConcurrentRequestLimiter _request_limiter;
   // Round-robin counter. Incremented per pread (PER_PREAD) or per chunk (PER_CHUNK).
   std::atomic<std::size_t> _next_reactor_counter{0};
   std::atomic<bool> _dead{false};

--- a/cpp/src/defaults.cpp
+++ b/cpp/src/defaults.cpp
@@ -173,6 +173,14 @@ defaults::defaults()
     _remote_io_reactor_dispatch =
       getenv_or("KVIKIO_REMOTE_IO_REACTOR_DISPATCH", RemoteReactorDispatch::PER_CHUNK);
   }
+  {
+    ssize_t const env = getenv_or("KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS", ssize_t{256});
+    KVIKIO_EXPECT(
+      env >= 0,
+      "KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS has to be a non-negative integer (0 = unlimited)",
+      std::invalid_argument);
+    _remote_io_max_concurrent_requests = static_cast<std::size_t>(env);
+  }
 }
 
 defaults* defaults::instance()
@@ -292,5 +300,10 @@ unsigned int defaults::remote_io_num_reactors() { return instance()->_remote_io_
 RemoteReactorDispatch defaults::remote_io_reactor_dispatch()
 {
   return instance()->_remote_io_reactor_dispatch;
+}
+
+std::size_t defaults::remote_io_max_concurrent_requests()
+{
+  return instance()->_remote_io_max_concurrent_requests;
 }
 }  // namespace kvikio

--- a/cpp/src/detail/concurrent_request_limiter.cpp
+++ b/cpp/src/detail/concurrent_request_limiter.cpp
@@ -39,8 +39,8 @@ void ConcurrentRequestLimiter::release() noexcept
 {
   [[maybe_unused]] auto const prev = _count.fetch_sub(1, std::memory_order_relaxed);
 
-  // A release without a matching successful acquire may underflow the unsigned count and silently
-  // disables the cap
+  // A release without a matching successful acquire underflows the unsigned count to SIZE_MAX,
+  // corrupting the limiter. This guard only logs the programming error.
   try {
     KVIKIO_EXPECT(prev > 0,
                   "ConcurrentRequestLimiter::release() called more times than try_acquire()");

--- a/cpp/src/detail/concurrent_request_limiter.cpp
+++ b/cpp/src/detail/concurrent_request_limiter.cpp
@@ -22,7 +22,7 @@ ConcurrentRequestLimiter::ConcurrentRequestLimiter(
 
 bool ConcurrentRequestLimiter::try_acquire() noexcept
 {
-  if (!_max_concurrent_requests) {
+  if (!_max_concurrent_requests.has_value()) {
     _count.fetch_add(1, std::memory_order_relaxed);
     return true;
   }
@@ -31,7 +31,7 @@ bool ConcurrentRequestLimiter::try_acquire() noexcept
   // over-count to concurrent acquirers.
   auto cur = _count.load(std::memory_order_relaxed);
   do {
-    if (cur >= *_max_concurrent_requests) { return false; }
+    if (cur >= _max_concurrent_requests.value()) { return false; }
   } while (!_count.compare_exchange_weak(
     cur, cur + 1, std::memory_order_relaxed, std::memory_order_relaxed));
   return true;

--- a/cpp/src/detail/concurrent_request_limiter.cpp
+++ b/cpp/src/detail/concurrent_request_limiter.cpp
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+
+#include <kvikio/detail/concurrent_request_limiter.hpp>
+
+namespace kvikio::detail {
+
+ConcurrentRequestLimiter::ConcurrentRequestLimiter(std::size_t max_concurrent_requests) noexcept
+  : _max{max_concurrent_requests}
+{
+}
+
+bool ConcurrentRequestLimiter::try_acquire() noexcept
+{
+  if (_max == 0) {
+    _count.fetch_add(1, std::memory_order_relaxed);
+    return true;
+  }
+  // Increment only while strictly below the ceiling. A CAS loop keeps `_count` a hard cap, unlike a
+  // plain fetch_add followed by a corrective fetch_sub, which would transiently expose an
+  // over-count to concurrent acquirers.
+  auto cur = _count.load(std::memory_order_relaxed);
+  do {
+    if (cur >= _max) { return false; }
+  } while (!_count.compare_exchange_weak(
+    cur, cur + 1, std::memory_order_acquire, std::memory_order_relaxed));
+  return true;
+}
+
+void ConcurrentRequestLimiter::release() noexcept
+{
+  [[maybe_unused]] auto const prev = _count.fetch_sub(1, std::memory_order_release);
+  // A release without a matching successful acquire underflows the unsigned count and silently
+  // disables the cap, so guard against it in debug builds.
+  assert(prev > 0 && "ConcurrentRequestLimiter::release() called more times than try_acquire()");
+}
+
+bool ConcurrentRequestLimiter::unlimited() const noexcept { return _max == 0; }
+
+}  // namespace kvikio::detail

--- a/cpp/src/detail/concurrent_request_limiter.cpp
+++ b/cpp/src/detail/concurrent_request_limiter.cpp
@@ -4,21 +4,23 @@
  */
 
 #include <atomic>
-#include <cassert>
 #include <cstddef>
 
 #include <kvikio/detail/concurrent_request_limiter.hpp>
+#include <kvikio/error.hpp>
+#include <kvikio/logger.hpp>
+#include <kvikio/logger_macros.hpp>
 
 namespace kvikio::detail {
 
 ConcurrentRequestLimiter::ConcurrentRequestLimiter(std::size_t max_concurrent_requests) noexcept
-  : _max{max_concurrent_requests}
+  : _max_concurrent_requests{max_concurrent_requests}
 {
 }
 
 bool ConcurrentRequestLimiter::try_acquire() noexcept
 {
-  if (_max == 0) {
+  if (_max_concurrent_requests == 0) {
     _count.fetch_add(1, std::memory_order_relaxed);
     return true;
   }
@@ -27,20 +29,26 @@ bool ConcurrentRequestLimiter::try_acquire() noexcept
   // over-count to concurrent acquirers.
   auto cur = _count.load(std::memory_order_relaxed);
   do {
-    if (cur >= _max) { return false; }
+    if (cur >= _max_concurrent_requests) { return false; }
   } while (!_count.compare_exchange_weak(
-    cur, cur + 1, std::memory_order_acquire, std::memory_order_relaxed));
+    cur, cur + 1, std::memory_order_relaxed, std::memory_order_relaxed));
   return true;
 }
 
 void ConcurrentRequestLimiter::release() noexcept
 {
-  [[maybe_unused]] auto const prev = _count.fetch_sub(1, std::memory_order_release);
-  // A release without a matching successful acquire underflows the unsigned count and silently
-  // disables the cap, so guard against it in debug builds.
-  assert(prev > 0 && "ConcurrentRequestLimiter::release() called more times than try_acquire()");
+  [[maybe_unused]] auto const prev = _count.fetch_sub(1, std::memory_order_relaxed);
+
+  // A release without a matching successful acquire may underflow the unsigned count and silently
+  // disables the cap
+  try {
+    KVIKIO_EXPECT(prev > 0,
+                  "ConcurrentRequestLimiter::release() called more times than try_acquire()");
+  } catch (std::exception const& e) {
+    KVIKIO_LOG_ERROR(e.what());
+  }
 }
 
-bool ConcurrentRequestLimiter::unlimited() const noexcept { return _max == 0; }
+bool ConcurrentRequestLimiter::unlimited() const noexcept { return _max_concurrent_requests == 0; }
 
 }  // namespace kvikio::detail

--- a/cpp/src/detail/concurrent_request_limiter.cpp
+++ b/cpp/src/detail/concurrent_request_limiter.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <optional>
 
 #include <kvikio/detail/concurrent_request_limiter.hpp>
 #include <kvikio/error.hpp>
@@ -13,14 +14,15 @@
 
 namespace kvikio::detail {
 
-ConcurrentRequestLimiter::ConcurrentRequestLimiter(std::size_t max_concurrent_requests) noexcept
+ConcurrentRequestLimiter::ConcurrentRequestLimiter(
+  std::optional<std::size_t> max_concurrent_requests) noexcept
   : _max_concurrent_requests{max_concurrent_requests}
 {
 }
 
 bool ConcurrentRequestLimiter::try_acquire() noexcept
 {
-  if (_max_concurrent_requests == 0) {
+  if (!_max_concurrent_requests) {
     _count.fetch_add(1, std::memory_order_relaxed);
     return true;
   }
@@ -29,7 +31,7 @@ bool ConcurrentRequestLimiter::try_acquire() noexcept
   // over-count to concurrent acquirers.
   auto cur = _count.load(std::memory_order_relaxed);
   do {
-    if (cur >= _max_concurrent_requests) { return false; }
+    if (cur >= *_max_concurrent_requests) { return false; }
   } while (!_count.compare_exchange_weak(
     cur, cur + 1, std::memory_order_relaxed, std::memory_order_relaxed));
   return true;
@@ -49,6 +51,9 @@ void ConcurrentRequestLimiter::release() noexcept
   }
 }
 
-bool ConcurrentRequestLimiter::unlimited() const noexcept { return _max_concurrent_requests == 0; }
+bool ConcurrentRequestLimiter::unlimited() const noexcept
+{
+  return !_max_concurrent_requests.has_value();
+}
 
 }  // namespace kvikio::detail

--- a/cpp/src/detail/multi_poll_reactor.cpp
+++ b/cpp/src/detail/multi_poll_reactor.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <algorithm>
 #include <cstddef>
 #include <exception>
 #include <memory>
@@ -261,6 +262,13 @@ MultiReactorPool::MultiReactorPool() : _dispatch{defaults::remote_io_reactor_dis
   auto const n = defaults::remote_io_num_reactors();
   KVIKIO_EXPECT(n > 0, "remote_io_num_reactors must be a positive integer", std::invalid_argument);
 
+  // Split the global budget into a private per-reactor share so each reactor enforces its own cap
+  // against its own inbox, with no cross-reactor synchronization. The effective total is only
+  // approximately `max_total`: integer division rounds down when `max_total` is not a multiple of
+  // `n`, and the `max(..., 1)` floor rounds up when `max_total < n` (a computed share of 0 would be
+  // a "limited" reactor that admits nothing, so we give it at least 1). This even split assumes
+  // sub-ranges are spread across reactors (PER_CHUNK). Under PER_PREAD a single large pread() lands
+  // entirely on one reactor and is therefore capped at this share while the others stay idle.
   auto const max_total = defaults::remote_io_max_concurrent_requests();
   std::size_t const per_reactor_max =
     (max_total == 0) ? 0 : std::max<std::size_t>(max_total / n, 1);

--- a/cpp/src/detail/multi_poll_reactor.cpp
+++ b/cpp/src/detail/multi_poll_reactor.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <exception>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -64,7 +65,8 @@ void RemoteMultiAggregateContext::on_subrange_failed(std::exception_ptr eptr)
 
 std::future<std::size_t> RemoteMultiAggregateContext::get_future() { return _promise.get_future(); }
 
-MultiPollReactor::MultiPollReactor(MultiReactorPool* pool, std::size_t max_concurrent_requests)
+MultiPollReactor::MultiPollReactor(MultiReactorPool* pool,
+                                   std::optional<std::size_t> max_concurrent_requests)
   : _pool{pool}, _request_limiter{max_concurrent_requests}
 {
   KVIKIO_EXPECT(
@@ -263,8 +265,8 @@ MultiReactorPool::MultiReactorPool() : _dispatch{defaults::remote_io_reactor_dis
   KVIKIO_EXPECT(n > 0, "remote_io_num_reactors must be a positive integer", std::invalid_argument);
 
   auto const max_total = defaults::remote_io_max_concurrent_requests();
-  std::size_t const per_reactor_max =
-    (max_total == 0) ? 0 : std::max<std::size_t>(max_total / n, 1);
+  std::optional<std::size_t> const per_reactor_max =
+    (max_total == 0) ? std::nullopt : std::optional{std::max<std::size_t>(max_total / n, 1)};
 
   _reactors.reserve(n);
   for (unsigned int i = 0; i < n; ++i) {

--- a/cpp/src/detail/multi_poll_reactor.cpp
+++ b/cpp/src/detail/multi_poll_reactor.cpp
@@ -63,7 +63,8 @@ void RemoteMultiAggregateContext::on_subrange_failed(std::exception_ptr eptr)
 
 std::future<std::size_t> RemoteMultiAggregateContext::get_future() { return _promise.get_future(); }
 
-MultiPollReactor::MultiPollReactor(MultiReactorPool* pool) : _pool{pool}
+MultiPollReactor::MultiPollReactor(MultiReactorPool* pool, std::size_t max_concurrent_requests)
+  : _pool{pool}, _request_limiter{max_concurrent_requests}
 {
   KVIKIO_EXPECT(
     _pool != nullptr, "MultiPollReactor requires a non-null pool", std::invalid_argument);
@@ -121,10 +122,12 @@ void MultiPollReactor::io_thread_main()
         // Lock is needed since _inbox is shared between the I/O thread and the caller thread.
         std::unique_lock<std::mutex> lock(_submit_mutex);
         while (!_inbox.empty()) {
-          // Bound concurrent in-flight requests across all reactors. The limiter is a single
-          // global gate, so once it is at capacity every remaining inbox entry would fail the same
-          // check. Stop the walk and leave the rest queued in FIFO order for a later iteration.
-          if (!_pool->concurrent_request_limiter().try_acquire()) {
+          // Bound this reactor's in-flight requests to its private share of the global budget. Once
+          // its limiter is at capacity every remaining inbox entry would fail the same check, so
+          // stop the walk and leave the rest queued in FIFO order for a later iteration. Because the
+          // share is private, completions on this reactor free its own slots and it re-admits its
+          // own inbox with no cross-reactor hand-off.
+          if (!_request_limiter.try_acquire()) {
             has_deferred = true;
             break;
           }
@@ -139,7 +142,7 @@ void MultiPollReactor::io_thread_main()
           if (mc != CURLM_OK) {
             // The slot was acquired for a transfer that will never reach _in_flight, so release it
             // now to avoid permanently shrinking capacity.
-            _pool->concurrent_request_limiter().release();
+            _request_limiter.release();
             // This transfer is now in transit between _inbox and _in_flight. fail_all_pending (run
             // on the catch path below) iterates only those two containers, so it cannot find this
             // transfer. We must mark its aggregate as failed here to maintain the per-aggregate
@@ -196,7 +199,7 @@ void MultiPollReactor::io_thread_main()
         }
         // This request has left _in_flight (success or failure); return its concurrency slot so a
         // deferred request can be admitted.
-        _pool->concurrent_request_limiter().release();
+        _request_limiter.release();
         // transfer (unique_ptr) drops here, returning easy to the LibCurl pool.
       }
 
@@ -249,23 +252,32 @@ void MultiPollReactor::fail_all_pending(std::exception_ptr eptr)
     transfer->aggregate->on_subrange_failed(eptr);
     // Every _in_flight entry holds a concurrency slot (the inbox entries drained above never
     // acquired one, so they are not released here).
-    _pool->concurrent_request_limiter().release();
+    _request_limiter.release();
   }
   _in_flight.clear();
 }
 
-MultiReactorPool::MultiReactorPool()
-  : _dispatch{defaults::remote_io_reactor_dispatch()},
-    _request_limiter{defaults::remote_io_max_concurrent_requests()}
+MultiReactorPool::MultiReactorPool() : _dispatch{defaults::remote_io_reactor_dispatch()}
 {
   // Force LibCurl global init before any reactor opens a multi handle.
   std::ignore = LibCurl::instance();
 
   auto const n = defaults::remote_io_num_reactors();
   KVIKIO_EXPECT(n > 0, "remote_io_num_reactors must be a positive integer", std::invalid_argument);
+
+  // Split the global concurrent-request budget into a private per-reactor share. Each reactor
+  // enforces its own share against its own inbox, which avoids a single shared admission gate (that
+  // gate caused reactor starvation and pipeline stalls under heavy re-admission churn). The shares
+  // sum to at most the global cap, so total in-flight stays bounded. 0 means unlimited. Floor the
+  // share at 1 so a cap smaller than the reactor count cannot starve a reactor into a hang (this
+  // can let the sum slightly exceed the cap only in that small-cap corner case).
+  auto const max_total = defaults::remote_io_max_concurrent_requests();
+  std::size_t per_reactor_max = (max_total == 0) ? 0 : (max_total / n);
+  if (max_total != 0 && per_reactor_max == 0) { per_reactor_max = 1; }
+
   _reactors.reserve(n);
   for (unsigned int i = 0; i < n; ++i) {
-    _reactors.emplace_back(std::make_unique<MultiPollReactor>(this));
+    _reactors.emplace_back(std::make_unique<MultiPollReactor>(this, per_reactor_max));
   }
 }
 

--- a/cpp/src/detail/multi_poll_reactor.cpp
+++ b/cpp/src/detail/multi_poll_reactor.cpp
@@ -109,11 +109,25 @@ void MultiPollReactor::io_thread_main()
 {
   try {
     while (!_pool->is_dead()) {
-      // (1) Drain submission queue. Attach each pending easy handle to the multi handle.
+      // Set true if stage (1) leaves at least one request queued because the concurrency limiter
+      // is at capacity. Stage (4) then shortens the poll timeout so the inbox is re-checked
+      // promptly once a completing request frees a slot (a release on another reactor thread does
+      // not raise libcurl socket activity here).
+      bool has_deferred = false;
+
+      // (1) Drain submission queue. Admit as many requests as the concurrency limiter allows and
+      // attach each admitted easy handle to the multi handle.
       {
         // Lock is needed since _inbox is shared between the I/O thread and the caller thread.
         std::unique_lock<std::mutex> lock(_submit_mutex);
         while (!_inbox.empty()) {
+          // Bound concurrent in-flight requests across all reactors. The limiter is a single
+          // global gate, so once it is at capacity every remaining inbox entry would fail the same
+          // check. Stop the walk and leave the rest queued in FIFO order for a later iteration.
+          if (!_pool->concurrent_request_limiter().try_acquire()) {
+            has_deferred = true;
+            break;
+          }
           auto transfer = std::move(_inbox.front());
           _inbox.pop_front();
           lock.unlock();
@@ -123,6 +137,9 @@ void MultiPollReactor::io_thread_main()
           // handle. We just attach it to the multi handle.
           auto const mc = curl_multi_add_handle(_curl_multi, easy);
           if (mc != CURLM_OK) {
+            // The slot was acquired for a transfer that will never reach _in_flight, so release it
+            // now to avoid permanently shrinking capacity.
+            _pool->concurrent_request_limiter().release();
             // This transfer is now in transit between _inbox and _in_flight. fail_all_pending (run
             // on the catch path below) iterates only those two containers, so it cannot find this
             // transfer. We must mark its aggregate as failed here to maintain the per-aggregate
@@ -177,15 +194,21 @@ void MultiPollReactor::io_thread_main()
           transfer->aggregate->on_subrange_failed(
             std::make_exception_ptr(std::runtime_error(ss.str())));
         }
+        // This request has left _in_flight (success or failure); return its concurrency slot so a
+        // deferred request can be admitted.
+        _pool->concurrent_request_limiter().release();
         // transfer (unique_ptr) drops here, returning easy to the LibCurl pool.
       }
 
-      // (4) Wait for activity, wakeup, or a bounded timeout.
-      auto const poll_mc = curl_multi_poll(_curl_multi,
-                                           nullptr,   // extra_fds
-                                           0,         // extra_nfds
-                                           1000,      // timeout_ms
-                                           nullptr);  // numfds
+      // (4) Wait for activity, wakeup, or a bounded timeout. Shorten the timeout when at least one
+      // request is deferred on a full limiter, so the inbox is re-checked promptly after a
+      // completing request frees a slot (such a release does not raise libcurl socket activity).
+      int const poll_timeout_ms = has_deferred ? 10 : 1000;
+      auto const poll_mc        = curl_multi_poll(_curl_multi,
+                                           nullptr,          // extra_fds
+                                           0,                // extra_nfds
+                                           poll_timeout_ms,  // timeout_ms
+                                           nullptr);         // numfds
       KVIKIO_EXPECT(poll_mc == CURLM_OK,
                     std::string("curl_multi_poll: ") + curl_multi_strerror(poll_mc),
                     std::runtime_error);
@@ -224,11 +247,16 @@ void MultiPollReactor::fail_all_pending(std::exception_ptr eptr)
     // attached, which is undefined behavior.
     std::ignore = curl_multi_remove_handle(_curl_multi, easy);
     transfer->aggregate->on_subrange_failed(eptr);
+    // Every _in_flight entry holds a concurrency slot (the inbox entries drained above never
+    // acquired one, so they are not released here).
+    _pool->concurrent_request_limiter().release();
   }
   _in_flight.clear();
 }
 
-MultiReactorPool::MultiReactorPool() : _dispatch{defaults::remote_io_reactor_dispatch()}
+MultiReactorPool::MultiReactorPool()
+  : _dispatch{defaults::remote_io_reactor_dispatch()},
+    _request_limiter{defaults::remote_io_max_concurrent_requests()}
 {
   // Force LibCurl global init before any reactor opens a multi handle.
   std::ignore = LibCurl::instance();

--- a/cpp/src/detail/multi_poll_reactor.cpp
+++ b/cpp/src/detail/multi_poll_reactor.cpp
@@ -262,13 +262,6 @@ MultiReactorPool::MultiReactorPool() : _dispatch{defaults::remote_io_reactor_dis
   auto const n = defaults::remote_io_num_reactors();
   KVIKIO_EXPECT(n > 0, "remote_io_num_reactors must be a positive integer", std::invalid_argument);
 
-  // Split the global budget into a private per-reactor share so each reactor enforces its own cap
-  // against its own inbox, with no cross-reactor synchronization. The effective total is only
-  // approximately `max_total`: integer division rounds down when `max_total` is not a multiple of
-  // `n`, and the `max(..., 1)` floor rounds up when `max_total < n` (a computed share of 0 would be
-  // a "limited" reactor that admits nothing, so we give it at least 1). This even split assumes
-  // sub-ranges are spread across reactors (PER_CHUNK). Under PER_PREAD a single large pread() lands
-  // entirely on one reactor and is therefore capped at this share while the others stay idle.
   auto const max_total = defaults::remote_io_max_concurrent_requests();
   std::size_t const per_reactor_max =
     (max_total == 0) ? 0 : std::max<std::size_t>(max_total / n, 1);

--- a/cpp/src/detail/multi_poll_reactor.cpp
+++ b/cpp/src/detail/multi_poll_reactor.cpp
@@ -110,10 +110,9 @@ void MultiPollReactor::io_thread_main()
 {
   try {
     while (!_pool->is_dead()) {
-      // Set true if stage (1) leaves at least one request queued because the concurrency limiter
-      // is at capacity. Stage (4) then shortens the poll timeout so the inbox is re-checked
-      // promptly once a completing request frees a slot (a release on another reactor thread does
-      // not raise libcurl socket activity here).
+      // Set true if stage (1) leaves at least one request queued because the concurrency limiter is
+      // at capacity. Stage (4) then shortens the poll timeout so the inbox is re-checked promptly
+      // once a completing request frees a slot.
       bool has_deferred = false;
 
       // (1) Drain submission queue. Admit as many requests as the concurrency limiter allows and
@@ -124,9 +123,7 @@ void MultiPollReactor::io_thread_main()
         while (!_inbox.empty()) {
           // Bound this reactor's in-flight requests to its private share of the global budget. Once
           // its limiter is at capacity every remaining inbox entry would fail the same check, so
-          // stop the walk and leave the rest queued in FIFO order for a later iteration. Because the
-          // share is private, completions on this reactor free its own slots and it re-admits its
-          // own inbox with no cross-reactor hand-off.
+          // stop the walk and leave the rest queued in FIFO order for a later iteration.
           if (!_request_limiter.try_acquire()) {
             has_deferred = true;
             break;
@@ -197,15 +194,14 @@ void MultiPollReactor::io_thread_main()
           transfer->aggregate->on_subrange_failed(
             std::make_exception_ptr(std::runtime_error(ss.str())));
         }
-        // This request has left _in_flight (success or failure); return its concurrency slot so a
+        // This request has left _in_flight (success or failure). Return its concurrency slot so a
         // deferred request can be admitted.
         _request_limiter.release();
         // transfer (unique_ptr) drops here, returning easy to the LibCurl pool.
       }
 
-      // (4) Wait for activity, wakeup, or a bounded timeout. Shorten the timeout when at least one
-      // request is deferred on a full limiter, so the inbox is re-checked promptly after a
-      // completing request frees a slot (such a release does not raise libcurl socket activity).
+      // (4) Wait for activity, wakeup, or a bounded timeout. Use a shorter timeout when requests
+      // are deferred. Completions normally raise socket activity, but not if stage (3) drained all.
       int const poll_timeout_ms = has_deferred ? 10 : 1000;
       auto const poll_mc        = curl_multi_poll(_curl_multi,
                                            nullptr,          // extra_fds
@@ -250,8 +246,8 @@ void MultiPollReactor::fail_all_pending(std::exception_ptr eptr)
     // attached, which is undefined behavior.
     std::ignore = curl_multi_remove_handle(_curl_multi, easy);
     transfer->aggregate->on_subrange_failed(eptr);
-    // Every _in_flight entry holds a concurrency slot (the inbox entries drained above never
-    // acquired one, so they are not released here).
+    // Every _in_flight entry holds a concurrency slot. The inbox entries drained above never
+    // acquired one, so they are not released here.
     _request_limiter.release();
   }
   _in_flight.clear();
@@ -265,15 +261,9 @@ MultiReactorPool::MultiReactorPool() : _dispatch{defaults::remote_io_reactor_dis
   auto const n = defaults::remote_io_num_reactors();
   KVIKIO_EXPECT(n > 0, "remote_io_num_reactors must be a positive integer", std::invalid_argument);
 
-  // Split the global concurrent-request budget into a private per-reactor share. Each reactor
-  // enforces its own share against its own inbox, which avoids a single shared admission gate (that
-  // gate caused reactor starvation and pipeline stalls under heavy re-admission churn). The shares
-  // sum to at most the global cap, so total in-flight stays bounded. 0 means unlimited. Floor the
-  // share at 1 so a cap smaller than the reactor count cannot starve a reactor into a hang (this
-  // can let the sum slightly exceed the cap only in that small-cap corner case).
   auto const max_total = defaults::remote_io_max_concurrent_requests();
-  std::size_t per_reactor_max = (max_total == 0) ? 0 : (max_total / n);
-  if (max_total != 0 && per_reactor_max == 0) { per_reactor_max = 1; }
+  std::size_t const per_reactor_max =
+    (max_total == 0) ? 0 : std::max<std::size_t>(max_total / n, 1);
 
   _reactors.reserve(n);
   for (unsigned int i = 0; i < n; ++i) {

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -78,6 +78,8 @@ kvikio_add_test(NAME FILE_UTILS_TEST SOURCES test_file_utils.cpp)
 
 kvikio_add_test(NAME MMAP_TEST SOURCES test_mmap.cpp)
 
+kvikio_add_test(NAME CONCURRENT_REQUEST_LIMITER_TEST SOURCES test_concurrent_request_limiter.cpp)
+
 if(KvikIO_REMOTE_SUPPORT)
   kvikio_add_test(NAME REMOTE_HANDLE_TEST SOURCES test_remote_handle.cpp utils/env.cpp)
   kvikio_add_test(NAME HDFS_TEST SOURCES test_hdfs.cpp utils/hdfs_helper.cpp)

--- a/cpp/tests/test_concurrent_request_limiter.cpp
+++ b/cpp/tests/test_concurrent_request_limiter.cpp
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <atomic>
+#include <cstddef>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <kvikio/detail/concurrent_request_limiter.hpp>
+
+using kvikio::detail::ConcurrentRequestLimiter;
+
+TEST(ConcurrentRequestLimiter, EnforcesCeiling)
+{
+  ConcurrentRequestLimiter limiter{3};
+  EXPECT_FALSE(limiter.unlimited());
+  EXPECT_TRUE(limiter.try_acquire());
+  EXPECT_TRUE(limiter.try_acquire());
+  EXPECT_TRUE(limiter.try_acquire());
+  // At capacity: further acquisitions fail without blocking.
+  EXPECT_FALSE(limiter.try_acquire());
+  EXPECT_FALSE(limiter.try_acquire());
+}
+
+TEST(ConcurrentRequestLimiter, ReleaseFreesSlot)
+{
+  ConcurrentRequestLimiter limiter{1};
+  EXPECT_TRUE(limiter.try_acquire());
+  EXPECT_FALSE(limiter.try_acquire());
+  limiter.release();
+  // The freed slot can be re-acquired, and the cap still holds at one.
+  EXPECT_TRUE(limiter.try_acquire());
+  EXPECT_FALSE(limiter.try_acquire());
+}
+
+TEST(ConcurrentRequestLimiter, UnlimitedAlwaysAcquires)
+{
+  ConcurrentRequestLimiter limiter{0};
+  EXPECT_TRUE(limiter.unlimited());
+  for (int i = 0; i < 10000; ++i) {
+    EXPECT_TRUE(limiter.try_acquire());
+  }
+}
+
+TEST(ConcurrentRequestLimiter, HardCapUnderContention)
+{
+  // Many threads hammer try_acquire() with no releases. The number of successes must equal the cap
+  // exactly, proving the ceiling is never exceeded under concurrent acquisition.
+  constexpr std::size_t cap         = 64;
+  constexpr int n_threads           = 16;
+  constexpr int attempts_per_thread = 10000;
+  ConcurrentRequestLimiter limiter{cap};
+  std::atomic<std::size_t> successes{0};
+
+  std::vector<std::thread> threads;
+  threads.reserve(n_threads);
+  for (int t = 0; t < n_threads; ++t) {
+    threads.emplace_back([&] {
+      for (int i = 0; i < attempts_per_thread; ++i) {
+        if (limiter.try_acquire()) { successes.fetch_add(1, std::memory_order_relaxed); }
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+  EXPECT_EQ(successes.load(), cap);
+}
+
+TEST(ConcurrentRequestLimiter, AcquireReleaseChurnNeverExceedsCap)
+{
+  // Acquire/release churn from many threads. The live count (acquired minus released) must never
+  // exceed the cap at any observation point.
+  constexpr std::size_t cap = 8;
+  constexpr int n_threads   = 16;
+  constexpr int iterations  = 50000;
+  ConcurrentRequestLimiter limiter{cap};
+  std::atomic<long> live{0};
+  std::atomic<long> max_live{0};
+
+  std::vector<std::thread> threads;
+  threads.reserve(n_threads);
+  for (int t = 0; t < n_threads; ++t) {
+    threads.emplace_back([&] {
+      for (int i = 0; i < iterations; ++i) {
+        if (limiter.try_acquire()) {
+          auto const now = live.fetch_add(1, std::memory_order_relaxed) + 1;
+          auto prev      = max_live.load(std::memory_order_relaxed);
+          while (now > prev &&
+                 !max_live.compare_exchange_weak(prev, now, std::memory_order_relaxed)) {}
+          live.fetch_sub(1, std::memory_order_relaxed);
+          limiter.release();
+        }
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+  EXPECT_LE(max_live.load(), static_cast<long>(cap));
+  EXPECT_EQ(live.load(), 0);
+}

--- a/cpp/tests/test_concurrent_request_limiter.cpp
+++ b/cpp/tests/test_concurrent_request_limiter.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -39,7 +40,7 @@ TEST(ConcurrentRequestLimiter, ReleaseFreesSlot)
 
 TEST(ConcurrentRequestLimiter, UnlimitedAlwaysAcquires)
 {
-  ConcurrentRequestLimiter limiter{0};
+  ConcurrentRequestLimiter limiter{std::nullopt};
   EXPECT_TRUE(limiter.unlimited());
   for (int i = 0; i < 10000; ++i) {
     EXPECT_TRUE(limiter.try_acquire());

--- a/cpp/tests/test_concurrent_request_limiter.cpp
+++ b/cpp/tests/test_concurrent_request_limiter.cpp
@@ -70,37 +70,3 @@ TEST(ConcurrentRequestLimiter, HardCapUnderContention)
   }
   EXPECT_EQ(successes.load(), cap);
 }
-
-TEST(ConcurrentRequestLimiter, AcquireReleaseChurnNeverExceedsCap)
-{
-  // Acquire/release churn from many threads. The live count (acquired minus released) must never
-  // exceed the cap at any observation point.
-  constexpr std::size_t cap = 8;
-  constexpr int n_threads   = 16;
-  constexpr int iterations  = 50000;
-  ConcurrentRequestLimiter limiter{cap};
-  std::atomic<long> live{0};
-  std::atomic<long> max_live{0};
-
-  std::vector<std::thread> threads;
-  threads.reserve(n_threads);
-  for (int t = 0; t < n_threads; ++t) {
-    threads.emplace_back([&] {
-      for (int i = 0; i < iterations; ++i) {
-        if (limiter.try_acquire()) {
-          auto const now = live.fetch_add(1, std::memory_order_relaxed) + 1;
-          auto prev      = max_live.load(std::memory_order_relaxed);
-          while (now > prev &&
-                 !max_live.compare_exchange_weak(prev, now, std::memory_order_relaxed)) {}
-          live.fetch_sub(1, std::memory_order_relaxed);
-          limiter.release();
-        }
-      }
-    });
-  }
-  for (auto& th : threads) {
-    th.join();
-  }
-  EXPECT_LE(max_live.load(), static_cast<long>(cap));
-  EXPECT_EQ(live.load(), 0);
-}

--- a/docs/source/runtime_settings.rst
+++ b/docs/source/runtime_settings.rst
@@ -67,21 +67,37 @@ Set the environment variable ``KVIKIO_REMOTE_VERBOSE`` to ``true``, ``on``, ``ye
 
    This may show sensitive contents from headers and data.
 
-Remote I/O Backend ``KVIKIO_REMOTE_IO_BACKEND``, ``KVIKIO_REMOTE_IO_NUM_REACTORS``, ``KVIKIO_REMOTE_IO_REACTOR_DISPATCH``
--------------------------------------------------------------------------------------------------------------------------
+Remote I/O Backend ``KVIKIO_REMOTE_IO_BACKEND``
+-----------------------------------------------
 
 KvikIO supports two backends for remote (HTTP/S3/WebHDFS) reads, selected at process startup via the environment variable ``KVIKIO_REMOTE_IO_BACKEND``. The accepted values (case-insensitive) are:
 
   * ``EASY_THREADPOOL`` (default): Libcurl easy API running in the KvikIO thread pool. Each sub-range of a :py:func:`kvikio.RemoteFile.pread` is dispatched to a worker thread that blocks in ``curl_easy_perform()`` until its transfer completes. Concurrency is bounded by the thread pool size: one busy thread per in-flight transfer.
-  * ``MULTI_POLL``: Libcurl multi API driven by N reactor threads, each of which blocks in ``curl_multi_poll()``. A single reactor multiplexes many in-flight easy handles concurrently, so the number of simultaneous transfers is not bounded by the reactor count. See ``KVIKIO_REMOTE_IO_NUM_REACTORS`` and ``KVIKIO_REMOTE_IO_REACTOR_DISPATCH``.
+  * ``MULTI_POLL``: Libcurl multi API driven by N reactor threads, each of which blocks in ``curl_multi_poll()``. A single reactor multiplexes many in-flight easy handles concurrently, so the number of simultaneous transfers is bounded by ``KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS`` rather than by the reactor count.
 
-When ``MULTI_POLL`` is selected, two additional settings are honored:
+The ``MULTI_POLL`` backend honors three additional settings, described in the sections below: ``KVIKIO_REMOTE_IO_NUM_REACTORS``, ``KVIKIO_REMOTE_IO_REACTOR_DISPATCH``, and ``KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS``. They have no effect under ``EASY_THREADPOOL``.
 
-  * ``KVIKIO_REMOTE_IO_NUM_REACTORS`` (default ``1``): number of reactor threads. Each reactor owns one ``CURLM*`` handle and serializes its libcurl-multi calls. Increase beyond ``1`` to spread the in-callback ``memcpy`` cost when one reactor's CPU is the bottleneck.
-  * ``KVIKIO_REMOTE_IO_REACTOR_DISPATCH``: how sub-ranges of a single :py:func:`kvikio.RemoteFile.pread` are distributed across reactor threads when ``MULTI_POLL`` is active. When only one reactor is used, both modes are equivalent. The accepted values (case-insensitive) are:
+Remote I/O Reactor Count ``KVIKIO_REMOTE_IO_NUM_REACTORS``
+----------------------------------------------------------
 
-    * ``PER_CHUNK`` (default): Sub-ranges are routed to reactors round-robin, independently of which :py:func:`kvikio.RemoteFile.pread` they belong to. This maximizes load balance across reactors. Trade-off: two sub-ranges of the same file may land on different reactors, each with its own libcurl connection cache, so they may not share an established TCP/TLS connection.
-    * ``PER_PREAD``: All sub-ranges of a single :py:func:`kvikio.RemoteFile.pread` are submitted to the same reactor (the reactor is itself chosen round-robin per :py:func:`kvikio.RemoteFile.pread` call). The sub-ranges then share that reactor's libcurl connection cache, allowing an established TCP/TLS connection to be reused. Best for HTTPS, where the TLS handshake cost is non-trivial.
+Number of reactor threads used by the ``MULTI_POLL`` backend. The default value is ``1``. Each reactor owns one ``CURLM*`` handle and serializes its libcurl-multi calls. Increase beyond ``1`` to spread the in-callback ``memcpy`` cost across cores when one reactor's CPU is the bottleneck. This setting has no effect under ``EASY_THREADPOOL``.
+
+Remote I/O Reactor Dispatch ``KVIKIO_REMOTE_IO_REACTOR_DISPATCH``
+-----------------------------------------------------------------
+
+Controls how the sub-ranges of a single :py:func:`kvikio.RemoteFile.pread` are distributed across reactor threads when ``MULTI_POLL`` is active. When only one reactor is used, both modes are equivalent. This setting has no effect under ``EASY_THREADPOOL``. The accepted values (case-insensitive) are:
+
+  * ``PER_CHUNK`` (default): Sub-ranges are routed to reactors round-robin, independently of which :py:func:`kvikio.RemoteFile.pread` they belong to. This maximizes load balance across reactors. Trade-off: two sub-ranges of the same file may land on different reactors, each with its own libcurl connection cache, so they may not share an established TCP/TLS connection.
+  * ``PER_PREAD``: All sub-ranges of a single :py:func:`kvikio.RemoteFile.pread` are submitted to the same reactor (the reactor is itself chosen round-robin per :py:func:`kvikio.RemoteFile.pread` call). The sub-ranges then share that reactor's libcurl connection cache, allowing an established TCP/TLS connection to be reused. Best for HTTPS, where the TLS handshake cost is non-trivial.
+
+Remote I/O Concurrency Cap ``KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS``
+-----------------------------------------------------------------------
+
+Upper bound on the number of HTTP range requests the ``MULTI_POLL`` backend keeps in flight at once, summed across all reactor threads. The default value is ``256``. It must be a non-negative integer, and ``0`` means unlimited. The value is ignored when the active backend is not ``MULTI_POLL`` (``EASY_THREADPOOL`` is already bounded by ``KVIKIO_NTHREADS``).
+
+The global budget is divided into an equal private share per reactor (``KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS`` divided by ``KVIKIO_REMOTE_IO_NUM_REACTORS``), so each reactor enforces its own cap against its own inbox with no cross-reactor synchronization. Integer division rounds the per-reactor share down when the budget is not a multiple of the reactor count, and a floor of 1 rounds it up when the budget is smaller than the reactor count (a computed share of 0 would be a reactor that can never admit a request). The effective total is therefore only approximate.
+
+The even split assumes sub-ranges are spread across reactors, which holds under ``PER_CHUNK``. Under ``PER_PREAD`` all sub-ranges of one large :py:func:`kvikio.RemoteFile.pread` land on a single reactor, so that read is effectively limited to one reactor's share while the others stay idle.
 
 CA bundle file and CA directory ``CURL_CA_BUNDLE``, ``SSL_CERT_FILE``, ``SSL_CERT_DIR``
 ---------------------------------------------------------------------------------------
@@ -140,6 +156,15 @@ Example:
    # Enable Direct I/O for reads, and disable it for writes
    kvikio.defaults.set({"auto_direct_io_read": True, "auto_direct_io_write": False})
 
+Over-read Alignment ``KVIKIO_AUTO_DIRECT_IO_READ_OVERREAD``
+-----------------------------------------------------------
+
+When opportunistic Direct I/O is enabled for reads, unaligned prefix and suffix portions of each transfer fall back to buffered I/O. Setting ``KVIKIO_AUTO_DIRECT_IO_READ_OVERREAD=1`` forces all disk reads to use Direct I/O by aligning offsets down and sizes up to page boundaries, discarding the extra bytes after the read. This only affects the device memory read path (disk to bounce buffer to GPU). Host memory reads are unaffected. Defaults to disabled.
+
+.. code-block:: bash
+
+   export KVIKIO_AUTO_DIRECT_IO_READ_OVERREAD=1
+
 Logging ``KVIKIO_LOG_LEVEL``, ``KVIKIO_LOG_FILE``
 -------------------------------------------------
 
@@ -159,12 +184,3 @@ Each level includes all messages from less verbose levels.
 If not set or set to any other value, logging is disabled.
 
 By default, log output are written to the standard error stream. To write log output to a file, set the environment variable ``KVIKIO_LOG_FILE`` to a file path. The file is overwritten on each process start. If the file cannot be opened (e.g. the parent directory does not exist), KvikIO falls back to the standard error with a warning. ``KVIKIO_LOG_FILE`` has no effect when logging is disabled.
-
-Over-read Alignment ``KVIKIO_AUTO_DIRECT_IO_READ_OVERREAD``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When opportunistic Direct I/O is enabled for reads, unaligned prefix and suffix portions of each transfer fall back to buffered I/O. Setting ``KVIKIO_AUTO_DIRECT_IO_READ_OVERREAD=1`` forces all disk reads to use Direct I/O by aligning offsets down and sizes up to page boundaries, discarding the extra bytes after the read. This only affects the device memory read path (disk to bounce buffer to GPU). Host memory reads are unaffected. Defaults to disabled.
-
-.. code-block:: bash
-
-   export KVIKIO_AUTO_DIRECT_IO_READ_OVERREAD=1


### PR DESCRIPTION
[Our previous result](https://github.com/rapidsai/kvikio/pull/960#issuecomment-4469200925) showed that when reading a sequence of ~620 MB files into host buffer, the multi poll backend achieved the same level of aggregate bandwidth with the easy thread pool backend, on the order of 6.1 GiB/s, on an EC2 instance with theoretical bandwidth of 11.64 GiB/s.

However, a follow-up study on SOL shows that when reading a large 8 GiB file, the easy thread pool backend is able to saturate the bandwidth, but the multi poll backend falls far behind, even lower than 6.1 GiB/s. It is found that:

- This slowdown is NOT the well-documented [S3 throttling](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html), as we did not receive the HTTP 503 (slow down) response.
- When the slowdown happened, the kernel received fewer incoming TPC packets per second, indicating that this might be related to an unknown server-side throttling mechanism.

While the exact reason is currently not well understood, an effective workaround has been found: do NOT leave the concurrency unbounded, but instead impose a limit. This PR introduces the setting `KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS` that caps the global concurrency for the host buffer read. Each reactor is allowed to have `KVIKIO_REMOTE_IO_MAX_CONCURRENT_REQUESTS / num_reactors` concurrent requests, and if the limit is reached, the request stays in the inbox until admitted requests complete. This method improves the performance effectively:

```
host buffer, 8 GiB data read repeatedly
Meaning of configs: t: threads, c: connections, r: reactors
In main, the multi poll concurrency is unbounded
+------------+------------+----------+------------+---------------+
|  branch    |  backend   |  config  | bw (GiB/s) |  cpu%/(GiB/s) |
+------------+------------+----------+------------+---------------+
|            |    easy    |   128t   |   9.81     |     165.1     |
|   main     | multi-poll |    8r    |   5.87     |     129.0     |
|            | multi-poll |   16r    |   5.13     |     167.0     |
+------------+------------+----------+------------+---------------+
| this PR    | multi-poll | 16r/128c |   9.68     |     115.1     |
+------------+------------+----------+------------+---------------+
```
With 16 reactors and a cap of 128 connections, the multi poll backend can have higher bandwidth than the same backend on the main branch (`9.68 > 5.87`), with more efficient CPU usage than the easy thread pool backend (`165.1 > 115.1`).