### PR TITLE
Handle zero-size remote reads

### DIFF
--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -172,6 +172,7 @@ std::size_t get_file_size_using_head_impl(RemoteEndpoint& endpoint, std::string 
  */
 void setup_range_request_impl(CurlHandle& curl, std::size_t file_offset, std::size_t size)
 {
+  KVIKIO_EXPECT(size > 0, "cannot create a zero-size range request", std::invalid_argument);
   std::string const byte_range =
     std::to_string(file_offset) + "-" + std::to_string(file_offset + size - 1);
   curl.setopt(CURLOPT_RANGE, byte_range.c_str());
@@ -735,6 +736,8 @@ std::size_t callback_device_memory(char* data, std::size_t size, std::size_t nme
 std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_offset)
 {
   KVIKIO_NVTX_FUNC_RANGE(size);
+
+  if (size == 0) { return 0; }
 
   if (file_offset + size > _nbytes) {
     std::stringstream ss;

--- a/cpp/tests/test_remote_handle.cpp
+++ b/cpp/tests/test_remote_handle.cpp
@@ -4,8 +4,10 @@
  */
 
 #include <functional>
+#include <memory>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -18,6 +20,26 @@
 
 using ::testing::HasSubstr;
 using ::testing::ThrowsMessage;
+
+class CountingEndpoint : public kvikio::RemoteEndpoint {
+ public:
+  CountingEndpoint() : RemoteEndpoint{kvikio::RemoteEndpointType::HTTP} {}
+
+  void setopt(kvikio::CurlHandle&) override { ++setopt_calls; }
+
+  std::string str() const override { return "http://example.com/test"; }
+
+  std::size_t get_file_size() override { return file_size; }
+
+  void setup_range_request(kvikio::CurlHandle&, std::size_t, std::size_t) override
+  {
+    ++range_request_calls;
+  }
+
+  std::size_t file_size{100};
+  int setopt_calls{};
+  int range_request_calls{};
+};
 
 class RemoteHandleTest : public testing::Test {
  protected:
@@ -137,6 +159,18 @@ TEST_F(RemoteHandleTest, test_http_url)
       EXPECT_FALSE(kvikio::HttpEndpoint::is_url_valid(invalid_url));
     }
   }
+}
+
+TEST_F(RemoteHandleTest, read_zero_size_returns_without_range_request)
+{
+  auto endpoint      = std::make_unique<CountingEndpoint>();
+  auto* endpoint_ptr = endpoint.get();
+  kvikio::RemoteHandle remote_handle(std::move(endpoint), endpoint_ptr->file_size);
+
+  std::vector<char> output(1);
+  EXPECT_EQ(remote_handle.read(output.data(), 0, 0), 0);
+  EXPECT_EQ(endpoint_ptr->setopt_calls, 0);
+  EXPECT_EQ(endpoint_ptr->range_request_calls, 0);
 }
 
 TEST_F(RemoteHandleTest, test_s3_url)


### PR DESCRIPTION
## Summary
- return early from synchronous remote reads when `size == 0`
- reject zero-size HTTP range construction in the shared range helper
- add a regression test that verifies `RemoteHandle::read(buf, 0, 0)` returns without configuring curl or a range request

## Notes
`RemoteHandle::pread()` already treated zero-size reads as a no-op, but the synchronous `read()` path went on to build a range string from `file_offset + size - 1`. For `size == 0`, that underflows and produces an invalid range.

## Validation
- `pre-commit run --files cpp/src/remote_handle.cpp cpp/tests/test_remote_handle.cpp`
- `git diff --check`

C++ tests were not run locally because this machine does not have CUDA tooling/GPU access (`nvcc` and `nvidia-smi` are unavailable).