### PR TITLE
Close resources before move assignment

### DIFF
--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -115,13 +115,16 @@ FileHandle::FileHandle(FileHandle&& o) noexcept
 
 FileHandle& FileHandle::operator=(FileHandle&& o) noexcept
 {
-  _file_direct_on      = std::exchange(o._file_direct_on, {});
-  _file_direct_off     = std::exchange(o._file_direct_off, {});
-  _initialized         = std::exchange(o._initialized, false);
-  _nbytes              = std::exchange(o._nbytes, 0);
-  _cufile_handle       = std::exchange(o._cufile_handle, {});
-  _compat_mode_manager = std::move(o._compat_mode_manager);
-  _thread_pool         = std::exchange(o._thread_pool, {});
+  if (this != &o) {
+    close();
+    _file_direct_on      = std::exchange(o._file_direct_on, {});
+    _file_direct_off     = std::exchange(o._file_direct_off, {});
+    _initialized         = std::exchange(o._initialized, false);
+    _nbytes              = std::exchange(o._nbytes, 0);
+    _cufile_handle       = std::exchange(o._cufile_handle, {});
+    _compat_mode_manager = std::move(o._compat_mode_manager);
+    _thread_pool         = std::exchange(o._thread_pool, {});
+  }
   return *this;
 }
 

--- a/cpp/src/file_utils.cpp
+++ b/cpp/src/file_utils.cpp
@@ -48,7 +48,10 @@ FileWrapper::FileWrapper(FileWrapper&& o) noexcept : _fd(std::exchange(o._fd, -1
 
 FileWrapper& FileWrapper::operator=(FileWrapper&& o) noexcept
 {
-  _fd = std::exchange(o._fd, -1);
+  if (this != &o) {
+    close();
+    _fd = std::exchange(o._fd, -1);
+  }
   return *this;
 }
 
@@ -83,8 +86,11 @@ CUFileHandleWrapper::CUFileHandleWrapper(CUFileHandleWrapper&& o) noexcept
 
 CUFileHandleWrapper& CUFileHandleWrapper::operator=(CUFileHandleWrapper&& o) noexcept
 {
-  _handle     = std::exchange(o._handle, {});
-  _registered = std::exchange(o._registered, false);
+  if (this != &o) {
+    unregister_handle();
+    _handle     = std::exchange(o._handle, {});
+    _registered = std::exchange(o._registered, false);
+  }
   return *this;
 }
 

--- a/cpp/tests/test_file_utils.cpp
+++ b/cpp/tests/test_file_utils.cpp
@@ -3,18 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <fcntl.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <cerrno>
 #include <filesystem>
 #include <kvikio/error.hpp>
 #include <kvikio/file_handle.hpp>
 #include <kvikio/file_utils.hpp>
 #include <kvikio/utils.hpp>
+#include <utility>
 
 #include "utils/utils.hpp"
 
 using ::testing::HasSubstr;
 using ::testing::ThrowsMessage;
+
+namespace {
+void expect_fd_closed(int fd)
+{
+  errno             = 0;
+  auto const result = ::fcntl(fd, F_GETFD);
+  auto const err    = errno;
+  EXPECT_EQ(result, -1);
+  EXPECT_EQ(err, EBADF);
+}
+}  // namespace
 
 // Note: Dropping pages from the cache is precise, whereas warming pages usually overshoots by
 // bringing more pages to the cache due to kernel's readahead. Therefore in the tests below we
@@ -337,4 +351,47 @@ TEST(FileUtilsTest, get_block_device_info)
       kvikio::get_block_device_info(nonexistent_file_path);
     },
     ThrowsMessage<kvikio::GenericSystemError>(HasSubstr("No such file or directory")));
+}
+
+TEST(FileUtilsTest, file_wrapper_move_assignment_closes_existing_fd)
+{
+  kvikio::test::TempDir tmp_dir;
+  auto const dst_path = tmp_dir.path() / "dst";
+  auto const src_path = tmp_dir.path() / "src";
+
+  kvikio::FileWrapper dst(dst_path.string(), "w", false, kvikio::FileHandle::m644);
+  kvikio::FileWrapper src(src_path.string(), "w", false, kvikio::FileHandle::m644);
+  auto const dst_fd_before = dst.fd();
+  auto const src_fd_before = src.fd();
+  ASSERT_NE(dst_fd_before, -1);
+  ASSERT_NE(src_fd_before, -1);
+  ASSERT_NE(dst_fd_before, src_fd_before);
+
+  dst = std::move(src);
+
+  expect_fd_closed(dst_fd_before);
+  EXPECT_EQ(dst.fd(), src_fd_before);
+  EXPECT_EQ(src.fd(), -1);
+}
+
+TEST(FileUtilsTest, file_handle_move_assignment_closes_existing_fd)
+{
+  kvikio::test::TempDir tmp_dir;
+  auto const dst_path = tmp_dir.path() / "dst";
+  auto const src_path = tmp_dir.path() / "src";
+
+  kvikio::FileHandle dst(dst_path.string(), "w", kvikio::FileHandle::m644, kvikio::CompatMode::ON);
+  kvikio::FileHandle src(src_path.string(), "w", kvikio::FileHandle::m644, kvikio::CompatMode::ON);
+  auto const dst_fd_before = dst.fd();
+  auto const src_fd_before = src.fd();
+  ASSERT_NE(dst_fd_before, -1);
+  ASSERT_NE(src_fd_before, -1);
+  ASSERT_NE(dst_fd_before, src_fd_before);
+
+  dst = std::move(src);
+
+  expect_fd_closed(dst_fd_before);
+  EXPECT_FALSE(dst.closed());
+  EXPECT_EQ(dst.fd(), src_fd_before);
+  EXPECT_TRUE(src.closed());
 }


### PR DESCRIPTION
## Summary
- close existing `FileWrapper` and `CUFileHandleWrapper` resources before move assignment takes ownership
- close an existing `FileHandle` before move assignment so cuFile deregistration happens before fd teardown
- add fd-based regression coverage for wrapper and file-handle move assignment

## Validation
- `pre-commit run --files cpp/src/file_utils.cpp cpp/src/file_handle.cpp cpp/tests/test_file_utils.cpp`
- `git diff --check`

Targeted CTest was not run locally because no installed/devcontainer KvikIO test build was present at the paths searched by `ci/run_ctests.sh -R FILE_UTILS_TEST`.
