### PR TITLE
Test zero-size remote file reads

### DIFF
--- a/python/kvikio/tests/test_http_io.py
+++ b/python/kvikio/tests/test_http_io.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -172,6 +172,19 @@ def test_no_range_support(http_server, tmpdir, xp):
             OverflowError, match="maybe the server doesn't support file ranges?"
         ):
             f.read(b, size=10, file_offset=10)
+
+
+@pytest.mark.parametrize("http_server", [{"range_support": False}], indirect=True)
+@pytest.mark.parametrize("file_offset", [0, 100])
+def test_zero_size_read_returns_without_range_request(http_server, tmpdir, file_offset):
+    a = np.arange(100, dtype="uint8")
+    a.tofile(tmpdir / "a")
+    b = np.full(10, 42, dtype="uint8")
+
+    with kvikio.RemoteFile.open_http(f"{http_server}/a") as f:
+        assert f.read(b, size=0, file_offset=file_offset) == 0
+
+    np.testing.assert_array_equal(b, np.full_like(b, 42))
 
 
 def test_retry_http_503_ok(tmpdir, xp):


### PR DESCRIPTION
## Summary
- add Python RemoteFile.read(size=0) regression coverage for HTTP reads
- run the zero-size reads against a no-range HTTP server so the test fails if KvikIO tries to set a range request
- cover offsets at start-of-file and EOF while verifying the destination buffer is untouched

## Notes
Current main already returns 0 in `RemoteHandle::read()` before setting up a range request when size is 0. This adds Python API coverage for that behavior.

## Validation
- `pre-commit run --files python/kvikio/tests/test_http_io.py`
- `git diff --check`

Not run locally: `python3 -m pytest python/kvikio/tests/test_http_io.py -k zero_size_read_returns_without_range_request -q` because the system Python does not have pytest installed.
