### PR TITLE
Avoid overflow in remote read bounds checks

### DIFF
--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -179,6 +179,11 @@ void setup_range_request_impl(CurlHandle& curl, std::size_t file_offset, std::si
   curl.setopt(CURLOPT_RANGE, byte_range.c_str());
 }
 
+bool is_read_out_of_bounds(std::size_t file_offset, std::size_t size, std::size_t nbytes) noexcept
+{
+  return file_offset > nbytes || size > nbytes - file_offset;
+}
+
 /**
  * @brief Whether the given URL is compatible with the S3 endpoint (including the credential-based
  * access and presigned URL) which uses HTTP/HTTPS.
@@ -762,7 +767,7 @@ std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_off
 
   if (size == 0) { return 0; }
 
-  if (file_offset + size > _nbytes) {
+  if (is_read_out_of_bounds(file_offset, size, _nbytes)) {
     std::stringstream ss;
     ss << "cannot read " << file_offset << "+" << size << " bytes into a " << _nbytes
        << " bytes file (" << _endpoint->str() << ")";
@@ -858,7 +863,7 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
                 "device-memory buffers.",
                 std::invalid_argument);
   KVIKIO_EXPECT(task_size > 0, "`task_size` must be positive", std::invalid_argument);
-  if (file_offset + size > _nbytes) {
+  if (is_read_out_of_bounds(file_offset, size, _nbytes)) {
     std::stringstream ss;
     ss << "cannot read " << file_offset << "+" << size << " bytes into a " << _nbytes
        << " bytes file (" << _endpoint->str() << ")";

--- a/cpp/tests/test_remote_handle.cpp
+++ b/cpp/tests/test_remote_handle.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/test_remote_handle.cpp
+++ b/cpp/tests/test_remote_handle.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -169,6 +170,21 @@ TEST_F(RemoteHandleTest, read_zero_size_returns_without_range_request)
 
   std::vector<char> output(1);
   EXPECT_EQ(remote_handle.read(output.data(), 0, 0), 0);
+  EXPECT_EQ(endpoint_ptr->setopt_calls, 0);
+  EXPECT_EQ(endpoint_ptr->range_request_calls, 0);
+}
+
+TEST_F(RemoteHandleTest, read_overflowing_range_throws_without_range_request)
+{
+  auto endpoint      = std::make_unique<CountingEndpoint>();
+  auto* endpoint_ptr = endpoint.get();
+  kvikio::RemoteHandle remote_handle(std::move(endpoint), endpoint_ptr->file_size);
+
+  std::vector<char> output(1);
+  auto constexpr file_offset = std::numeric_limits<std::size_t>::max() - 1;
+  auto constexpr size        = std::size_t{4};
+  EXPECT_THAT([&] { remote_handle.read(output.data(), size, file_offset); },
+              ThrowsMessage<std::invalid_argument>(HasSubstr("cannot read ")));
   EXPECT_EQ(endpoint_ptr->setopt_calls, 0);
   EXPECT_EQ(endpoint_ptr->range_request_calls, 0);
 }


### PR DESCRIPTION
## Summary
- avoid overflow in remote read bounds checks by comparing `file_offset` before subtracting from `_nbytes`
- use the same bounds helper in direct `RemoteHandle::read()` and the `MULTI_POLL` `pread()` setup path
- add a regression test for a wrapping `file_offset + size` range that must fail before range setup

## Validation
- `pre-commit run --files cpp/src/remote_handle.cpp cpp/tests/test_remote_handle.cpp`
- `git diff --check`

