### PR TITLE
Fix unused variable handling in `infer_remote_endpoint_type`

### DIFF
--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -14,7 +14,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 
 #include <kvikio/bounce_buffer.hpp>
 #include <kvikio/defaults.hpp>

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -658,8 +658,7 @@ bool S3EndpointWithPresignedUrl::is_url_valid(std::string const& url) noexcept
 RemoteEndpointType infer_remote_endpoint_type(std::string const& url)
 {
   KVIKIO_NVTX_FUNC_RANGE();
-  auto [endpoint, _]              = infer_endpoint_impl(url, get_default_allow_list(), false);
-  std::tie(endpoint, std::ignore) = infer_endpoint_impl(url, get_default_allow_list(), false);
+  auto [endpoint, _] = infer_endpoint_impl(url, get_default_allow_list(), false);
   return endpoint->remote_endpoint_type();
 }
 


### PR DESCRIPTION
This fixes how we handle the unused variable in the call to `infer_endpoint_impl`, mentioned in https://github.com/rapidsai/kvikio/pull/982/changes#r3463959618