### PR TITLE
java: use GCS mirror for Maven, other small changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
+      - id: check-xml
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/PyCQA/isort
@@ -74,7 +75,7 @@ repos:
             ^CHANGELOG.md$
           )
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.4.3
+    rev: v1.5.1
     hooks:
       - id: verify-copyright
         args: [--fix, --spdx]
@@ -100,7 +101,7 @@ repos:
           (?x)
             ^pyproject[.]toml$
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.20.0
+    rev: v1.21.0
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean", "--warn-all", "--strict"]

--- a/java/.mvn/maven.config
+++ b/java/.mvn/maven.config
@@ -1,0 +1,6 @@
+-e
+-B
+-Daether.connector.basic.downstreamThreads=1
+-Daether.transport.http.retryHandler.count=5
+-Daether.transport.http.retryHandler.interval=10000
+-Dmaven.wagon.http.retryHandler.count=5

--- a/java/README.md
+++ b/java/README.md
@@ -1,33 +1,43 @@
 # Java KvikIO Bindings
 
 ## Summary
+
 These Java KvikIO bindings for GDS currently support only synchronous read and write IO operations using the underlying cuFile API. Support for batch IO and asynchronous operations are not yet supported.
 
 ## Dependencies
+
 The Java KvikIO bindings have been developed to work on Linux based systems and require [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) to be installed and for [GDS](https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/index.html) to be properly enabled. To compile the shared library it is also necessary to have a JDK installed. To run the included example, it is also necessary to install JCuda as it is used to handle memory allocations and the transfer of data between host and GPU memory. JCuda jar files supporting CUDA 12.x can be found here:
-[jcuda-12.0.0.jar](https://repo1.maven.org/maven2/org/jcuda/jcuda/12.0.0/jcuda-12.0.0.jar),
-[jcuda-natives-12.0.0.jar](https://repo1.maven.org/maven2/org/jcuda/jcuda-natives/12.0.0/jcuda-natives-12.0.0.jar)
+
+* [jcuda-12.0.0.jar](https://repo1.maven.org/maven2/org/jcuda/jcuda/12.0.0/jcuda-12.0.0.jar),
+* [jcuda-natives-12.0.0.jar](https://repo1.maven.org/maven2/org/jcuda/jcuda-natives/12.0.0/jcuda-natives-12.0.0.jar)
 
 For more information on JCuda and potentially more up to date installation instructions or jar files, see here:
 [JCuda](http://javagl.de/jcuda.org/), [JCuda Usage](https://github.com/jcuda/jcuda-main/blob/master/USAGE.md), [JCuda Maven Repo](https://mvnrepository.com/artifact/org.jcuda)
 
 ## Compilation and examples
+
 An example for how to use the Java KvikIO bindings can be found in `src/test/java/ai/rapids/kvikio/cufile/BasicReadWriteTest.java`
 
 ##### Note: This example has a dependency on JCuda so ensure that when running the example the JCuda shared library files are on the JVM library path along with the `libCuFileJNI.so` file.
 
 ### Setup a test file target
+
 ##### NOTE: the example as written will default to creating a temporary file in your `/tmp` directory. This directory may not be mounted in a compatible manner for use with GDS on your particular system, causing the example to run in compatibility mode. If this is the case, run the following command replacing `/mnt/nvme/` with your mount directory and update `cufile/BasicReadWriteTest.java` to point to the correct file path.
 
     touch /mnt/nvme/java_test
 
 ### Compile the shared library and Java files with Maven
+
 ##### Note: This wil also run the example code
 
-    cd kvikio/java/
-    mvn clean install
+```shell
+cd kvikio/java/
+mvn clean install
+```
 
 ### Rerun example code with Maven
 
-    cd kvikio/java/
-    mvn test
+```shell
+cd kvikio/java/
+mvn test
+```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 <project  xmlns="http://maven.apache.org/POM/4.0.0"
@@ -27,6 +27,60 @@ SPDX-License-Identifier: Apache-2.0
     <jcuda.version>12.0.0</jcuda.version>
     <cmake.version>4.0.3-b1</cmake.version>
   </properties>
+
+    <repositories>
+        <!-- Prefer Google Cloud mirror, which has higher rate limits -->
+        <repository>
+            <id>gcs-maven-central-mirror</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- Fall back to Maven upstream for packages not found in GCS mirror -->
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <!-- Prefer Google Cloud mirror, which has higher rate limits -->
+        <pluginRepository>
+            <id>gcs-maven-central-mirror</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <!-- Fall back to Maven upstream for packages not found in GCS mirror -->
+        <pluginRepository>
+            <id>central</id>
+            <name>Maven Plugin Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
   <dependencies>
     <dependency>
@@ -59,15 +113,8 @@ SPDX-License-Identifier: Apache-2.0
     <pluginManagement>
       <plugins>
         <plugin>
-          <artifactId>maven-exec-plugin</artifactId>
-          <version>1.6.0</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
-          <configuration>
-            <createDirs>true</createDirs>
-          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
@@ -88,7 +135,7 @@ SPDX-License-Identifier: Apache-2.0
             <dependency>
               <groupId>org.junit.jupiter</groupId>
               <artifactId>junit-jupiter-engine</artifactId>
-              <version>5.4.2</version>
+              <version>${junit.version}</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -103,14 +150,6 @@ SPDX-License-Identifier: Apache-2.0
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/297

RAPIDS projects using NVIDIA-hosted GitHub Actions runners have been getting rate-limited by Maven Central. Similar to https://github.com/NVIDIA/cuvs/pull/2253, this proposes fixing that by using the same read-only Maven mirror that Apache Orc, Lucene, Spark and others use in their builds (https://storage-download.googleapis.com/maven-central/index.html).

Other changes:

* adding default `mvn` options to request packages more slowly and wait longer between retries
* updating RAPIDS `pre-commit` hooks
* adding `check-xml` hook to validate that `pom.xml` are valid XML docs
* reformatting READMEs per https://yihui.org/en/2021/06/markdown-breath/
* other minor `pom.xml` maintenance (see comments)