### PR TITLE
simplify handling of 'moto[server]' dependency

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Dependency list for https://github.com/rapidsai/dependency-file-generator
@@ -441,17 +441,6 @@ dependencies:
           - matrix:
             packages:
               - *cuda_python_cu13
-      # 'pip' constraints files cannot include extras like 'moto[server]'. This group
-      # ensures that dependencies ends up in 'kvikio[test]' ('dependencies' key not passed)
-      # but not in the output of 'rapids-generate-pip-constraints' in CI scripts ('dependencies' passed).
-      - output_types: requirements
-        matrices:
-          - matrix:
-              dependencies: "*"
-            packages:
-          - matrix:
-            packages:
-              - *moto_server
   test_java:
     common:
       - output_types: conda


### PR DESCRIPTION
Closes #945

Dependencies with extras like `moto[server]` cannot be used in constraints files for `pip`. I realize now that I way-overcomplicated this in https://github.com/rapidsai/kvikio/pull/942#discussion_r2954135278 ... it's enough to simply make sure that that is only in `dependencies.yaml` groups with `output_types: pyproject`, and not `output_types: requirements`.

Everything will still work as expected because the test-time constraints and `kvikio*.whl[test]` are installed together

https://github.com/rapidsai/kvikio/blob/5baea4603ee31a5c489ec15e55dbf1f43c8618ef/ci/test_wheel.sh#L24-L29

This removes the workaround for `output_types: requirements` for `moto`.