### PR TITLE
switch from 'cuda-python' to specific components (e.g. 'cuda-core')

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -20,7 +20,7 @@ rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_python \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
   --prepend-channel "${CPP_CHANNEL}" --prepend-channel "${PYTHON_CHANNEL}" \
   | tee env.yaml
 

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -8,8 +8,8 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=4.0
+- cuda-core>=0.5.0,<2
 - cuda-nvcc
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -8,7 +8,7 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=4.0
-- cuda-core>=0.5.0,<2
+- cuda-core>=0.5.1,<2
 - cuda-nvcc
 - cuda-version=12.9
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -8,8 +8,8 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=4.0
+- cuda-core>=0.5.0,<2
 - cuda-nvcc
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -8,7 +8,7 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=4.0
-- cuda-core>=0.5.0,<2
+- cuda-core>=0.5.1,<2
 - cuda-nvcc
 - cuda-version=12.9
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -8,7 +8,7 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=4.0
-- cuda-core>=0.5.0,<2
+- cuda-core>=0.5.1,<2
 - cuda-nvcc
 - cuda-version=13.3
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -8,8 +8,8 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=4.0
+- cuda-core>=0.5.0,<2
 - cuda-nvcc
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -8,7 +8,7 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=4.0
-- cuda-core>=0.5.0,<2
+- cuda-core>=0.5.1,<2
 - cuda-nvcc
 - cuda-version=13.3
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -8,8 +8,8 @@ dependencies:
 - boto3>=1.21.21
 - c-compiler
 - cmake>=4.0
+- cuda-core>=0.5.0,<2
 - cuda-nvcc
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -430,7 +430,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - cuda-core>=0.5.0,<2
+          - cuda-core>=0.5.1,<2
           - rapids-dask-dependency==26.8.*,>=0.0.0a0
           - pytest
           - pytest-asyncio
@@ -451,7 +451,7 @@ dependencies:
           - matrix:
               dependencies: "oldest"
             packages:
-              - cuda-core==0.5.0
+              - cuda-core==0.5.1
           - matrix:
             packages:
   test_java:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -430,6 +430,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
+          - cuda-core>=0.5.0,<2
           - rapids-dask-dependency==26.8.*,>=0.0.0a0
           - pytest
           - pytest-asyncio
@@ -448,16 +449,11 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         matrices:
           - matrix:
-              cuda: "12.*"
+              dependencies: "oldest"
             packages:
-              - cuda-python>=12.9.2,<13.0
-          - matrix:
-              cuda: "13.*"
-            packages:
-              - &cuda_python_cu13 cuda-python>=13.0.1,<14.0
+              - cuda-core==0.5.0
           - matrix:
             packages:
-              - *cuda_python_cu13
   test_java:
     common:
       - output_types: conda

--- a/python/kvikio/kvikio/benchmarks/utils.py
+++ b/python/kvikio/kvikio/benchmarks/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ has_cuda_core_system = False
 with contextlib.suppress(ImportError):
     from cuda.core import system
 
-    has_cuda_core_system = system.CUDA_BINDINGS_NVML_IS_COMPATIBLE
+    has_cuda_core_system = system.getattr("CUDA_BINDINGS_NVML_IS_COMPATIBLE", False)
 
 
 def drop_vm_cache() -> None:

--- a/python/kvikio/kvikio/benchmarks/utils.py
+++ b/python/kvikio/kvikio/benchmarks/utils.py
@@ -20,7 +20,7 @@ has_cuda_core_system = False
 with contextlib.suppress(ImportError):
     from cuda.core import system
 
-    has_cuda_core_system = system.getattr("CUDA_BINDINGS_NVML_IS_COMPATIBLE", False)
+    has_cuda_core_system = getattr(system, "CUDA_BINDINGS_NVML_IS_COMPATIBLE", False)
 
 
 def drop_vm_cache() -> None:

--- a/python/kvikio/pyproject.toml
+++ b/python/kvikio/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 [project.optional-dependencies]
 test = [
     "boto3>=1.21.21",
-    "cuda-python>=13.0.1,<14.0",
+    "cuda-core>=0.5.0,<2",
     "moto[server]>=4.0.8",
     "pytest",
     "pytest-asyncio",

--- a/python/kvikio/pyproject.toml
+++ b/python/kvikio/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 [project.optional-dependencies]
 test = [
     "boto3>=1.21.21",
-    "cuda-core>=0.5.0,<2",
+    "cuda-core>=0.5.1,<2",
     "moto[server]>=4.0.8",
     "pytest",
     "pytest-asyncio",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/285

`cuda-python` is a metapackage and sometimes pulls in components that RAPIDS libraries don't need. This PR is part of a series dropping direct use of `cuda-python` in favor of depending only on those specific components.

* drops dependency on `cuda-python` (test-only)
* adds explicit dependencies on components:
  - `cuda-core>=0.5.1` (test-only)
* adds explicit testing of oldest `cuda-core` in CI (and fixes an issue with that support missed in #970)

## Notes for Reviewers

### Why these specific bounds?

* these roughly match what we were getting with `cuda-python`
* worked through finding compatible ranges in https://github.com/rapidsai/rmm/pull/2460#discussion_r3514148466