### PR TITLE
Update docs to use NVIDIA Sphinx theme

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -37,7 +37,8 @@ dependencies:
 - scikit-build-core>=0.11.0
 - sphinx
 - sphinx-click
-- sphinx_rtd_theme
 - sysroot_linux-aarch64=2.28
 - zarr>=3.0.0,<3.2.0,<4.0.0
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -37,7 +37,8 @@ dependencies:
 - scikit-build-core>=0.11.0
 - sphinx
 - sphinx-click
-- sphinx_rtd_theme
 - sysroot_linux-64=2.28
 - zarr>=3.0.0,<3.2.0,<4.0.0
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -37,7 +37,8 @@ dependencies:
 - scikit-build-core>=0.11.0
 - sphinx
 - sphinx-click
-- sphinx_rtd_theme
 - sysroot_linux-aarch64=2.28
 - zarr>=3.0.0,<3.2.0,<4.0.0
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -37,7 +37,8 @@ dependencies:
 - scikit-build-core>=0.11.0
 - sphinx
 - sphinx-click
-- sphinx_rtd_theme
 - sysroot_linux-64=2.28
 - zarr>=3.0.0,<3.2.0,<4.0.0
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-133_arch-x86_64

--- a/cpp/doxygen/header.html
+++ b/cpp/doxygen/header.html
@@ -17,10 +17,6 @@ $mathjax
 <link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
 $extrastylesheet
 
-<!-- RAPIDS CUSTOM JS & CSS: START, Please add these two lines back after every version upgrade -->
-<script defer src="https://docs.rapids.ai/assets/js/custom.js"></script>
-<link rel="stylesheet" href="https://docs.rapids.ai/assets/css/custom.css">
-<!-- RAPIDS CUSTOM JS & CSS: END -->
 
 </head>
 <body>

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -360,7 +360,8 @@ dependencies:
           - zarr>=3.0.0,<3.2.0,<4.0.0
           - sphinx
           - sphinx-click
-          - sphinx_rtd_theme
+          - pip:
+              - nvidia-sphinx-theme
       - output_types: conda
         packages:
           - doxygen=1.9.1 # pre-commit hook needs a specific version.

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -360,11 +360,14 @@ dependencies:
           - zarr>=3.0.0,<3.2.0,<4.0.0
           - sphinx
           - sphinx-click
-          - pip:
-              - nvidia-sphinx-theme
       - output_types: conda
         packages:
           - doxygen=1.9.1 # pre-commit hook needs a specific version.
+          - pip:
+              - nvidia-sphinx-theme
+      - output_types: requirements
+        packages:
+          - nvidia-sphinx-theme
   py_version:
     specific:
       - output_types: conda

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,6 +98,16 @@ autodoc_default_options = {
 # a list of builtin themes.
 #
 html_theme = "nvidia_sphinx_theme"
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/rapidsai/kvikio",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+    ],
+}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -148,7 +158,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "kvikio.tex", "kvikio Documentation", "NVIDIA", "manual")
+    (master_doc, "kvikio.tex", f"{project} Documentation", author, "manual")
 ]
 
 
@@ -156,7 +166,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "kvikio", "kvikio Documentation", [author], 1)]
+man_pages = [(master_doc, "kvikio", f"{project} Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------------
@@ -168,7 +178,7 @@ texinfo_documents = [
     (
         master_doc,
         "kvikio",
-        "kvikio Documentation",
+        f"{project} Documentation",
         author,
         "kvikio",
         "One line description of project.",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Configuration file for the Sphinx documentation builder.
@@ -51,7 +51,6 @@ extensions = [
     "sphinx.ext.extlinks",
     "numpydoc",
     "sphinx_click",
-    "sphinx_rtd_theme",
 ]
 
 numpydoc_show_class_members = False
@@ -96,7 +95,7 @@ autodoc_default_options = {
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "nvidia_sphinx_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -195,10 +194,3 @@ epub_exclude_files = ["search.html"]
 
 
 # -- Extension configuration -------------------------------------------------
-
-
-def setup(app):
-    app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
-    app.add_js_file(
-        "https://docs.rapids.ai/assets/js/custom.js", loading_method="defer"
-    )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,15 +17,17 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import datetime
+
 from packaging.version import Version
 
 import kvikio
 
 # -- Project information -----------------------------------------------------
 
-project = "kvikio"
-copyright = "2023, NVIDIA"
-author = "NVIDIA"
+project = "NVIDIA KvikIO"
+copyright = f"2023-{datetime.datetime.today().year}, NVIDIA Corporation"
+author = "NVIDIA Corporation"
 
 KVIKIO_VERSION = Version(kvikio.__version__)
 # The short X.Y version.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
-Welcome to KvikIO's Python documentation!
-=========================================
+NVIDIA KvikIO Documentation
+===========================
 
-KvikIO is a Python and C++ library for high performance file IO. It provides C++ and Python
+NVIDIA KvikIO is a Python and C++ library for high performance file IO. It provides C++ and Python
 bindings to `cuFile <https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html>`_,
 which enables `GPUDirect Storage <https://developer.nvidia.com/blog/gpudirect-storage/>`_ (GDS).
 KvikIO also works efficiently when GDS isn't available and can read/write both host and device data seamlessly.


### PR DESCRIPTION
## Description

Updates the Sphinx documentation to use `nvidia_sphinx_theme` with the theme's default left navigation.

This replaces the previous Sphinx theme dependency, removes the legacy shared RAPIDS CSS/JavaScript injection where present, and regenerates dependency manifests.

Contributes to rapidsai/build-planning#300.

## Validation

- Commit-time pre-commit hooks passed, including generated dependency files.
- Doxygen completed and `sphinx-build -b dirhtml source _html -W` passed in the CUDA 13.3 devcontainer.
- Rendered HTML loads the NVIDIA theme, uses the default left navigation, and contains no legacy shared RAPIDS asset URLs.

