### PR TITLE
wheels: ensure cuda-toolkit doesn't end up in [test] extra when use_cuda_wheels=false

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -487,16 +487,25 @@ dependencies:
           - matrix:
             packages:
   test_cufile:
-    common:
-      - output_types: pyproject
-        packages:
-          - cuda-toolkit[cufile]
     specific:
+      - output_types: pyproject
+        matrices:
+          # if use_cuda_wheels=false is provided, do not add dependencies on any CUDA wheels
+          # (e.g. for DLFW and pip devcontainers)
+          - matrix:
+              use_cuda_wheels: "false"
+            packages:
+          - matrix:
+            packages:
+              - cuda-toolkit[cufile]
       # The `cufile` extra was added to the `cuda-toolkit` metapackage in 12.6.3
       # Adding an explicit test dependency on the cufile package here for
       # testing on versions before 12.6.3
       - output_types: pyproject
         matrices:
+          - matrix:
+              use_cuda_wheels: "false"
+            packages:
           - matrix:
               cuda: "12.*"
               use_cuda_wheels: "true"


### PR DESCRIPTION
Follow-up to #1000 and #1003

As of that PR, `kvikio[test]` would pull in `cuda-toolkit`, even if the wheel was built with the `use_cuda_wheels=false` filter. This is undesirable for situations like pip devcontainers and DLFW builds, where we want to exclusively depend on a system installation of the CUDA toolkit.

This guards that dependency with `use_cuda_wheels`.

## Notes for Reviewers

This is the type of thing that could be caught earlier if we did https://github.com/rapidsai/pre-commit-hooks/issues/132