### PR TITLE
[DO NOT MERGE] ci: add KvikIO release catalog canary

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,13 +43,15 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       node_type: cpu8
       date: ${{ inputs.date }}
       script: ci/build_cpp.sh
+      release-build-output: true
+      release-unit: conda:kvikio-cpp
       sha: ${{ inputs.sha }}
   python-build:
     needs: [cpp-build]
@@ -60,12 +62,14 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh
+      release-build-output: true
+      release-unit: conda:kvikio-python
       sha: ${{ inputs.sha }}
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
@@ -112,7 +116,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       build_type: ${{ inputs.build_type || 'branch' }}
@@ -123,6 +127,8 @@ jobs:
       script: ci/build_wheel_cpp.sh
       package-name: libkvikio
       package-type: cpp
+      release-build-output: true
+      release-unit: wheel:libkvikio
   wheel-build-python:
     needs: wheel-build-cpp
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -132,7 +138,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -142,6 +148,8 @@ jobs:
       script: ci/build_wheel_python.sh
       package-name: kvikio
       package-type: python
+      release-build-output: true
+      release-unit: wheel:kvikio
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-publish-cpp:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,8 +50,6 @@ jobs:
       node_type: cpu8
       date: ${{ inputs.date }}
       script: ci/build_cpp.sh
-      release-build-output: true
-      release-unit: conda:kvikio-cpp
       sha: ${{ inputs.sha }}
   python-build:
     needs: [cpp-build]
@@ -68,8 +66,6 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh
-      release-build-output: true
-      release-unit: conda:kvikio-python
       sha: ${{ inputs.sha }}
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
@@ -127,8 +123,6 @@ jobs:
       script: ci/build_wheel_cpp.sh
       package-name: libkvikio
       package-type: cpp
-      release-build-output: true
-      release-unit: wheel:libkvikio
   wheel-build-python:
     needs: wheel-build-cpp
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -148,8 +142,6 @@ jobs:
       script: ci/build_wheel_python.sh
       package-name: kvikio
       package-type: python
-      release-build-output: true
-      release-unit: wheel:kvikio
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-publish-cpp:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -208,8 +208,6 @@ jobs:
       build_type: pull-request
       node_type: cpu8
       script: ci/build_cpp.sh
-      release-build-output: true
-      release-unit: conda:kvikio-cpp
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -253,8 +251,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_python.sh
-      release-build-output: true
-      release-unit: conda:kvikio-python
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   conda-python-tests:
@@ -327,8 +323,6 @@ jobs:
       script: ci/build_wheel_cpp.sh
       package-name: libkvikio
       package-type: cpp
-      release-build-output: true
-      release-unit: wheel:libkvikio
   wheel-python-build:
     needs: wheel-cpp-build
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -345,8 +339,6 @@ jobs:
       script: ci/build_wheel_python.sh
       package-name: kvikio
       package-type: python
-      release-build-output: true
-      release-unit: wheel:kvikio
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-python-tests:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -203,11 +203,13 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       node_type: cpu8
       script: ci/build_cpp.sh
+      release-build-output: true
+      release-unit: conda:kvikio-cpp
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -247,10 +249,12 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       script: ci/build_python.sh
+      release-build-output: true
+      release-unit: conda:kvikio-python
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   conda-python-tests:
@@ -315,7 +319,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       build_type: pull-request
@@ -323,6 +327,8 @@ jobs:
       script: ci/build_wheel_cpp.sh
       package-name: libkvikio
       package-type: cpp
+      release-build-output: true
+      release-unit: wheel:libkvikio
   wheel-python-build:
     needs: wheel-cpp-build
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -332,13 +338,15 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       node_type: cpu8
       script: ci/build_wheel_python.sh
       package-name: kvikio
       package-type: python
+      release-build-output: true
+      release-unit: wheel:kvikio
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-python-tests:


### PR DESCRIPTION
**Posted by Codex (GPT-5) on behalf of [@msarahan](https://github.com/msarahan). This pull request description is LLM-generated; readers should treat its content accordingly.**

## Summary

- exercise KvikIO's Conda C++, Conda Python, `libkvikio` wheel, and `kvikio` wheel producers;
- apply the canary consistently in both `build.yaml` and `pr.yaml`;
- keep CUDA, architecture, and Python expansion inside the owning shared producer workflows; and
- validate standard-producer release catalog entry generation across 16 matrix outputs.

This was a historical branch canary for the predecessor interface. The current contract uploads `release-catalog-<source-artifact-name>` companions containing one enveloped `release-catalog-entries.json` and evidence. These job-level entries are aggregated by the release platform into the release catalog.

The literal development branch name and historical run artifact names retain predecessor vocabulary because they are immutable Git and Actions identifiers.

## Expected canary coverage

- `conda:kvikio` for the repository's Conda publishable artifact set; and
- `wheel:kvikio` for the repository's wheel publishable artifact set.

Package-name differences alone do not justify distinct `release_catalog_key` values. Matrix variants and multiple packages sharing one release lifecycle remain under the same repository-level key.

KvikIO supplies no dependency SBOM sidecars, so generated SPDX records are `generated-identity` envelopes, not dependency coverage.

## Validation

- `pre-commit run --all-files`
- `git diff --check`

Tracks [`rapidsai/build-infra#381`](https://github.com/rapidsai/build-infra/issues/381).
