### PR TITLE
Fix cuFile dependency and enable CI wheel tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,21 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/test_python.sh
       sha: ${{ inputs.sha }}
+  wheel-tests:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    with:
+      build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      script: ci/test_wheel.sh
   conda-java-tests:
     secrets: inherit # zizmor: ignore[secrets-inherit]
     permissions:

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -16,11 +16,10 @@ KVIKIO_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_py
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"
 
 # Verify libkvikio's runtime dependencies before KvikIO's test extra can install them.
-python -m venv /tmp/libkvikio-wheel-test
-/tmp/libkvikio-wheel-test/bin/pip install \
+rapids-pip-retry install \
   --constraint "${PIP_CONSTRAINT}" \
   "$(echo "${LIBKVIKIO_WHEELHOUSE}"/libkvikio_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)"
-/tmp/libkvikio-wheel-test/bin/python -c "import libkvikio; libkvikio.load_library()"
+python -c "import libkvikio; libkvikio.load_library()"
 
 # notes:
 #

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -eou pipefail
@@ -27,5 +27,7 @@ rapids-pip-retry install \
   --constraint "${PIP_CONSTRAINT}" \
   "$(echo "${LIBKVIKIO_WHEELHOUSE}"/libkvikio_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)" \
   "$(echo "${KVIKIO_WHEELHOUSE}"/kvikio_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)[test]"
+
+python -c "import libkvikio; libkvikio.load_library()"
 
 python -m pytest --cache-clear --verbose ./python/kvikio/tests

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -15,13 +15,19 @@ KVIKIO_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_py
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"
 
-# Verify libkvikio's runtime dependencies before KvikIO's test extra can install them.
+python -m venv libkvikio-env
+. libkvikio-env/bin/activate
+
 rapids-pip-retry install \
   -v \
   --prefer-binary \
   --constraint "${PIP_CONSTRAINT}" \
   "$(echo "${LIBKVIKIO_WHEELHOUSE}"/libkvikio_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)"
 python -c "import libkvikio; libkvikio.load_library()"
+deactivate
+
+python -m venv kvikio-env
+. kvikio-env/bin/activate
 
 # notes:
 #

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -15,6 +15,12 @@ KVIKIO_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_py
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"
 
+python -m venv /tmp/libkvikio-wheel-test
+/tmp/libkvikio-wheel-test/bin/pip install \
+  --constraint "${PIP_CONSTRAINT}" \
+  "$(echo "${LIBKVIKIO_WHEELHOUSE}"/libkvikio_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)"
+/tmp/libkvikio-wheel-test/bin/python -c "import libkvikio; libkvikio.load_library()"
+
 # notes:
 #
 #   * echo to expand wildcard before adding `[test]` requires for pip
@@ -27,7 +33,5 @@ rapids-pip-retry install \
   --constraint "${PIP_CONSTRAINT}" \
   "$(echo "${LIBKVIKIO_WHEELHOUSE}"/libkvikio_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)" \
   "$(echo "${KVIKIO_WHEELHOUSE}"/kvikio_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)[test]"
-
-python -c "import libkvikio; libkvikio.load_library()"
 
 python -m pytest --cache-clear --verbose ./python/kvikio/tests

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -15,6 +15,7 @@ KVIKIO_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_py
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"
 
+# Verify libkvikio's runtime dependencies before KvikIO's test extra can install them.
 python -m venv /tmp/libkvikio-wheel-test
 /tmp/libkvikio-wheel-test/bin/pip install \
   --constraint "${PIP_CONSTRAINT}" \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -17,6 +17,8 @@ rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"
 
 # Verify libkvikio's runtime dependencies before KvikIO's test extra can install them.
 rapids-pip-retry install \
+  -v \
+  --prefer-binary \
   --constraint "${PIP_CONSTRAINT}" \
   "$(echo "${LIBKVIKIO_WHEELHOUSE}"/libkvikio_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)"
 python -c "import libkvikio; libkvikio.load_library()"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -240,16 +240,22 @@ dependencies:
               # some components (like nvidia-cublas-cu12 and nvidia-cuda-nvcc-cu12) didn't have
               # aarch64 wheels until CTK 12.3, so allow a slightly looser bound here
               - cuda-toolkit>=12.2,<12.4
+              # Pin the oldest available cuFile wheel, released with CUDA Toolkit 12.6.3.
+              - nvidia-cufile-cu12==1.11.1.6.*
           - matrix:
               cuda: "12.2"
               use_cuda_wheels: "true"
             packages:
               - cuda-toolkit==12.2.*
+              # Pin the oldest available cuFile wheel, released with CUDA Toolkit 12.6.3.
+              - nvidia-cufile-cu12==1.11.1.6.*
           - matrix:
               cuda: "12.5"
               use_cuda_wheels: "true"
             packages:
               - cuda-toolkit==12.5.*
+              # Pin the oldest available cuFile wheel, released with CUDA Toolkit 12.6.3.
+              - nvidia-cufile-cu12==1.11.1.6.*
           - matrix:
               cuda: "12.8"
               use_cuda_wheels: "true"
@@ -304,6 +310,8 @@ dependencies:
               use_cuda_wheels: "true"
             packages:
               - cuda-toolkit[cufile]==12.*
+              # cuda-toolkit before 12.6.3 does not have the `cufile` extra.
+              - nvidia-cufile-cu12
               - cuda-pathfinder
           - matrix:
               cuda: "13.*"


### PR DESCRIPTION
A few critical packaging/CI fixes:
- Wheel tests were not being run in `test.yaml`. This adds that job.
- The cuFile dependency wasn't being specified properly, so CUDA < 12.6 didn't have a runtime dependency on cuFile wheels, and `libkvikio.load_library()` would fail.
- The wheel script now explicitly loads libkvikio after installation (and without the `[test]` extras), so any missing runtime libraries will trigger a failure in CI.