### PR TITLE
Add structured, physical read traces

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -64,7 +64,7 @@ rapids_cpm_init()
 
 include(${rapids-cmake-dir}/cpm/rapids_logger.cmake)
 rapids_cpm_rapids_logger(BUILD_EXPORT_SET kvikio-exports INSTALL_EXPORT_SET kvikio-exports)
-create_logger_macros(KVIKIO "kvikio::default_logger()" include/kvikio)
+create_logger_macros(KVIKIO "kvikio::formatted_logger()" include/kvikio)
 
 rapids_find_package(
   Threads REQUIRED

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <string>
 
 #include <kvikio/buffer.hpp>
 #include <kvikio/compat_mode.hpp>
@@ -37,6 +38,7 @@ class FileHandle {
   FileWrapper _file_direct_off{};
   bool _initialized{false};
   mutable std::size_t _nbytes{0};  // The size of the underlying file, zero means unknown.
+  std::string _file_path{};
   CUFileHandleWrapper _cufile_handle{};
   CompatModeManager _compat_mode_manager;
   friend class CompatModeManager;

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/kvikio/logger.hpp
+++ b/cpp/include/kvikio/logger.hpp
@@ -102,6 +102,7 @@ std::string sanitize_read_log_url(std::string const& url);
  * - `status: str`
  * - `isDeviceBuffer: bool`
  * - `requestId: int`
+ * - `method: str` (optional; HTTP method such as `"GET"` for remote reads)
  */
 void log_physical_read(std::string const& source,
                        std::int64_t start,
@@ -112,5 +113,29 @@ void log_physical_read(std::string const& source,
                        char const* backend,
                        char const* status,
                        bool is_device_buffer,
-                       std::size_t request_id);
+                       std::size_t request_id,
+                       char const* method = nullptr);
+
+/**
+ * @brief Emit one HTTP metadata / probe request record at TRACE level.
+ *
+ * Used for size discovery and similar non-data-read HTTP operations (for example HEAD
+ * during `RemoteFile` open, or a one-byte GET used when HEAD is unavailable).
+ *
+ * Record schema:
+ * - `event: "http"`
+ * - `source: str`
+ * - `start: int` (epoch nanoseconds)
+ * - `end: int` (epoch nanoseconds)
+ * - `threadId: int`
+ * - `method: str` (for example `"HEAD"` or `"GET"`)
+ * - `status: str`
+ * - `purpose: str` (for example `"metadata"`)
+ */
+void log_http_request(std::string const& source,
+                      std::int64_t start,
+                      std::int64_t end,
+                      char const* method,
+                      char const* status,
+                      char const* purpose = "metadata");
 }  // namespace KVIKIO_EXPORT kvikio

--- a/cpp/include/kvikio/logger.hpp
+++ b/cpp/include/kvikio/logger.hpp
@@ -4,6 +4,9 @@
  */
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include <kvikio/logger_macros.hpp>
 #include <kvikio/shim/utils.hpp>
 
@@ -25,4 +28,57 @@ namespace KVIKIO_EXPORT kvikio {
  * @return Reference to the global KvikIO logger
  */
 rapids_logger::logger& default_logger();
+
+/**
+ * @brief Returns the global structured-read logger instance for KvikIO.
+ *
+ * The logger is configured once on first access using the following environment variables:
+ *
+ * - `KVIKIO_READ_LOG_FILE`: If set, structured read records are written to this file path in
+ *   append mode.
+ * - `KVIKIO_READ_LOG_LEVEL`: Optional log level (`INFO` by default). Use `OFF` to disable
+ *   structured read logging while keeping `KVIKIO_READ_LOG_FILE` set.
+ * - `KVIKIO_READ_LOG_REDACT_QUERY`: Optional boolean (`ON` by default). When enabled, URL query
+ *   strings are removed from the `source` field.
+ *
+ * @return Reference to the global structured-read logger.
+ */
+rapids_logger::logger& read_logger();
+
+/**
+ * @brief Whether structured read logging is enabled.
+ */
+bool is_read_logging_enabled();
+
+/**
+ * @brief Return a URL string sanitized for structured read logging.
+ */
+std::string sanitize_read_log_url(std::string const& url);
+
+/**
+ * @brief Emit one structured read record as NDJSON.
+ *
+ * Record schema:
+ * - `source: str`
+ * - `start: int` (epoch nanoseconds)
+ * - `end: int` (epoch nanoseconds)
+ * - `offset: int`
+ * - `size: int`
+ * - `threadId: int`
+ * - `bytesRead: int`
+ * - `backend: str`
+ * - `status: str`
+ * - `isDeviceBuffer: bool`
+ * - `requestId: int`
+ */
+void log_structured_read(std::string const& source,
+                         std::int64_t start,
+                         std::int64_t end,
+                         std::size_t offset,
+                         std::size_t size,
+                         std::size_t bytes_read,
+                         char const* backend,
+                         char const* status,
+                         bool is_device_buffer,
+                         std::size_t request_id);
 }  // namespace KVIKIO_EXPORT kvikio

--- a/cpp/include/kvikio/logger.hpp
+++ b/cpp/include/kvikio/logger.hpp
@@ -1,11 +1,16 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 
 #include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
+#include <utility>
 
 #include <kvikio/logger_macros.hpp>
 #include <kvikio/shim/utils.hpp>
@@ -24,39 +29,66 @@ namespace KVIKIO_EXPORT kvikio {
  * - `KVIKIO_LOG_FILE`: If set, log output is written to this file path (overwritten on each process
  * start). If the file cannot be opened, falls back to stderr with a warning. Has no effect when
  * logging is disabled.
+ * - `KVIKIO_LOG_FORMAT`: Sets the output format to `TEXT` (the default) or `JSON`.
  *
  * @return Reference to the global KvikIO logger
  */
 rapids_logger::logger& default_logger();
 
 /**
- * @brief Returns the global structured-read logger instance for KvikIO.
- *
- * The logger is configured once on first access using the following environment variables:
- *
- * - `KVIKIO_READ_LOG_FILE`: If set, structured read records are written to this file path in
- *   append mode.
- * - `KVIKIO_READ_LOG_LEVEL`: Optional log level (`INFO` by default). Use `OFF` to disable
- *   structured read logging while keeping `KVIKIO_READ_LOG_FILE` set.
- * - `KVIKIO_READ_LOG_REDACT_QUERY`: Optional boolean (`ON` by default). When enabled, URL query
- *   strings are removed from the `source` field.
- *
- * @return Reference to the global structured-read logger.
+ * @brief Log a preformatted message using the configured output format.
  */
-rapids_logger::logger& read_logger();
+void log_message(rapids_logger::level_enum level, std::string const& message);
 
 /**
- * @brief Whether structured read logging is enabled.
+ * @brief Logger facade that applies KvikIO's configured output format.
  */
-bool is_read_logging_enabled();
+class Logger {
+ public:
+  template <typename... Args>
+  void log(rapids_logger::level_enum level, std::string const& format, Args&&... args)
+  {
+    if (!default_logger().should_log(level)) { return; }
+
+    auto convert_to_c_string = [](auto&& arg) -> decltype(auto) {
+      using ArgType = std::decay_t<decltype(arg)>;
+      if constexpr (std::is_same_v<ArgType, std::string>) {
+        return arg.c_str();
+      } else {
+        return std::forward<decltype(arg)>(arg);
+      }
+    };
+
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
+    auto const formatted_size =
+      std::snprintf(nullptr, 0, format.c_str(), convert_to_c_string(std::forward<Args>(args))...);
+    if (formatted_size < 0) { throw std::runtime_error("Error during formatting."); }
+    if (formatted_size == 0) {
+      log_message(level, {});
+      return;
+    }
+    auto const size = static_cast<std::size_t>(formatted_size) + 1;
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
+    auto buffer = std::make_unique<char[]>(size);
+    std::snprintf(
+      buffer.get(), size, format.c_str(), convert_to_c_string(std::forward<Args>(args))...);
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
+    log_message(level, {buffer.get(), buffer.get() + formatted_size});
+  }
+};
 
 /**
- * @brief Return a URL string sanitized for structured read logging.
+ * @brief Returns the global output-formatting logger facade.
+ */
+Logger& formatted_logger();
+
+/**
+ * @brief Return a URL string sanitized for read logging.
  */
 std::string sanitize_read_log_url(std::string const& url);
 
 /**
- * @brief Emit one structured read record as NDJSON.
+ * @brief Emit one physical-read record at TRACE level.
  *
  * Record schema:
  * - `source: str`
@@ -71,14 +103,14 @@ std::string sanitize_read_log_url(std::string const& url);
  * - `isDeviceBuffer: bool`
  * - `requestId: int`
  */
-void log_structured_read(std::string const& source,
-                         std::int64_t start,
-                         std::int64_t end,
-                         std::size_t offset,
-                         std::size_t size,
-                         std::size_t bytes_read,
-                         char const* backend,
-                         char const* status,
-                         bool is_device_buffer,
-                         std::size_t request_id);
+void log_physical_read(std::string const& source,
+                       std::int64_t start,
+                       std::int64_t end,
+                       std::size_t offset,
+                       std::size_t size,
+                       std::size_t bytes_read,
+                       char const* backend,
+                       char const* status,
+                       bool is_device_buffer,
+                       std::size_t request_id);
 }  // namespace KVIKIO_EXPORT kvikio

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -8,9 +8,12 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 
@@ -30,6 +33,29 @@
 namespace kvikio {
 
 namespace {
+
+std::int64_t epoch_nanos()
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+           std::chrono::system_clock::now().time_since_epoch())
+    .count();
+}
+
+thread_local std::optional<std::size_t> current_request_id{};
+
+class scoped_request_id {
+ public:
+  explicit scoped_request_id(std::size_t request_id) : _prev{current_request_id}
+  {
+    current_request_id = request_id;
+  }
+  ~scoped_request_id() { current_request_id = _prev; }
+
+ private:
+  std::optional<std::size_t> _prev;
+};
+
+std::size_t active_request_id() { return current_request_id.value_or(0); }
 
 /**
  * @brief Get a thread pool specific to the block device hosting the given file.
@@ -96,7 +122,9 @@ FileHandle::FileHandle(std::string const& file_path,
                        std::string const& flags,
                        mode_t mode,
                        CompatMode compat_mode)
-  : _initialized{true}, _compat_mode_manager{file_path, flags, mode, compat_mode, this}
+  : _initialized{true},
+    _file_path{file_path},
+    _compat_mode_manager{file_path, flags, mode, compat_mode, this}
 {
   KVIKIO_NVTX_FUNC_RANGE();
   _thread_pool = get_thread_pool_per_block_device(file_path);
@@ -107,6 +135,7 @@ FileHandle::FileHandle(FileHandle&& o) noexcept
     _file_direct_off{std::exchange(o._file_direct_off, {})},
     _initialized{std::exchange(o._initialized, false)},
     _nbytes{std::exchange(o._nbytes, 0)},
+    _file_path{std::move(o._file_path)},
     _cufile_handle{std::exchange(o._cufile_handle, {})},
     _compat_mode_manager{std::move(o._compat_mode_manager)},
     _thread_pool{std::exchange(o._thread_pool, {})}
@@ -121,6 +150,7 @@ FileHandle& FileHandle::operator=(FileHandle&& o) noexcept
     _file_direct_off     = std::exchange(o._file_direct_off, {});
     _initialized         = std::exchange(o._initialized, false);
     _nbytes              = std::exchange(o._nbytes, 0);
+    _file_path           = std::move(o._file_path);
     _cufile_handle       = std::exchange(o._cufile_handle, {});
     _compat_mode_manager = std::move(o._compat_mode_manager);
     _thread_pool         = std::exchange(o._thread_pool, {});
@@ -180,9 +210,23 @@ std::size_t FileHandle::read(void* devPtr_base,
                              bool sync_default_stream)
 {
   KVIKIO_NVTX_FUNC_RANGE(size);
+  auto const start = epoch_nanos();
+  auto emit_log    = [&](std::size_t bytes_read) {
+    log_structured_read(_file_path,
+                        start,
+                        epoch_nanos(),
+                        file_offset,
+                        size,
+                        bytes_read,
+                        "local",
+                        "ok",
+                        true,
+                        active_request_id());
+    return bytes_read;
+  };
   if (get_compat_mode_manager().is_compat_mode_preferred()) {
-    return detail::posix_device_read(
-      _file_direct_off.fd(), devPtr_base, size, file_offset, devPtr_offset, _file_direct_on.fd());
+    return emit_log(detail::posix_device_read(
+      _file_direct_off.fd(), devPtr_base, size, file_offset, devPtr_offset, _file_direct_on.fd()));
   }
   if (sync_default_stream) {
     KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(nullptr));
@@ -194,7 +238,7 @@ std::size_t FileHandle::read(void* devPtr_base,
                                            convert_size2off(file_offset),
                                            convert_size2off(devPtr_offset));
   KVIKIO_CUFILE_CHECK_BYTES_DONE(ret);
-  return ret;
+  return emit_log(ret);
 }
 
 std::size_t FileHandle::write(void const* devPtr_base,
@@ -232,9 +276,11 @@ std::future<std::size_t> FileHandle::pread(void* buf,
                                            bool sync_default_stream,
                                            ThreadPool* thread_pool)
 {
+  auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
   KVIKIO_LOG_DEBUG(
-    "FileHandle::pread(buf=%p, size=%zu, file_offset=%zu, task_size=%zu, gds_threshold=%zu, "
-    "sync_default_stream=%d)",
+    "FileHandle::pread(request_id=%zu, buf=%p, size=%zu, file_offset=%zu, task_size=%zu, "
+    "gds_threshold=%zu, sync_default_stream=%d)",
+    call_idx,
     buf,
     size,
     file_offset,
@@ -249,16 +295,28 @@ std::future<std::size_t> FileHandle::pread(void* buf,
     (_thread_pool != nullptr && thread_pool == &defaults::thread_pool()) ? _thread_pool
                                                                          : thread_pool;
 
-  auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
   KVIKIO_NVTX_FUNC_RANGE(size, nvtx_color);
   if (is_host_memory(buf)) {
-    auto op = [this](void* hostPtr_base,
-                     std::size_t size,
-                     std::size_t file_offset,
-                     std::size_t hostPtr_offset) -> std::size_t {
+    auto op = [this, call_idx](void* hostPtr_base,
+                               std::size_t size,
+                               std::size_t file_offset,
+                               std::size_t hostPtr_offset) -> std::size_t {
+      scoped_request_id request_scope{call_idx};
+      auto const start = epoch_nanos();
       char* buf = static_cast<char*>(hostPtr_base) + hostPtr_offset;
-      return detail::posix_host_read<detail::PartialIO::NO>(
+      auto const bytes_read = detail::posix_host_read<detail::PartialIO::NO>(
         _file_direct_off.fd(), buf, size, file_offset, _file_direct_on.fd());
+      log_structured_read(_file_path,
+                          start,
+                          epoch_nanos(),
+                          file_offset,
+                          size,
+                          bytes_read,
+                          "local",
+                          "ok",
+                          false,
+                          call_idx);
+      return bytes_read;
     };
 
     return detail::parallel_io(
@@ -275,9 +333,21 @@ std::future<std::size_t> FileHandle::pread(void* buf,
 
   // Shortcut that circumvent the threadpool and use the POSIX backend directly.
   if (size < gds_threshold) {
+    scoped_request_id request_scope{call_idx};
+    auto const start = epoch_nanos();
     PushAndPopContext c(ctx);
     auto bytes_read = detail::posix_device_read(
       _file_direct_off.fd(), buf, size, file_offset, 0, _file_direct_on.fd());
+    log_structured_read(_file_path,
+                        start,
+                        epoch_nanos(),
+                        file_offset,
+                        size,
+                        bytes_read,
+                        "local",
+                        "ok",
+                        true,
+                        call_idx);
     // Maintain API consistency while making this trivial case synchronous.
     // The result in the future is immediately available after the call.
     return make_ready_future(bytes_read);
@@ -290,10 +360,11 @@ std::future<std::size_t> FileHandle::pread(void* buf,
   }
 
   // Regular case that use the threadpool and run the tasks in parallel
-  auto task = [this, ctx](void* devPtr_base,
-                          std::size_t size,
-                          std::size_t file_offset,
-                          std::size_t devPtr_offset) -> std::size_t {
+  auto task = [this, ctx, call_idx](void* devPtr_base,
+                                    std::size_t size,
+                                    std::size_t file_offset,
+                                    std::size_t devPtr_offset) -> std::size_t {
+    scoped_request_id request_scope{call_idx};
     PushAndPopContext c(ctx);
     return read(devPtr_base, size, file_offset, devPtr_offset, /* sync_default_stream = */ false);
   };

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -212,16 +212,16 @@ std::size_t FileHandle::read(void* devPtr_base,
   KVIKIO_NVTX_FUNC_RANGE(size);
   auto const start = epoch_nanos();
   auto emit_log    = [&](std::size_t bytes_read) {
-    log_structured_read(_file_path,
-                        start,
-                        epoch_nanos(),
-                        file_offset,
-                        size,
-                        bytes_read,
-                        "local",
-                        "ok",
-                        true,
-                        active_request_id());
+    log_physical_read(_file_path,
+                      start,
+                      epoch_nanos(),
+                      file_offset,
+                      size,
+                      bytes_read,
+                      "local",
+                      "ok",
+                      true,
+                      active_request_id());
     return bytes_read;
   };
   if (get_compat_mode_manager().is_compat_mode_preferred()) {
@@ -302,20 +302,20 @@ std::future<std::size_t> FileHandle::pread(void* buf,
                                std::size_t file_offset,
                                std::size_t hostPtr_offset) -> std::size_t {
       scoped_request_id request_scope{call_idx};
-      auto const start = epoch_nanos();
-      char* buf = static_cast<char*>(hostPtr_base) + hostPtr_offset;
+      auto const start      = epoch_nanos();
+      char* buf             = static_cast<char*>(hostPtr_base) + hostPtr_offset;
       auto const bytes_read = detail::posix_host_read<detail::PartialIO::NO>(
         _file_direct_off.fd(), buf, size, file_offset, _file_direct_on.fd());
-      log_structured_read(_file_path,
-                          start,
-                          epoch_nanos(),
-                          file_offset,
-                          size,
-                          bytes_read,
-                          "local",
-                          "ok",
-                          false,
-                          call_idx);
+      log_physical_read(_file_path,
+                        start,
+                        epoch_nanos(),
+                        file_offset,
+                        size,
+                        bytes_read,
+                        "local",
+                        "ok",
+                        false,
+                        call_idx);
       return bytes_read;
     };
 
@@ -338,16 +338,16 @@ std::future<std::size_t> FileHandle::pread(void* buf,
     PushAndPopContext c(ctx);
     auto bytes_read = detail::posix_device_read(
       _file_direct_off.fd(), buf, size, file_offset, 0, _file_direct_on.fd());
-    log_structured_read(_file_path,
-                        start,
-                        epoch_nanos(),
-                        file_offset,
-                        size,
-                        bytes_read,
-                        "local",
-                        "ok",
-                        true,
-                        call_idx);
+    log_physical_read(_file_path,
+                      start,
+                      epoch_nanos(),
+                      file_offset,
+                      size,
+                      bytes_read,
+                      "local",
+                      "ok",
+                      true,
+                      call_idx);
     // Maintain API consistency while making this trivial case synchronous.
     // The result in the future is immediately available after the call.
     return make_ready_future(bytes_read);

--- a/cpp/src/hdfs.cpp
+++ b/cpp/src/hdfs.cpp
@@ -1,8 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <chrono>
 #include <regex>
 
 #include <kvikio/detail/env.hpp>
@@ -10,6 +11,7 @@
 #include <kvikio/detail/remote_callback.hpp>
 #include <kvikio/error.hpp>
 #include <kvikio/hdfs.hpp>
+#include <kvikio/logger.hpp>
 #include <kvikio/remote_handle.hpp>
 #include <kvikio/shim/libcurl.hpp>
 
@@ -82,6 +84,9 @@ std::size_t WebHdfsEndpoint::get_file_size()
 {
   KVIKIO_NVTX_FUNC_RANGE();
 
+  auto const start = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                       std::chrono::system_clock::now().time_since_epoch())
+                       .count();
   std::stringstream ss;
   ss << _url << "?";
   if (_username.has_value()) { ss << "user.name=" << _username.value() << "&"; }
@@ -111,6 +116,10 @@ std::size_t WebHdfsEndpoint::get_file_size()
   bool found = std::regex_search(response, match_results, pattern);
   KVIKIO_EXPECT(
     found, "Regular expression search failed. Cannot extract file length from the JSON response.");
+  auto const end = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                     std::chrono::system_clock::now().time_since_epoch())
+                     .count();
+  log_http_request(_url, start, end, "GET", "ok", "metadata");
   return std::stoull(match_results[1].str());
 }
 

--- a/cpp/src/logger.cpp
+++ b/cpp/src/logger.cpp
@@ -5,16 +5,20 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
 
 #include <kvikio/logger.hpp>
 
 namespace KVIKIO_EXPORT kvikio {
 
 namespace {
-rapids_logger::level_enum get_level_from_env()
+rapids_logger::level_enum parse_level(char const* env)
 {
-  auto const* env = std::getenv("KVIKIO_LOG_LEVEL");
   if (env == nullptr) { return rapids_logger::level_enum::off; }
 
   // Convert to lowercase
@@ -32,6 +36,29 @@ rapids_logger::level_enum get_level_from_env()
 
   // Ignore invalid log value
   return rapids_logger::level_enum::off;
+}
+
+rapids_logger::level_enum get_default_level_from_env()
+{
+  return parse_level(std::getenv("KVIKIO_LOG_LEVEL"));
+}
+
+rapids_logger::level_enum get_read_level_from_env()
+{
+  auto const* env = std::getenv("KVIKIO_READ_LOG_LEVEL");
+  if (env == nullptr) { return rapids_logger::level_enum::info; }
+  return parse_level(env);
+}
+
+bool parse_bool_env(char const* env, bool default_val)
+{
+  if (env == nullptr) { return default_val; }
+  std::string val{env};
+  std::transform(
+    val.begin(), val.end(), val.begin(), [](unsigned char c) { return std::tolower(c); });
+  if (val == "1" || val == "true" || val == "on" || val == "yes") { return true; }
+  if (val == "0" || val == "false" || val == "off" || val == "no") { return false; }
+  return default_val;
 }
 
 rapids_logger::sink_ptr make_sink(rapids_logger::level_enum level)
@@ -52,12 +79,61 @@ rapids_logger::sink_ptr make_sink(rapids_logger::level_enum level)
     return std::make_shared<rapids_logger::stderr_sink_mt>();
   }
 }
+
+rapids_logger::sink_ptr make_read_sink(rapids_logger::level_enum level)
+{
+  if (level == rapids_logger::level_enum::off) {
+    return std::make_shared<rapids_logger::null_sink_mt>();
+  }
+  auto const* path = std::getenv("KVIKIO_READ_LOG_FILE");
+  if (path == nullptr || path[0] == '\0') {
+    return std::make_shared<rapids_logger::null_sink_mt>();
+  }
+  if (std::string_view{path} == "-") {
+    return std::make_shared<rapids_logger::ostream_sink_mt>(std::cout, true);
+  }
+  try {
+    bool const truncate{false};  // Append to existing file for post-hoc analysis.
+    return std::make_shared<rapids_logger::basic_file_sink_mt>(path, truncate);
+  } catch (std::exception const& e) {
+    std::cerr << "KvikIO warning: Cannot open read log file " << path << ": " << e.what()
+              << ". Structured read logging is disabled.\n";
+    return std::make_shared<rapids_logger::null_sink_mt>();
+  }
+}
+
+std::string escape_json(std::string const& input)
+{
+  std::string out;
+  out.reserve(input.size());
+  for (auto const c : input) {
+    switch (c) {
+      case '\"': out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\b': out += "\\b"; break;
+      case '\f': out += "\\f"; break;
+      case '\n': out += "\\n"; break;
+      case '\r': out += "\\r"; break;
+      case '\t': out += "\\t"; break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          std::ostringstream oss;
+          oss << "\\u" << std::hex << std::uppercase << std::setfill('0') << std::setw(4)
+              << static_cast<int>(static_cast<unsigned char>(c));
+          out += oss.str();
+        } else {
+          out += c;
+        }
+    }
+  }
+  return out;
+}
 }  // namespace
 
 rapids_logger::logger& default_logger()
 {
   static rapids_logger::logger logger_ = [] {
-    auto const level = get_level_from_env();
+    auto const level = get_default_level_from_env();
     rapids_logger::logger logger_{"kvikio", {make_sink(level)}};
     // Pattern: [thread_id][hours:minutes:seconds:microseconds][level ] message
     logger_.set_pattern("[%6t][%H:%M:%S:%f][%-6l] %v");
@@ -65,5 +141,74 @@ rapids_logger::logger& default_logger()
     return logger_;
   }();
   return logger_;
+}
+
+rapids_logger::logger& read_logger()
+{
+  static rapids_logger::logger logger_ = [] {
+    auto const level = get_read_level_from_env();
+    rapids_logger::logger logger_{"kvikio_read", {make_read_sink(level)}};
+    logger_.set_pattern("%v");
+    logger_.set_level(level);
+    return logger_;
+  }();
+  return logger_;
+}
+
+bool is_read_logging_enabled()
+{
+  auto const* path = std::getenv("KVIKIO_READ_LOG_FILE");
+  if (path == nullptr || path[0] == '\0') { return false; }
+  return read_logger().level() != rapids_logger::level_enum::off;
+}
+
+std::string sanitize_read_log_url(std::string const& url)
+{
+  auto const redact_query = parse_bool_env(std::getenv("KVIKIO_READ_LOG_REDACT_QUERY"), true);
+  if (!redact_query) { return url; }
+  auto const pos = url.find('?');
+  return pos == std::string::npos ? url : url.substr(0, pos);
+}
+
+void log_structured_read(std::string const& source,
+                         std::int64_t start,
+                         std::int64_t end,
+                         std::size_t offset,
+                         std::size_t size,
+                         std::size_t bytes_read,
+                         char const* backend,
+                         char const* status,
+                         bool is_device_buffer,
+                         std::size_t request_id)
+{
+  if (!is_read_logging_enabled()) { return; }
+  auto const sanitized = sanitize_read_log_url(source);
+  auto const thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
+  auto json            = std::string{};
+  json.reserve(sanitized.size() + 256);
+  json += "{\"source\":\"";
+  json += escape_json(sanitized);
+  json += "\",\"start\":";
+  json += std::to_string(start);
+  json += ",\"end\":";
+  json += std::to_string(end);
+  json += ",\"offset\":";
+  json += std::to_string(offset);
+  json += ",\"size\":";
+  json += std::to_string(size);
+  json += ",\"threadId\":";
+  json += std::to_string(thread_id);
+  json += ",\"bytesRead\":";
+  json += std::to_string(bytes_read);
+  json += ",\"backend\":\"";
+  json += escape_json(backend);
+  json += "\",\"status\":\"";
+  json += escape_json(status);
+  json += "\",\"isDeviceBuffer\":";
+  json += is_device_buffer ? "true" : "false";
+  json += ",\"requestId\":";
+  json += std::to_string(request_id);
+  json += "}";
+  read_logger().log(rapids_logger::level_enum::info, json);
 }
 }  // namespace KVIKIO_EXPORT kvikio

--- a/cpp/src/logger.cpp
+++ b/cpp/src/logger.cpp
@@ -1,10 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
@@ -17,6 +18,8 @@
 namespace KVIKIO_EXPORT kvikio {
 
 namespace {
+enum class LogFormat { TEXT, JSON };
+
 rapids_logger::level_enum parse_level(char const* env)
 {
   if (env == nullptr) { return rapids_logger::level_enum::off; }
@@ -43,11 +46,20 @@ rapids_logger::level_enum get_default_level_from_env()
   return parse_level(std::getenv("KVIKIO_LOG_LEVEL"));
 }
 
-rapids_logger::level_enum get_read_level_from_env()
+LogFormat get_log_format_from_env()
 {
-  auto const* env = std::getenv("KVIKIO_READ_LOG_LEVEL");
-  if (env == nullptr) { return rapids_logger::level_enum::info; }
-  return parse_level(env);
+  auto const* env = std::getenv("KVIKIO_LOG_FORMAT");
+  if (env == nullptr) { return LogFormat::TEXT; }
+  std::string value{env};
+  std::transform(
+    value.begin(), value.end(), value.begin(), [](unsigned char c) { return std::tolower(c); });
+  return value == "json" ? LogFormat::JSON : LogFormat::TEXT;
+}
+
+LogFormat log_format()
+{
+  static auto const format = get_log_format_from_env();
+  return format;
 }
 
 bool parse_bool_env(char const* env, bool default_val)
@@ -80,25 +92,24 @@ rapids_logger::sink_ptr make_sink(rapids_logger::level_enum level)
   }
 }
 
-rapids_logger::sink_ptr make_read_sink(rapids_logger::level_enum level)
+std::int64_t epoch_nanos()
 {
-  if (level == rapids_logger::level_enum::off) {
-    return std::make_shared<rapids_logger::null_sink_mt>();
-  }
-  auto const* path = std::getenv("KVIKIO_READ_LOG_FILE");
-  if (path == nullptr || path[0] == '\0') {
-    return std::make_shared<rapids_logger::null_sink_mt>();
-  }
-  if (std::string_view{path} == "-") {
-    return std::make_shared<rapids_logger::ostream_sink_mt>(std::cout, true);
-  }
-  try {
-    bool const truncate{false};  // Append to existing file for post-hoc analysis.
-    return std::make_shared<rapids_logger::basic_file_sink_mt>(path, truncate);
-  } catch (std::exception const& e) {
-    std::cerr << "KvikIO warning: Cannot open read log file " << path << ": " << e.what()
-              << ". Structured read logging is disabled.\n";
-    return std::make_shared<rapids_logger::null_sink_mt>();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+           std::chrono::system_clock::now().time_since_epoch())
+    .count();
+}
+
+char const* level_name(rapids_logger::level_enum level)
+{
+  switch (level) {
+    case rapids_logger::level_enum::trace: return "trace";
+    case rapids_logger::level_enum::debug: return "debug";
+    case rapids_logger::level_enum::info: return "info";
+    case rapids_logger::level_enum::warn: return "warn";
+    case rapids_logger::level_enum::error: return "error";
+    case rapids_logger::level_enum::critical: return "critical";
+    case rapids_logger::level_enum::off: return "off";
+    default: return "unknown";
   }
 }
 
@@ -128,6 +139,8 @@ std::string escape_json(std::string const& input)
   }
   return out;
 }
+
+std::size_t thread_id() { return std::hash<std::thread::id>{}(std::this_thread::get_id()); }
 }  // namespace
 
 rapids_logger::logger& default_logger()
@@ -135,58 +148,90 @@ rapids_logger::logger& default_logger()
   static rapids_logger::logger logger_ = [] {
     auto const level = get_default_level_from_env();
     rapids_logger::logger logger_{"kvikio", {make_sink(level)}};
-    // Pattern: [thread_id][hours:minutes:seconds:microseconds][level ] message
-    logger_.set_pattern("[%6t][%H:%M:%S:%f][%-6l] %v");
+    if (log_format() == LogFormat::JSON) {
+      // JSON serialization is handled before messages reach rapids-logger.
+      logger_.set_pattern("%v");
+    } else {
+      // Pattern: [thread_id][hours:minutes:seconds:microseconds][level ] message
+      logger_.set_pattern("[%6t][%H:%M:%S:%f][%-6l] %v");
+    }
     logger_.set_level(level);
     return logger_;
   }();
   return logger_;
 }
 
-rapids_logger::logger& read_logger()
+Logger& formatted_logger()
 {
-  static rapids_logger::logger logger_ = [] {
-    auto const level = get_read_level_from_env();
-    rapids_logger::logger logger_{"kvikio_read", {make_read_sink(level)}};
-    logger_.set_pattern("%v");
-    logger_.set_level(level);
-    return logger_;
-  }();
+  static Logger logger_;
   return logger_;
 }
 
-bool is_read_logging_enabled()
+void log_message(rapids_logger::level_enum level, std::string const& message)
 {
-  auto const* path = std::getenv("KVIKIO_READ_LOG_FILE");
-  if (path == nullptr || path[0] == '\0') { return false; }
-  return read_logger().level() != rapids_logger::level_enum::off;
+  if (log_format() == LogFormat::TEXT) {
+    default_logger().log(level, message);
+    return;
+  }
+
+  std::string json;
+  json.reserve(message.size() + 128);
+  json += "{\"event\":\"log\",\"timestamp\":";
+  json += std::to_string(epoch_nanos());
+  json += ",\"threadId\":";
+  json += std::to_string(thread_id());
+  json += ",\"level\":\"";
+  json += level_name(level);
+  json += "\",\"message\":\"";
+  json += escape_json(message);
+  json += "\"}";
+  default_logger().log(level, json);
 }
 
 std::string sanitize_read_log_url(std::string const& url)
 {
-  auto const redact_query = parse_bool_env(std::getenv("KVIKIO_READ_LOG_REDACT_QUERY"), true);
+  auto const redact_query = parse_bool_env(std::getenv("KVIKIO_LOG_REDACT_QUERY"), true);
   if (!redact_query) { return url; }
   auto const pos = url.find('?');
   return pos == std::string::npos ? url : url.substr(0, pos);
 }
 
-void log_structured_read(std::string const& source,
-                         std::int64_t start,
-                         std::int64_t end,
-                         std::size_t offset,
-                         std::size_t size,
-                         std::size_t bytes_read,
-                         char const* backend,
-                         char const* status,
-                         bool is_device_buffer,
-                         std::size_t request_id)
+void log_physical_read(std::string const& source,
+                       std::int64_t start,
+                       std::int64_t end,
+                       std::size_t offset,
+                       std::size_t size,
+                       std::size_t bytes_read,
+                       char const* backend,
+                       char const* status,
+                       bool is_device_buffer,
+                       std::size_t request_id)
 {
-  if (!is_read_logging_enabled()) { return; }
-  auto const sanitized = sanitize_read_log_url(source);
-  auto const thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
-  auto json            = std::string{};
+  if (!default_logger().should_log(rapids_logger::level_enum::trace)) { return; }
+  auto const sanitized         = sanitize_read_log_url(source);
+  auto const current_thread_id = thread_id();
+  if (log_format() == LogFormat::TEXT) {
+    default_logger().log(
+      rapids_logger::level_enum::trace,
+      "read(source=%s, start=%lld, end=%lld, offset=%zu, size=%zu, thread_id=%zu, "
+      "bytes_read=%zu, backend=%s, status=%s, is_device_buffer=%s, request_id=%zu)",
+      sanitized,
+      static_cast<long long>(start),
+      static_cast<long long>(end),
+      offset,
+      size,
+      current_thread_id,
+      bytes_read,
+      backend,
+      status,
+      is_device_buffer ? "true" : "false",
+      request_id);
+    return;
+  }
+
+  auto json = std::string{};
   json.reserve(sanitized.size() + 256);
-  json += "{\"source\":\"";
+  json += "{\"event\":\"read\",\"level\":\"trace\",\"source\":\"";
   json += escape_json(sanitized);
   json += "\",\"start\":";
   json += std::to_string(start);
@@ -197,7 +242,7 @@ void log_structured_read(std::string const& source,
   json += ",\"size\":";
   json += std::to_string(size);
   json += ",\"threadId\":";
-  json += std::to_string(thread_id);
+  json += std::to_string(current_thread_id);
   json += ",\"bytesRead\":";
   json += std::to_string(bytes_read);
   json += ",\"backend\":\"";
@@ -209,6 +254,6 @@ void log_structured_read(std::string const& source,
   json += ",\"requestId\":";
   json += std::to_string(request_id);
   json += "}";
-  read_logger().log(rapids_logger::level_enum::info, json);
+  default_logger().log(rapids_logger::level_enum::trace, json);
 }
 }  // namespace KVIKIO_EXPORT kvikio

--- a/cpp/src/logger.cpp
+++ b/cpp/src/logger.cpp
@@ -205,32 +205,53 @@ void log_physical_read(std::string const& source,
                        char const* backend,
                        char const* status,
                        bool is_device_buffer,
-                       std::size_t request_id)
+                       std::size_t request_id,
+                       char const* method)
 {
   if (!default_logger().should_log(rapids_logger::level_enum::trace)) { return; }
   auto const sanitized         = sanitize_read_log_url(source);
   auto const current_thread_id = thread_id();
   if (log_format() == LogFormat::TEXT) {
-    default_logger().log(
-      rapids_logger::level_enum::trace,
-      "read(source=%s, start=%lld, end=%lld, offset=%zu, size=%zu, thread_id=%zu, "
-      "bytes_read=%zu, backend=%s, status=%s, is_device_buffer=%s, request_id=%zu)",
-      sanitized,
-      static_cast<long long>(start),
-      static_cast<long long>(end),
-      offset,
-      size,
-      current_thread_id,
-      bytes_read,
-      backend,
-      status,
-      is_device_buffer ? "true" : "false",
-      request_id);
+    if (method == nullptr) {
+      default_logger().log(
+        rapids_logger::level_enum::trace,
+        "read(source=%s, start=%lld, end=%lld, offset=%zu, size=%zu, thread_id=%zu, "
+        "bytes_read=%zu, backend=%s, status=%s, is_device_buffer=%s, request_id=%zu)",
+        sanitized,
+        static_cast<long long>(start),
+        static_cast<long long>(end),
+        offset,
+        size,
+        current_thread_id,
+        bytes_read,
+        backend,
+        status,
+        is_device_buffer ? "true" : "false",
+        request_id);
+    } else {
+      default_logger().log(
+        rapids_logger::level_enum::trace,
+        "read(source=%s, start=%lld, end=%lld, offset=%zu, size=%zu, thread_id=%zu, "
+        "bytes_read=%zu, backend=%s, status=%s, is_device_buffer=%s, request_id=%zu, "
+        "method=%s)",
+        sanitized,
+        static_cast<long long>(start),
+        static_cast<long long>(end),
+        offset,
+        size,
+        current_thread_id,
+        bytes_read,
+        backend,
+        status,
+        is_device_buffer ? "true" : "false",
+        request_id,
+        method);
+    }
     return;
   }
 
   auto json = std::string{};
-  json.reserve(sanitized.size() + 256);
+  json.reserve(sanitized.size() + 280);
   json += "{\"event\":\"read\",\"level\":\"trace\",\"source\":\"";
   json += escape_json(sanitized);
   json += "\",\"start\":";
@@ -253,7 +274,56 @@ void log_physical_read(std::string const& source,
   json += is_device_buffer ? "true" : "false";
   json += ",\"requestId\":";
   json += std::to_string(request_id);
+  if (method != nullptr) {
+    json += ",\"method\":\"";
+    json += escape_json(method);
+    json += "\"";
+  }
   json += "}";
+  default_logger().log(rapids_logger::level_enum::trace, json);
+}
+
+void log_http_request(std::string const& source,
+                      std::int64_t start,
+                      std::int64_t end,
+                      char const* method,
+                      char const* status,
+                      char const* purpose)
+{
+  if (!default_logger().should_log(rapids_logger::level_enum::trace)) { return; }
+  auto const sanitized         = sanitize_read_log_url(source);
+  auto const current_thread_id = thread_id();
+  if (log_format() == LogFormat::TEXT) {
+    default_logger().log(
+      rapids_logger::level_enum::trace,
+      "http(source=%s, start=%lld, end=%lld, thread_id=%zu, method=%s, status=%s, purpose=%s)",
+      sanitized,
+      static_cast<long long>(start),
+      static_cast<long long>(end),
+      current_thread_id,
+      method,
+      status,
+      purpose);
+    return;
+  }
+
+  auto json = std::string{};
+  json.reserve(sanitized.size() + 192);
+  json += "{\"event\":\"http\",\"level\":\"trace\",\"source\":\"";
+  json += escape_json(sanitized);
+  json += "\",\"start\":";
+  json += std::to_string(start);
+  json += ",\"end\":";
+  json += std::to_string(end);
+  json += ",\"threadId\":";
+  json += std::to_string(current_thread_id);
+  json += ",\"method\":\"";
+  json += escape_json(method);
+  json += "\",\"status\":\"";
+  json += escape_json(status);
+  json += "\",\"purpose\":\"";
+  json += escape_json(purpose);
+  json += "\"}";
   default_logger().log(rapids_logger::level_enum::trace, json);
 }
 }  // namespace KVIKIO_EXPORT kvikio

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -176,7 +176,8 @@ namespace {
  */
 std::size_t get_file_size_using_head_impl(RemoteEndpoint& endpoint, std::string const& url)
 {
-  auto curl = create_curl_handle();
+  auto const start = detail::epoch_nanos();
+  auto curl        = create_curl_handle();
 
   endpoint.setopt(curl);
   curl.setopt(CURLOPT_NOBODY, 1L);
@@ -188,6 +189,7 @@ std::size_t get_file_size_using_head_impl(RemoteEndpoint& endpoint, std::string 
     cl >= 0,
     "cannot get size of " + endpoint.str() + ", content-length not provided by the server",
     std::runtime_error);
+  log_http_request(endpoint.str(), start, detail::epoch_nanos(), "HEAD", "ok", "metadata");
   return static_cast<std::size_t>(cl);
 }
 
@@ -642,7 +644,8 @@ std::size_t S3EndpointWithPresignedUrl::get_file_size()
 
   KVIKIO_NVTX_FUNC_RANGE();
 
-  auto curl = create_curl_handle();
+  auto const start = detail::epoch_nanos();
+  auto curl        = create_curl_handle();
   curl.setopt(CURLOPT_URL, _url.c_str());
 
   // 1-byte range, specified in the format "<start-byte>-<end-byte>""
@@ -654,6 +657,7 @@ std::size_t S3EndpointWithPresignedUrl::get_file_size()
   curl.setopt(CURLOPT_HEADERFUNCTION, callback_header);
 
   curl.perform();
+  log_http_request(_url, start, detail::epoch_nanos(), "GET", "ok", "metadata");
   return file_size;
 }
 
@@ -837,7 +841,8 @@ std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_off
                     "remote",
                     "ok",
                     !is_host_mem,
-                    detail::active_request_id());
+                    detail::active_request_id(),
+                    "GET");
   return size;
 }
 

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -786,7 +786,7 @@ std::size_t callback_device_memory(char* data, std::size_t size, std::size_t nme
 std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_offset)
 {
   KVIKIO_NVTX_FUNC_RANGE(size);
-  auto const start = epoch_nanos();
+  auto const start = detail::epoch_nanos();
 
   if (size == 0) { return 0; }
 
@@ -828,16 +828,16 @@ std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_off
     }
     throw;
   }
-  log_structured_read(_endpoint->str(),
-                      start,
-                      epoch_nanos(),
-                      file_offset,
-                      size,
-                      size,
-                      "remote",
-                      "ok",
-                      !is_host_mem,
-                      active_request_id());
+  log_physical_read(_endpoint->str(),
+                    start,
+                    detail::epoch_nanos(),
+                    file_offset,
+                    size,
+                    size,
+                    "remote",
+                    "ok",
+                    !is_host_mem,
+                    detail::active_request_id());
   return size;
 }
 
@@ -861,7 +861,7 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
                                  std::size_t size,
                                  std::size_t file_offset,
                                  std::size_t devPtr_offset) -> std::size_t {
-      scoped_request_id request_scope{call_idx};
+      detail::scoped_request_id request_scope{call_idx};
       return read(static_cast<char*>(devPtr_base) + devPtr_offset, size, file_offset);
     };
     return detail::parallel_io(

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -6,10 +6,13 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <regex>
 #include <sstream>
 #include <stdexcept>
@@ -26,6 +29,7 @@
 #include <kvikio/detail/url.hpp>
 #include <kvikio/error.hpp>
 #include <kvikio/hdfs.hpp>
+#include <kvikio/logger.hpp>
 #include <kvikio/remote_handle.hpp>
 #include <kvikio/shim/libcurl.hpp>
 #include <kvikio/utils.hpp>
@@ -33,6 +37,29 @@
 namespace kvikio {
 
 namespace detail {
+
+std::int64_t epoch_nanos()
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+           std::chrono::system_clock::now().time_since_epoch())
+    .count();
+}
+
+thread_local std::optional<std::size_t> current_request_id{};
+
+class scoped_request_id {
+ public:
+  explicit scoped_request_id(std::size_t request_id) : _prev{current_request_id}
+  {
+    current_request_id = request_id;
+  }
+  ~scoped_request_id() { current_request_id = _prev; }
+
+ private:
+  std::optional<std::size_t> _prev;
+};
+
+std::size_t active_request_id() { return current_request_id.value_or(0); }
 
 /**
  * @brief Bounce buffer in pinned host memory.
@@ -759,6 +786,7 @@ std::size_t callback_device_memory(char* data, std::size_t size, std::size_t nme
 std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_offset)
 {
   KVIKIO_NVTX_FUNC_RANGE(size);
+  auto const start = epoch_nanos();
 
   if (size == 0) { return 0; }
 
@@ -800,6 +828,16 @@ std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_off
     }
     throw;
   }
+  log_structured_read(_endpoint->str(),
+                      start,
+                      epoch_nanos(),
+                      file_offset,
+                      size,
+                      size,
+                      "remote",
+                      "ok",
+                      !is_host_mem,
+                      active_request_id());
   return size;
 }
 
@@ -819,10 +857,11 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
     KVIKIO_EXPECT(thread_pool != nullptr, "The thread pool must not be nullptr");
     auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
 
-    auto task = [this](void* devPtr_base,
-                       std::size_t size,
-                       std::size_t file_offset,
-                       std::size_t devPtr_offset) -> std::size_t {
+    auto task = [this, call_idx](void* devPtr_base,
+                                 std::size_t size,
+                                 std::size_t file_offset,
+                                 std::size_t devPtr_offset) -> std::size_t {
+      scoped_request_id request_scope{call_idx};
       return read(static_cast<char*>(devPtr_base) + devPtr_offset, size, file_offset);
     };
     return detail::parallel_io(

--- a/docs/source/runtime_settings.rst
+++ b/docs/source/runtime_settings.rst
@@ -185,7 +185,7 @@ If not set or set to any other value, logging is disabled.
 
 By default, log output are written to the standard error stream. To write log output to a file, set the environment variable ``KVIKIO_LOG_FILE`` to a file path. The file is overwritten on each process start. If the file cannot be opened (e.g. the parent directory does not exist), KvikIO falls back to the standard error with a warning. ``KVIKIO_LOG_FILE`` has no effect when logging is disabled.
 
-Set ``KVIKIO_LOG_LEVEL=DEBUG`` to log logical I/O operations. Set ``KVIKIO_LOG_LEVEL=TRACE`` to additionally log each physical read performed for those operations.
+Set ``KVIKIO_LOG_LEVEL=DEBUG`` to log logical I/O operations. Set ``KVIKIO_LOG_LEVEL=TRACE`` to additionally log each physical read performed for those operations, as well as HTTP metadata probes such as the ``HEAD`` request used to discover remote file size during open.
 
 The environment variable ``KVIKIO_LOG_FORMAT`` controls the output format:
 
@@ -200,7 +200,7 @@ For example, to capture logical operations and physical reads as JSON:
    export KVIKIO_LOG_FORMAT=JSON
    export KVIKIO_LOG_FILE=/tmp/kvikio.jsonl
 
-The environment variable ``KVIKIO_LOG_REDACT_QUERY`` controls source redaction for physical-read records:
+The environment variable ``KVIKIO_LOG_REDACT_QUERY`` controls source redaction for physical-read and HTTP records:
 
   * ``ON``/``TRUE``/``YES``/``1`` (default): remove query strings from the ``source`` field
   * ``OFF``/``FALSE``/``NO``/``0``: keep the full source string
@@ -218,11 +218,27 @@ Physical-read JSON objects have ``"event":"read"`` and the following additional 
   * ``status`` (string): operation status (currently ``"ok"`` for successful reads)
   * ``isDeviceBuffer`` (boolean): whether the destination buffer is device memory
   * ``requestId`` (integer): logical read identifier shared across related physical reads
+  * ``method`` (string, remote only): HTTP method used for the transfer (currently ``"GET"``)
 
 Example record:
 
 .. code-block:: json
 
-   {"event":"read","level":"trace","source":"s3://bucket/data.parquet","start":1747901139123456789,"end":1747901139127890123,"offset":4194304,"size":1048576,"threadId":17390204170953158183,"bytesRead":1048576,"backend":"remote","status":"ok","isDeviceBuffer":true,"requestId":42}
+   {"event":"read","level":"trace","source":"s3://bucket/data.parquet","start":1747901139123456789,"end":1747901139127890123,"offset":4194304,"size":1048576,"threadId":17390204170953158183,"bytesRead":1048576,"backend":"remote","status":"ok","isDeviceBuffer":true,"requestId":42,"method":"GET"}
+
+HTTP metadata JSON objects have ``"event":"http"`` and the following fields:
+
+  * ``source`` (string): remote URL
+  * ``start`` / ``end`` (integer): request timestamps (epoch nanoseconds)
+  * ``threadId`` (integer): per-thread identifier
+  * ``method`` (string): HTTP method (``"HEAD"`` or ``"GET"``)
+  * ``status`` (string): operation status (currently ``"ok"``)
+  * ``purpose`` (string): why the request was issued (currently ``"metadata"`` for size discovery)
+
+Example metadata record:
+
+.. code-block:: json
+
+   {"event":"http","level":"trace","source":"s3://bucket/data.parquet","start":1747901139000000000,"end":1747901139000500000,"threadId":17390204170953158183,"method":"HEAD","status":"ok","purpose":"metadata"}
 
 Other JSON log objects have ``"event":"log"`` together with ``timestamp``, ``threadId``, ``level``, and ``message`` fields.

--- a/docs/source/runtime_settings.rst
+++ b/docs/source/runtime_settings.rst
@@ -184,3 +184,50 @@ Each level includes all messages from less verbose levels.
 If not set or set to any other value, logging is disabled.
 
 By default, log output are written to the standard error stream. To write log output to a file, set the environment variable ``KVIKIO_LOG_FILE`` to a file path. The file is overwritten on each process start. If the file cannot be opened (e.g. the parent directory does not exist), KvikIO falls back to the standard error with a warning. ``KVIKIO_LOG_FILE`` has no effect when logging is disabled.
+
+Structured Read Logging ``KVIKIO_READ_LOG_FILE``, ``KVIKIO_READ_LOG_LEVEL``, ``KVIKIO_READ_LOG_REDACT_QUERY``
+---------------------------------------------------------------------------------------------------------------
+
+KvikIO can emit one structured record per read operation as newline-delimited JSON (NDJSON), suitable for post-hoc analysis.
+
+Structured read logging is disabled by default.
+
+To enable it, set ``KVIKIO_READ_LOG_FILE`` to an output file path:
+
+.. code-block:: bash
+
+   export KVIKIO_READ_LOG_FILE=/tmp/kvikio-read-log.jsonl
+
+Records are appended to this file (the file is not truncated on process start).
+
+Set ``KVIKIO_READ_LOG_FILE=-`` to emit structured records to standard output instead of a file.
+
+The environment variable ``KVIKIO_READ_LOG_LEVEL`` controls whether records are emitted:
+
+  * ``INFO`` (default when unset): emit read records
+  * ``OFF``: disable structured read logging
+
+The environment variable ``KVIKIO_READ_LOG_REDACT_QUERY`` controls source redaction:
+
+  * ``ON``/``TRUE``/``YES``/``1`` (default): remove query strings from the ``source`` field
+  * ``OFF``/``FALSE``/``NO``/``0``: keep the full source string
+
+Each emitted record has the following schema:
+
+  * ``source`` (string): file path or remote URL
+  * ``start`` (integer): read start timestamp (epoch nanoseconds)
+  * ``end`` (integer): read end timestamp (epoch nanoseconds)
+  * ``offset`` (integer): read offset in bytes
+  * ``size`` (integer): requested read size in bytes
+  * ``threadId`` (integer): per-thread identifier for the thread executing the read
+  * ``bytesRead`` (integer): number of bytes read
+  * ``backend`` (string): backend type (currently ``"local"`` or ``"remote"``)
+  * ``status`` (string): operation status (currently ``"ok"`` for successful reads)
+  * ``isDeviceBuffer`` (boolean): whether the destination buffer is device memory
+  * ``requestId`` (integer): logical read identifier shared across related physical reads
+
+Example record:
+
+.. code-block:: json
+
+   {"source":"s3://bucket/data.parquet","start":1747901139123456789,"end":1747901139127890123,"offset":4194304,"size":1048576,"threadId":17390204170953158183,"bytesRead":1048576,"backend":"remote","status":"ok","isDeviceBuffer":true,"requestId":42}

--- a/docs/source/runtime_settings.rst
+++ b/docs/source/runtime_settings.rst
@@ -165,8 +165,8 @@ When opportunistic Direct I/O is enabled for reads, unaligned prefix and suffix 
 
    export KVIKIO_AUTO_DIRECT_IO_READ_OVERREAD=1
 
-Logging ``KVIKIO_LOG_LEVEL``, ``KVIKIO_LOG_FILE``
--------------------------------------------------
+Logging ``KVIKIO_LOG_LEVEL``, ``KVIKIO_LOG_FILE``, ``KVIKIO_LOG_FORMAT``
+------------------------------------------------------------------------
 
 By default, logging is disabled and no output is produced.
 
@@ -185,34 +185,27 @@ If not set or set to any other value, logging is disabled.
 
 By default, log output are written to the standard error stream. To write log output to a file, set the environment variable ``KVIKIO_LOG_FILE`` to a file path. The file is overwritten on each process start. If the file cannot be opened (e.g. the parent directory does not exist), KvikIO falls back to the standard error with a warning. ``KVIKIO_LOG_FILE`` has no effect when logging is disabled.
 
-Structured Read Logging ``KVIKIO_READ_LOG_FILE``, ``KVIKIO_READ_LOG_LEVEL``, ``KVIKIO_READ_LOG_REDACT_QUERY``
----------------------------------------------------------------------------------------------------------------
+Set ``KVIKIO_LOG_LEVEL=DEBUG`` to log logical I/O operations. Set ``KVIKIO_LOG_LEVEL=TRACE`` to additionally log each physical read performed for those operations.
 
-KvikIO can emit one structured record per read operation as newline-delimited JSON (NDJSON), suitable for post-hoc analysis.
+The environment variable ``KVIKIO_LOG_FORMAT`` controls the output format:
 
-Structured read logging is disabled by default.
+  * ``TEXT`` (default): emit the customary human-readable log prefix and message
+  * ``JSON``: emit one JSON object per line (NDJSON), suitable for post-hoc analysis
 
-To enable it, set ``KVIKIO_READ_LOG_FILE`` to an output file path:
+For example, to capture logical operations and physical reads as JSON:
 
 .. code-block:: bash
 
-   export KVIKIO_READ_LOG_FILE=/tmp/kvikio-read-log.jsonl
+   export KVIKIO_LOG_LEVEL=TRACE
+   export KVIKIO_LOG_FORMAT=JSON
+   export KVIKIO_LOG_FILE=/tmp/kvikio.jsonl
 
-Records are appended to this file (the file is not truncated on process start).
-
-Set ``KVIKIO_READ_LOG_FILE=-`` to emit structured records to standard output instead of a file.
-
-The environment variable ``KVIKIO_READ_LOG_LEVEL`` controls whether records are emitted:
-
-  * ``INFO`` (default when unset): emit read records
-  * ``OFF``: disable structured read logging
-
-The environment variable ``KVIKIO_READ_LOG_REDACT_QUERY`` controls source redaction:
+The environment variable ``KVIKIO_LOG_REDACT_QUERY`` controls source redaction for physical-read records:
 
   * ``ON``/``TRUE``/``YES``/``1`` (default): remove query strings from the ``source`` field
   * ``OFF``/``FALSE``/``NO``/``0``: keep the full source string
 
-Each emitted record has the following schema:
+Physical-read JSON objects have ``"event":"read"`` and the following additional fields:
 
   * ``source`` (string): file path or remote URL
   * ``start`` (integer): read start timestamp (epoch nanoseconds)
@@ -230,4 +223,6 @@ Example record:
 
 .. code-block:: json
 
-   {"source":"s3://bucket/data.parquet","start":1747901139123456789,"end":1747901139127890123,"offset":4194304,"size":1048576,"threadId":17390204170953158183,"bytesRead":1048576,"backend":"remote","status":"ok","isDeviceBuffer":true,"requestId":42}
+   {"event":"read","level":"trace","source":"s3://bucket/data.parquet","start":1747901139123456789,"end":1747901139127890123,"offset":4194304,"size":1048576,"threadId":17390204170953158183,"bytesRead":1048576,"backend":"remote","status":"ok","isDeviceBuffer":true,"requestId":42}
+
+Other JSON log objects have ``"event":"log"`` together with ``timestamp``, ``threadId``, ``level``, and ``message`` fields.

--- a/python/kvikio/kvikio/_readlog_to_trace.py
+++ b/python/kvikio/kvikio/_readlog_to_trace.py
@@ -92,9 +92,11 @@ def convert(input_path: Path, output_path: Path, pid: int) -> None:
             except json.JSONDecodeError as exc:
                 raise ValueError(f"Invalid JSON on line {line_no}: {exc}") from exc
 
-            # A JSON-formatted KvikIO log can contain ordinary messages as well
-            # as physical-read events. Only reads map to duration events.
-            if record.get("event", "read") != "read":
+            # A JSON-formatted KvikIO log can contain ordinary messages,
+            # HTTP metadata probes, and physical-read events. Map both
+            # duration-bearing events into the trace.
+            event = record.get("event", "read")
+            if event not in ("read", "http"):
                 continue
 
             missing = [field for field in ("start", "end") if field not in record]
@@ -103,7 +105,30 @@ def convert(input_path: Path, output_path: Path, pid: int) -> None:
                     f"Missing required field(s) {missing!r} on line {line_no}: {text}"
                 )
 
-            trace_events.append(_to_trace_event(record, tid_map, pid))
+            if event == "http":
+                start_ns = int(record["start"])
+                end_ns = int(record["end"])
+                duration_ns = max(0, end_ns - start_ns)
+                raw_thread_id = int(record.get("threadId", 0))
+                if raw_thread_id not in tid_map:
+                    tid_map[raw_thread_id] = len(tid_map) + 1
+                tid = tid_map[raw_thread_id]
+                method = record.get("method", "HTTP")
+                purpose = record.get("purpose", "metadata")
+                trace_events.append(
+                    {
+                        "name": f"http:{method}:{purpose}",
+                        "cat": "kvikio.http",
+                        "ph": "X",
+                        "pid": pid,
+                        "tid": tid,
+                        "ts": start_ns / 1000.0,
+                        "dur": duration_ns / 1000.0,
+                        "args": record,
+                    }
+                )
+            else:
+                trace_events.append(_to_trace_event(record, tid_map, pid))
 
     # Add thread metadata entries so normalized tids are easier to interpret.
     for original_tid, trace_tid in tid_map.items():

--- a/python/kvikio/kvikio/_readlog_to_trace.py
+++ b/python/kvikio/kvikio/_readlog_to_trace.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Convert KvikIO structured read logs into Chrome/Perfetto trace JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert KvikIO NDJSON read logs into Chrome/Perfetto trace format. "
+            "Input is one JSON object per line."
+        )
+    )
+    parser.add_argument("input", type=Path, help="Path to KvikIO read log NDJSON file")
+    parser.add_argument("output", type=Path, help="Path to output trace JSON file")
+    parser.add_argument(
+        "--pid",
+        type=int,
+        default=1,
+        help="Process id to use in trace events (default: 1)",
+    )
+    return parser.parse_args()
+
+
+def _to_trace_event(record: dict[str, Any], tid_map: dict[int, int], pid: int) -> dict[str, Any]:
+    start_ns = int(record["start"])
+    end_ns = int(record["end"])
+    duration_ns = max(0, end_ns - start_ns)
+    bytes_read = int(record.get("bytesRead", 0))
+    throughput_bytes_per_second = (
+        (bytes_read * 1_000_000_000.0 / duration_ns) if duration_ns > 0 else 0.0
+    )
+
+    raw_thread_id = int(record.get("threadId", 0))
+    if raw_thread_id not in tid_map:
+        tid_map[raw_thread_id] = len(tid_map) + 1
+    tid = tid_map[raw_thread_id]
+
+    args = {
+        "source": record.get("source"),
+        "offset": record.get("offset"),
+        "size": record.get("size"),
+        "bytesRead": bytes_read,
+        "backend": record.get("backend"),
+        "status": record.get("status"),
+        "isDeviceBuffer": record.get("isDeviceBuffer"),
+        "requestId": record.get("requestId"),
+        "threadId": raw_thread_id,
+        "startNs": start_ns,
+        "endNs": end_ns,
+        "durationNs": duration_ns,
+        "throughputBytesPerSecond": throughput_bytes_per_second,
+    }
+
+    # Keep any future fields without dropping them.
+    for key, value in record.items():
+        if key not in args:
+            args[key] = value
+
+    return {
+        "name": f"read:{record.get('backend', 'unknown')}",
+        "cat": "kvikio.read",
+        "ph": "X",
+        "pid": pid,
+        "tid": tid,
+        "ts": start_ns / 1000.0,  # trace timestamps are in microseconds
+        "dur": duration_ns / 1000.0,
+        "args": args,
+    }
+
+
+def convert(input_path: Path, output_path: Path, pid: int) -> None:
+    tid_map: dict[int, int] = {}
+    trace_events: list[dict[str, Any]] = []
+
+    with input_path.open() as f:
+        for line_no, line in enumerate(f, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                record = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON on line {line_no}: {exc}") from exc
+
+            missing = [field for field in ("start", "end") if field not in record]
+            if missing:
+                raise ValueError(
+                    f"Missing required field(s) {missing!r} on line {line_no}: {text}"
+                )
+
+            trace_events.append(_to_trace_event(record, tid_map, pid))
+
+    # Add thread metadata entries so normalized tids are easier to interpret.
+    for original_tid, trace_tid in tid_map.items():
+        trace_events.append(
+            {
+                "name": "thread_name",
+                "ph": "M",
+                "pid": pid,
+                "tid": trace_tid,
+                "args": {"name": f"kvikio-thread-{original_tid}"},
+            }
+        )
+
+    output = {"displayTimeUnit": "ns", "traceEvents": trace_events}
+    with output_path.open("w") as out:
+        json.dump(output, out)
+
+
+def main() -> None:
+    args = _parse_args()
+    convert(args.input, args.output, args.pid)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/kvikio/kvikio/_readlog_to_trace.py
+++ b/python/kvikio/kvikio/_readlog_to_trace.py
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Convert KvikIO structured read logs into Chrome/Perfetto trace JSON."""
+"""Convert KvikIO JSON physical-read logs into Chrome/Perfetto trace JSON."""
 
 from __future__ import annotations
 
@@ -29,7 +29,9 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _to_trace_event(record: dict[str, Any], tid_map: dict[int, int], pid: int) -> dict[str, Any]:
+def _to_trace_event(
+    record: dict[str, Any], tid_map: dict[int, int], pid: int
+) -> dict[str, Any]:
     start_ns = int(record["start"])
     end_ns = int(record["end"])
     duration_ns = max(0, end_ns - start_ns)
@@ -89,6 +91,11 @@ def convert(input_path: Path, output_path: Path, pid: int) -> None:
                 record = json.loads(text)
             except json.JSONDecodeError as exc:
                 raise ValueError(f"Invalid JSON on line {line_no}: {exc}") from exc
+
+            # A JSON-formatted KvikIO log can contain ordinary messages as well
+            # as physical-read events. Only reads map to duration events.
+            if record.get("event", "read") != "read":
+                continue
 
             missing = [field for field in ("start", "end") if field not in record]
             if missing:


### PR DESCRIPTION
This updates our logging setup to optionally emit structured, physical traces.

There are two main sets of changes:

1. Log *physical* reads at a `TRACE` level. This takes the "logical" reads from the user's program and traces the actual reads done by kvikio, which might be smaller thanks to kvikio's read splitting
2. Optionally output to a structured ndjson format, which is easier for downstream tools to parse.

Here's an example program:

```
import kvikio
import cupy as cp


remote_file = kvikio.RemoteFile.open_s3_url("s3://rapids-tpch/tpch-rs/scale-1/nation/part.0.parquet")
buf = cp.empty(remote_file.nbytes(), dtype=cp.uint8)

size = 1024

remote_file.read(buf, size, 0)
remote_file.read(buf, remote_file.nbytes() - size, size)

print("done")
```

When run with `KVIKIO_LOG_LEVEL=TRACE KVIKIO_LOG_FORMAT=JSON KVIKIO_LOG_FILE=trace.ndjson python test_remote.py` that writes 

```
$ cat trace.ndjson 
{"event":"http","level":"trace","source":"https://rapids-tpch.s3.us-east-2.amazonaws.com/tpch-rs/scale-1/nation/part.0.parquet","start":1785255602404710891,"end":1785255602626790456,"threadId":4621804004366526777,"method":"HEAD","status":"ok","purpose":"metadata"}
{"event":"read","level":"trace","source":"https://rapids-tpch.s3.us-east-2.amazonaws.com/tpch-rs/scale-1/nation/part.0.parquet","start":1785255603191754437,"end":1785255603272868402,"offset":0,"size":1024,"threadId":6135855871742540183,"bytesRead":1024,"backend":"remote","status":"ok","isDeviceBuffer":true,"requestId":1,"method":"GET"}
{"event":"read","level":"trace","source":"https://rapids-tpch.s3.us-east-2.amazonaws.com/tpch-rs/scale-1/nation/part.0.parquet","start":1785255603273011822,"end":1785255603349365176,"offset":1024,"size":1226,"threadId":6135855871742540183,"bytesRead":1226,"backend":"remote","status":"ok","isDeviceBuffer":true,"requestId":2,"method":"GET"}
```


Closes https://github.com/rapidsai/kvikio/issues/967