### PR TITLE
enforce 'yamllint' checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,11 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [types-cachetools, zarr]
-        args: ["--config-file=python/kvikio/pyproject.toml",
-                "python/kvikio/kvikio",
-                "python/kvikio/tests",
-                "python/kvikio/examples"
-              ]
+        args:
+          - "--config-file=python/kvikio/pyproject.toml"
+          - "python/kvikio/kvikio"
+          - "python/kvikio/tests"
+          - "python/kvikio/examples"
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.8
@@ -109,6 +109,17 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        additional_dependencies: [pyyaml]
+        exclude: |
+          (?x)^(
+            conda/environments/.*|
+            [.]clang-format$|
+            [.]clang-tidy$
+          )
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.24.1
     hooks:
@@ -116,4 +127,4 @@ repos:
 
 
 default_language_version:
-      python: python3
+  python: python3

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    # allow 1 space for jinja templating in conda recipes
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets: enable
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true
+  line-length: disable
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choice of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false

--- a/conda/recipes/kvikio/recipe.yaml
+++ b/conda/recipes/kvikio/recipe.yaml
@@ -9,7 +9,7 @@ context:
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   head_rev: '${{ git.head_rev(".")[:8] }}'
   py_abi_min: ${{ env.get("RAPIDS_PY_VERSION") }}
-  py_buildstring : ${{ py_abi_min | version_to_buildstring }}
+  py_buildstring: ${{ py_abi_min | version_to_buildstring }}
   py_runtime_latest: "3.14"
 
 package:
@@ -25,7 +25,7 @@ build:
   string: cuda${{ cuda_major }}_cp${{ py_buildstring }}_abi3_${{ date_string }}_${{ head_rev }}
   prefix_detection:
     # See https://github.com/rapidsai/build-planning/issues/160
-    ignore_binary_files: True
+    ignore_binary_files: true
   script:
     content: |
       # Remove `-fdebug-prefix-map` line from CFLAGS and CXXFLAGS so the

--- a/conda/recipes/libkvikio/recipe.yaml
+++ b/conda/recipes/libkvikio/recipe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 schema_version: 1
 
@@ -100,9 +100,9 @@ outputs:
       run:
         - if: cuda_version >= "13.0"
           then:
-          - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
+            - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
           else:
-          - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="12.2.0a0") }}
+            - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="12.2.0a0") }}
         - libcufile-dev
         - rapids-logger =0.2
       ignore_run_exports:
@@ -139,9 +139,9 @@ outputs:
       run:
         - if: cuda_version >= "13.0"
           then:
-          - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
+            - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
           else:
-          - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="12.2.0a0") }}
+            - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="12.2.0a0") }}
       ignore_run_exports:
         by_name:
           - cuda-version

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -324,7 +324,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - &cupy_unsuffixed cupy>=14.0.1,!=14.1.0
+          - cupy>=14.0.1,!=14.1.0
     specific:
       - output_types: requirements
         matrices:
@@ -480,7 +480,7 @@ dependencies:
           - boto3>=1.21.21
       - output_types: pyproject
         packages:
-          - &moto_server moto[server]>=4.0.8
+          - moto[server]>=4.0.8
       - output_types: conda
         packages:
           - moto>=4.0.8


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/305

Proposes enforcing `yamllint` checks here. My primary motivation is to catch correctness issues in `dependencies.yaml` files, like duplicate entries silently resolving to the last one or indentation mistakes leading to filters being ignored.

But this also has some side benefits for consistency, which makes it a bit easier to write automation.