### PR TITLE
Do not reset kvikio thread pool when nthreads is unchanged

### DIFF
--- a/cpp/src/defaults.cpp
+++ b/cpp/src/defaults.cpp
@@ -221,6 +221,7 @@ void defaults::set_thread_pool_nthreads(unsigned int nthreads)
 {
   KVIKIO_EXPECT(
     nthreads > 0, "number of threads must be a positive integer", std::invalid_argument);
+  if (nthreads == thread_pool().get_thread_count()) { return; }
   thread_pool().reset(nthreads, make_thread_pool_init_task("kvikio"));
 }
 


### PR DESCRIPTION
When `set_thread_pool_nthreads`, we reset the thread pool which drains and detroys the previous one. We avoid that if the number of threads we are setting is unchanged.

See

```cpp
void defaults::set_thread_pool_nthreads(unsigned int nthreads)
{
  KVIKIO_EXPECT(
    nthreads > 0, "number of threads must be a positive integer", std::invalid_argument);
  thread_pool().reset(nthreads, make_thread_pool_init_task("kvikio"));
}
```

xref https://github.com/NVIDIA/cudf/pull/23634