### PR TITLE
Add an I/O observation facility

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -175,6 +175,7 @@ set(SOURCES
     "src/detail/event.cpp"
     "src/detail/io_event_barrier.cpp"
     "src/detail/nvtx.cpp"
+    "src/detail/observation_recorder.cpp"
     "src/detail/posix_io.cpp"
     "src/detail/stream.cpp"
     "src/detail/utils.cpp"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -168,6 +168,7 @@ set(SOURCES
     "src/file_utils.cpp"
     "src/logger.cpp"
     "src/mmap.cpp"
+    "src/observation.cpp"
     "src/detail/bounce_buffer_cache.cpp"
     "src/detail/concurrent_request_limiter.cpp"
     "src/detail/env.cpp"

--- a/cpp/include/kvikio/detail/multi_poll_reactor.hpp
+++ b/cpp/include/kvikio/detail/multi_poll_reactor.hpp
@@ -23,6 +23,7 @@
 #include <kvikio/detail/concurrent_request_limiter.hpp>
 #include <kvikio/detail/http_retry.hpp>
 #include <kvikio/detail/io_event_barrier.hpp>
+#include <kvikio/detail/observation_recorder.hpp>
 #include <kvikio/detail/remote_callback.hpp>
 #include <kvikio/remote_handle.hpp>
 #include <kvikio/shim/cuda.hpp>
@@ -57,6 +58,11 @@ class RemoteMultiAggregateContext {
    * @brief Per-pread event barrier for the device-buffer path.
    */
   std::shared_ptr<IoEventBarrier> io_event_barrier;
+
+  /**
+   * @brief Records the logical operation these sub-ranges make up. Null when nobody is observing.
+   */
+  std::shared_ptr<LogicalObservationRecorder> recorder;
 
   /**
    * @brief Report that one sub-range transfer succeeded.

--- a/cpp/include/kvikio/detail/observation_recorder.hpp
+++ b/cpp/include/kvikio/detail/observation_recorder.hpp
@@ -1,0 +1,166 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
+#include <kvikio/observation.hpp>
+
+namespace kvikio::detail {
+
+/**
+ * @brief Throw if the calling thread is inside a monitor callback.
+ *
+ * @exception std::runtime_error if called from inside a monitor callback.
+ */
+void expect_not_in_monitor();
+
+/**
+ * @brief The reading KvikIO timestamps observations with.
+ *
+ * @return Now, on `kvikio::Clock`.
+ */
+[[nodiscard]] inline TimePoint now() noexcept { return Clock::now(); }
+
+/**
+ * @brief Tell every monitor subscribed to its kind that an operation started.
+ *
+ * Runs the callbacks inline, on the calling thread. Does nothing if no monitor is registered, or
+ * if the calling thread is already inside a monitor callback.
+ *
+ * @param observation The operation, with `start` set and the fields known at submission.
+ */
+void notify_started(Observation const& observation) noexcept;
+
+/**
+ * @brief Tell every monitor subscribed to its kind that an operation finished.
+ *
+ * Runs the callbacks inline, on the thread that completed the operation, which need not be the one
+ * that started it. Does nothing if no monitor is registered, or if the calling thread is already
+ * inside a monitor callback.
+ *
+ * @param observation The completed operation, with `end`, `bytes_transferred` and `ok` set.
+ */
+void notify_finished(Observation const& observation) noexcept;
+
+/**
+ * @brief Whether any monitor is registered.
+ *
+ * @return True if an observation would reach somebody.
+ */
+[[nodiscard]] bool monitoring_enabled() noexcept;
+
+/**
+ * @brief Times one user-facing call and emits its logical observation.
+ *
+ * Construction takes the start timestamp. `finish()` takes the end timestamp and notifies, exactly
+ * once. There are two ways to use it, according to where the call actually ends.
+ *
+ * **Scope-bound**, for a blocking call: leave it on the stack and let the destructor finish it. An
+ * exception leaving the scope marks the observation failed, so error paths are reported without
+ * every call site having to catch.
+ *
+ * **Shared**, for a call whose work outlives the function that started it. `pread()` returns as
+ * soon as the parts are submitted, so a destructor at the end of that function would stop the clock
+ * before the work finished. Hold the recorder by `std::shared_ptr`, hand it to the tasks, and have
+ * the task that completes the work call `finish()`. The end timestamp is then the true completion
+ * time, the observation is delivered before the caller's future becomes ready, and none of it
+ * depends on the caller ever waiting. A failing part calls `finish_with_failure()`, so one failed
+ * part is one failed logical operation rather than a lost one.
+ *
+ * `finish()` is idempotent, so the destructor is a safe backstop under either use. When nobody is
+ * subscribed the whole object collapses to a single relaxed atomic load. A shared user should still
+ * test `monitoring_enabled()` first, to skip the allocation.
+ */
+class LogicalObservationRecorder {
+ public:
+  /**
+   * @brief Start recording a call.
+   *
+   * @param backend The backend.
+   * @param direction The direction.
+   * @param memory_kind The kind of memory the caller's buffer lives in.
+   * @param offset Byte offset into the file or remote object.
+   * @param size Number of bytes requested.
+   * @param http_method HTTP method for a remote call, e.g. `"GET"`. A constructor parameter rather
+   * than a setter because the monitors are told the operation has started before this constructor
+   * returns, and the record they are shown must be as complete as it can be.
+   */
+  LogicalObservationRecorder(IoBackend backend,
+                             TransferDirection direction,
+                             MemoryKind memory_kind,
+                             std::size_t offset,
+                             std::size_t size,
+                             char const* http_method = nullptr) noexcept
+    : _active{monitoring_enabled()}
+  {
+    if (_active) { begin(backend, direction, memory_kind, offset, size, http_method); }
+  }
+
+  /**
+   * @brief Backstop. An operation that was never finished did not complete, so it is recorded as
+   * a failure.
+   *
+   * Every path that completes the work calls `finish()` or `finish_with_failure()`, and this then
+   * does nothing. Reaching here un-emitted means the call threw on its way to the work, or was
+   * abandoned.
+   */
+  ~LogicalObservationRecorder() { finish_with_failure(); }
+
+  LogicalObservationRecorder(LogicalObservationRecorder const&)            = delete;
+  LogicalObservationRecorder& operator=(LogicalObservationRecorder const&) = delete;
+  LogicalObservationRecorder(LogicalObservationRecorder&&)                 = delete;
+  LogicalObservationRecorder& operator=(LogicalObservationRecorder&&)      = delete;
+
+  /**
+   * @brief The call completed. Stamp the end time and emit. Idempotent.
+   *
+   * @param bytes_transferred Number of bytes the call actually moved.
+   */
+  void finish(std::size_t bytes_transferred) noexcept
+  {
+    if (!_active) { return; }
+    if (_emitted.exchange(true, std::memory_order_relaxed)) { return; }
+    _observation.bytes_transferred = bytes_transferred;
+    emit();
+  }
+
+  /**
+   * @brief The call failed. Emit it as an error that moved nothing. Idempotent.
+   *
+   * One failing part fails the whole logical operation, so this is what a fan-out calls when any
+   * of its parts failed.
+   */
+  void finish_with_failure() noexcept
+  {
+    if (!_active) { return; }
+    if (_emitted.exchange(true, std::memory_order_relaxed)) { return; }
+    _observation.ok                = false;
+    _observation.bytes_transferred = 0;
+    emit();
+  }
+
+ private:
+  /// Fill in the record and tell the monitors. Out of line, see the constructor.
+  void begin(IoBackend backend,
+             TransferDirection direction,
+             MemoryKind memory_kind,
+             std::size_t offset,
+             std::size_t size,
+             char const* http_method) noexcept;
+
+  /// Stamp the end and notify. Called once, from `finish()` or `finish_with_failure()`.
+  void emit() noexcept;
+
+  Observation _observation{};
+  bool _active{false};
+  std::atomic<bool> _emitted{false};
+};
+
+}  // namespace kvikio::detail

--- a/cpp/include/kvikio/detail/observation_recorder.hpp
+++ b/cpp/include/kvikio/detail/observation_recorder.hpp
@@ -6,9 +6,7 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
 #include <cstddef>
-#include <cstdint>
 #include <string_view>
 
 #include <kvikio/observation.hpp>
@@ -27,7 +25,7 @@ void expect_not_in_monitor();
  *
  * @return Now, on `kvikio::Clock`.
  */
-[[nodiscard]] inline TimePoint now() noexcept { return Clock::now(); }
+[[nodiscard]] TimePoint now() noexcept;
 
 /**
  * @brief Tell every monitor subscribed to its kind that an operation started.
@@ -75,9 +73,9 @@ void notify_finished(Observation const& observation) noexcept;
  * depends on the caller ever waiting. A failing part calls `finish_with_failure()`, so one failed
  * part is one failed logical operation rather than a lost one.
  *
- * `finish()` is idempotent, so the destructor is a safe backstop under either use. When nobody is
- * subscribed the whole object collapses to a single relaxed atomic load. A shared user should still
- * test `monitoring_enabled()` first, to skip the allocation.
+ * `finish()` is idempotent, so the destructor is a safe backstop under either use. With nobody
+ * subscribed the object does nothing beyond reading the monitor count, and fills in no record. A
+ * shared user should still test `monitoring_enabled()` first, to skip the allocation.
  */
 class LogicalObservationRecorder {
  public:
@@ -100,11 +98,7 @@ class LogicalObservationRecorder {
                              std::size_t offset,
                              std::size_t size,
                              std::string_view source = {},
-                             char const* http_method = nullptr) noexcept
-    : _active{monitoring_enabled()}
-  {
-    if (_active) { begin(backend, direction, memory_kind, offset, size, source, http_method); }
-  }
+                             char const* http_method = nullptr) noexcept;
 
   /**
    * @brief Backstop. An operation that was never finished did not complete, so it is recorded as
@@ -114,7 +108,7 @@ class LogicalObservationRecorder {
    * does nothing. Reaching here un-emitted means the call threw on its way to the work, or was
    * abandoned.
    */
-  ~LogicalObservationRecorder() { finish_with_failure(); }
+  ~LogicalObservationRecorder();
 
   LogicalObservationRecorder(LogicalObservationRecorder const&)            = delete;
   LogicalObservationRecorder& operator=(LogicalObservationRecorder const&) = delete;
@@ -126,13 +120,7 @@ class LogicalObservationRecorder {
    *
    * @param bytes_transferred Number of bytes the call actually moved.
    */
-  void finish(std::size_t bytes_transferred) noexcept
-  {
-    if (!_active) { return; }
-    if (_emitted.exchange(true, std::memory_order_relaxed)) { return; }
-    _observation.bytes_transferred = bytes_transferred;
-    emit();
-  }
+  void finish(std::size_t bytes_transferred) noexcept;
 
   /**
    * @brief The call failed. Emit it as an error that moved nothing. Idempotent.
@@ -140,14 +128,7 @@ class LogicalObservationRecorder {
    * One failing part fails the whole logical operation, so this is what a fan-out calls when any
    * of its parts failed.
    */
-  void finish_with_failure() noexcept
-  {
-    if (!_active) { return; }
-    if (_emitted.exchange(true, std::memory_order_relaxed)) { return; }
-    _observation.ok                = false;
-    _observation.bytes_transferred = 0;
-    emit();
-  }
+  void finish_with_failure() noexcept;
 
  private:
   /// Fill in the record and tell the monitors. Out of line, see the constructor.

--- a/cpp/include/kvikio/detail/observation_recorder.hpp
+++ b/cpp/include/kvikio/detail/observation_recorder.hpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <string_view>
 
 #include <kvikio/observation.hpp>
 
@@ -88,8 +89,9 @@ class LogicalObservationRecorder {
    * @param memory_kind The kind of memory the caller's buffer lives in.
    * @param offset Byte offset into the file or remote object.
    * @param size Number of bytes requested.
-   * @param http_method HTTP method for a remote call, e.g. `"GET"`. A constructor parameter rather
-   * than a setter because the monitors are told the operation has started before this constructor
+   * @param source The file path or URL, which must outlive the operation.
+   * @param http_method HTTP method for a remote call, e.g. `"GET"`. Constructor parameters rather
+   * than setters because the monitors are told the operation has started before this constructor
    * returns, and the record they are shown must be as complete as it can be.
    */
   LogicalObservationRecorder(IoBackend backend,
@@ -97,10 +99,11 @@ class LogicalObservationRecorder {
                              MemoryKind memory_kind,
                              std::size_t offset,
                              std::size_t size,
+                             std::string_view source = {},
                              char const* http_method = nullptr) noexcept
     : _active{monitoring_enabled()}
   {
-    if (_active) { begin(backend, direction, memory_kind, offset, size, http_method); }
+    if (_active) { begin(backend, direction, memory_kind, offset, size, source, http_method); }
   }
 
   /**
@@ -153,6 +156,7 @@ class LogicalObservationRecorder {
              MemoryKind memory_kind,
              std::size_t offset,
              std::size_t size,
+             std::string_view source,
              char const* http_method) noexcept;
 
   /// Stamp the end and notify. Called once, from `finish()` or `finish_with_failure()`.

--- a/cpp/include/kvikio/detail/parallel_operation.hpp
+++ b/cpp/include/kvikio/detail/parallel_operation.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -15,6 +15,7 @@
 
 #include <kvikio/defaults.hpp>
 #include <kvikio/detail/nvtx.hpp>
+#include <kvikio/detail/observation_recorder.hpp>
 #include <kvikio/detail/utils.hpp>
 #include <kvikio/error.hpp>
 #include <kvikio/threadpool_wrapper.hpp>
@@ -94,7 +95,7 @@ std::future<std::size_t> submit_task(F op,
                                       decltype(size),
                                       decltype(file_offset),
                                       decltype(devPtr_offset)>);
-
+  expect_not_in_monitor();
   return opts.thread_pool->submit_task([=] {
     KVIKIO_NVTX_SCOPED_RANGE("task", opts.nvtx_payload, opts.nvtx_color);
     return op(buf, size, file_offset, devPtr_offset);
@@ -112,6 +113,7 @@ template <typename F>
 std::future<std::size_t> submit_move_only_task(F op_move_only, TaskOptions opts = {})
 {
   static_assert(std::is_invocable_r_v<std::size_t, F>);
+  expect_not_in_monitor();
   auto op_copyable = make_copyable_lambda(std::move(op_move_only));
   return opts.thread_pool->submit_task([=] {
     KVIKIO_NVTX_SCOPED_RANGE("task", opts.nvtx_payload, opts.nvtx_color);
@@ -134,6 +136,9 @@ struct ParallelIoOptions {
   /// Size of the first task in bytes. If set, the first task uses this size instead of `task_size`,
   /// allowing callers to align subsequent tasks to page boundaries.
   std::optional<std::size_t> first_task_size = std::nullopt;
+  /// Records the logical operation these tasks make up. Null when nobody is observing. The task
+  /// that completes the work finishes it, so the observation lands before the caller's future.
+  std::shared_ptr<LogicalObservationRecorder> recorder = nullptr;
 
   TaskOptions to_task_options() const noexcept
   {
@@ -176,7 +181,22 @@ std::future<std::size_t> parallel_io(F op,
 
   // Single-task guard
   if (task_size >= size || get_page_size() >= size) {
-    return detail::submit_task(op, buf, size, file_offset, devPtr_offset, opts.to_task_options());
+    if (!opts.recorder) {
+      return detail::submit_task(op, buf, size, file_offset, devPtr_offset, opts.to_task_options());
+    }
+    auto single_task = [op, rec = opts.recorder](
+                         T b, std::size_t s, std::size_t fo, std::size_t dpo) -> std::size_t {
+      try {
+        auto const nbytes = op(b, s, fo, dpo);
+        rec->finish(nbytes);
+        return nbytes;
+      } catch (...) {
+        rec->finish_with_failure();
+        throw;
+      }
+    };
+    return detail::submit_task(
+      single_task, buf, size, file_offset, devPtr_offset, opts.to_task_options());
   }
 
   std::vector<std::future<std::size_t>> tasks;
@@ -202,12 +222,30 @@ std::future<std::size_t> parallel_io(F op,
 
   // 3) Submit the last task, which consists of performing the last I/O and waiting the previous
   // tasks.
-  auto last_task = [=, tasks = std::move(tasks)]() mutable -> std::size_t {
-    auto ret = op(buf, size, file_offset, devPtr_offset);
-    for (auto& task : tasks) {
-      ret += task.get();
+  auto last_task = [=, tasks = std::move(tasks), rec = opts.recorder]() mutable -> std::size_t {
+    // This task both performs the final part and waits for the others, so it is where the logical
+    // operation actually completes, and therefore where its observation is emitted.
+    try {
+      auto ret = op(buf, size, file_offset, devPtr_offset);
+      for (auto& task : tasks) {
+        ret += task.get();
+      }
+      if (rec) { rec->finish(ret); }
+      return ret;
+    } catch (...) {
+      // The other tasks may still be running. Wait for them, so the operation really is over both
+      // when the exception reaches the caller and when the failure is reported.
+      for (auto& task : tasks) {
+        if (!task.valid()) { continue; }
+        try {
+          task.get();
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+          // The first failure is the one that is propagated.
+        }
+      }
+      if (rec) { rec->finish_with_failure(); }
+      throw;
     }
-    return ret;
   };
   return detail::submit_move_only_task(std::move(last_task), opts.to_task_options());
 }

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -39,6 +39,7 @@ class FileHandle {
   mutable std::size_t _nbytes{0};  // The size of the underlying file, zero means unknown.
   CUFileHandleWrapper _cufile_handle{};
   CompatModeManager _compat_mode_manager;
+  std::string _file_path;  // Reported to the monitors, see `Observation::source`.
   friend class CompatModeManager;
 
   /// The read itself, without what the public `read()` wraps around it.

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdlib>
 
@@ -36,7 +37,8 @@ class FileHandle {
   FileWrapper _file_direct_on{};
   FileWrapper _file_direct_off{};
   bool _initialized{false};
-  mutable std::size_t _nbytes{0};  // The size of the underlying file, zero means unknown.
+  // The size of the underlying file, zero meaning unknown.
+  mutable std::atomic<std::size_t> _nbytes{0};
   CUFileHandleWrapper _cufile_handle{};
   CompatModeManager _compat_mode_manager;
   std::string _file_path;  // Reported to the monitors, see `Observation::source`.

--- a/cpp/include/kvikio/file_handle.hpp
+++ b/cpp/include/kvikio/file_handle.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -40,6 +40,20 @@ class FileHandle {
   CUFileHandleWrapper _cufile_handle{};
   CompatModeManager _compat_mode_manager;
   friend class CompatModeManager;
+
+  /// The read itself, without what the public `read()` wraps around it.
+  std::size_t read_impl(void* devPtr_base,
+                        std::size_t size,
+                        std::size_t file_offset,
+                        std::size_t devPtr_offset,
+                        bool sync_default_stream);
+
+  /// The write itself, without what the public `write()` wraps around it.
+  std::size_t write_impl(void const* devPtr_base,
+                         std::size_t size,
+                         std::size_t file_offset,
+                         std::size_t devPtr_offset,
+                         bool sync_default_stream);
   ThreadPool* _thread_pool{};
 
  public:

--- a/cpp/include/kvikio/mmap.hpp
+++ b/cpp/include/kvikio/mmap.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -38,6 +38,7 @@ class MmapHandle {
   int _map_protection{};
   int _map_flags{};
   FileWrapper _file_wrapper{};
+  std::string _file_path;  // Reported to the monitors, see `Observation::source`.
 
   /**
    * @brief Validate and adjust the read arguments.

--- a/cpp/include/kvikio/observation.hpp
+++ b/cpp/include/kvikio/observation.hpp
@@ -33,41 +33,41 @@ using Duration = std::chrono::nanoseconds;
  * @brief The I/O backend that carried out an operation.
  */
 enum class IoBackend : std::uint8_t {
-  Posix = 0,   ///< POSIX `pread`/`pwrite`, including the compatibility-mode path.
-  Gds,         ///< cuFile / GPUDirect Storage.
-  Mmap,        ///< Memory-mapped file access.
-  RemoteHttp,  ///< Remote I/O over HTTP(S), including S3.
-  RemoteHdfs   ///< Remote I/O over WebHDFS.
+  POSIX = 0,    ///< POSIX `pread`/`pwrite`, including the compatibility-mode path.
+  GDS,          ///< cuFile / GPUDirect Storage.
+  MMAP,         ///< Memory-mapped file access.
+  REMOTE_HTTP,  ///< Remote I/O over HTTP(S), including S3.
+  REMOTE_HDFS   ///< Remote I/O over WebHDFS.
 };
 
 /**
  * @brief The direction of an I/O operation.
  */
 enum class TransferDirection : std::uint8_t {
-  Read = 0,  ///< Data moves from the file or endpoint into the buffer.
-  Write      ///< Data moves from the buffer into the file or endpoint.
+  READ = 0,  ///< Data moves from the file or endpoint into the buffer.
+  WRITE      ///< Data moves from the buffer into the file or endpoint.
 };
 
 /**
  * @brief The kind of memory the caller's buffer lives in.
  */
 enum class MemoryKind : std::uint8_t {
-  Host = 0,  ///< Host (CPU) memory.
-  Device     ///< Device (GPU) memory.
+  HOST = 0,  ///< Host (CPU) memory.
+  DEVICE     ///< Device (GPU) memory.
 };
 
 /**
  * @brief What layer an observation describes.
  */
 enum class ObservationKind : std::uint8_t {
-  Logical = 0  ///< One user-facing call, such as one `FileHandle::pread()`.
+  LOGICAL = 0  ///< One user-facing call, such as one `FileHandle::pread()`.
 };
 
 /**
  * @brief Human-readable name of an I/O backend.
  *
  * @param backend The backend.
- * @return A static string such as `"Posix"`.
+ * @return A static string such as `"POSIX"`.
  */
 [[nodiscard]] std::string_view to_string(IoBackend backend) noexcept;
 
@@ -75,7 +75,7 @@ enum class ObservationKind : std::uint8_t {
  * @brief Human-readable name of a transfer direction.
  *
  * @param direction The direction.
- * @return A static string such as `"Read"`.
+ * @return A static string such as `"READ"`.
  */
 [[nodiscard]] std::string_view to_string(TransferDirection direction) noexcept;
 
@@ -83,7 +83,7 @@ enum class ObservationKind : std::uint8_t {
  * @brief Human-readable name of a memory kind.
  *
  * @param memory_kind The memory kind.
- * @return A static string such as `"Device"`.
+ * @return A static string such as `"DEVICE"`.
  */
 [[nodiscard]] std::string_view to_string(MemoryKind memory_kind) noexcept;
 
@@ -91,7 +91,7 @@ enum class ObservationKind : std::uint8_t {
  * @brief Human-readable name of an observation kind.
  *
  * @param kind The kind.
- * @return A static string such as `"Logical"`.
+ * @return A static string such as `"LOGICAL"`.
  */
 [[nodiscard]] std::string_view to_string(ObservationKind kind) noexcept;
 
@@ -118,14 +118,14 @@ struct Observation {
   /// HTTP method, e.g. `"GET"`. Null for local I/O.
   char const* http_method{nullptr};
 
-  /// What layer this describes. Always `ObservationKind::Logical` today.
-  ObservationKind kind{ObservationKind::Logical};
+  /// What layer this describes. Always `ObservationKind::LOGICAL` today.
+  ObservationKind kind{ObservationKind::LOGICAL};
   /// The backend that carried out the operation.
-  IoBackend backend{IoBackend::Posix};
+  IoBackend backend{IoBackend::POSIX};
   /// The direction of the operation.
-  TransferDirection direction{TransferDirection::Read};
+  TransferDirection direction{TransferDirection::READ};
   /// The kind of memory the caller's buffer lives in.
-  MemoryKind memory_kind{MemoryKind::Host};
+  MemoryKind memory_kind{MemoryKind::HOST};
   /// False if the operation failed.
   bool ok{true};
 
@@ -246,7 +246,7 @@ class Monitor {
  * @exception std::runtime_error if called from inside a monitor callback.
  */
 [[nodiscard]] std::uint64_t register_monitor(Monitor* monitor,
-                                             ObservationKind kind = ObservationKind::Logical);
+                                             ObservationKind kind = ObservationKind::LOGICAL);
 
 /**
  * @brief Unregister a monitor.

--- a/cpp/include/kvikio/observation.hpp
+++ b/cpp/include/kvikio/observation.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
+#include <type_traits>
 
 #include <kvikio/shim/utils.hpp>
 
@@ -64,6 +65,11 @@ struct ClockAnchor {
    */
   [[nodiscard]] std::chrono::system_clock::time_point to_wall_clock(TimePoint time) const noexcept
   {
+    // Chrono is not noexcept because a duration's representation may have throwing arithmetic, and
+    // duration_cast is specified in terms of the same operations. Ours are integers, so nothing
+    // here can throw.
+    static_assert(std::is_integral_v<TimePoint::rep>);
+    static_assert(std::is_integral_v<std::chrono::system_clock::rep>);
     return wall + std::chrono::duration_cast<std::chrono::system_clock::duration>(time - steady);
   }
 };

--- a/cpp/include/kvikio/observation.hpp
+++ b/cpp/include/kvikio/observation.hpp
@@ -41,6 +41,11 @@ enum class IoBackend : std::uint8_t {
 };
 
 /**
+ * @brief Number of `IoBackend` values.
+ */
+constexpr std::size_t num_io_backends = static_cast<std::size_t>(IoBackend::REMOTE_HDFS) + 1;
+
+/**
  * @brief The direction of an I/O operation.
  */
 enum class TransferDirection : std::uint8_t {

--- a/cpp/include/kvikio/observation.hpp
+++ b/cpp/include/kvikio/observation.hpp
@@ -162,6 +162,10 @@ struct Observation {
   /// HTTP method, e.g. `"GET"`. Null for local I/O.
   char const* http_method{nullptr};
 
+  /// The file path or URL the operation went to. Owned by the handle, and valid only for the
+  /// duration of the callback. Copy what is needed later.
+  std::string_view source{};
+
   /// What layer this describes. Always `ObservationKind::LOGICAL` today.
   ObservationKind kind{ObservationKind::LOGICAL};
   /// The backend that carried out the operation.

--- a/cpp/include/kvikio/observation.hpp
+++ b/cpp/include/kvikio/observation.hpp
@@ -1,0 +1,262 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+#include <kvikio/shim/utils.hpp>
+
+namespace KVIKIO_EXPORT kvikio {
+
+/**
+ * @brief The clock KvikIO timestamps observations with.
+ */
+using Clock = std::chrono::steady_clock;
+
+/**
+ * @brief A point in time on `Clock`.
+ */
+using TimePoint = Clock::time_point;
+
+/**
+ * @brief A length of time, in nanoseconds.
+ */
+using Duration = std::chrono::nanoseconds;
+
+/**
+ * @brief The I/O backend that carried out an operation.
+ */
+enum class IoBackend : std::uint8_t {
+  Posix = 0,   ///< POSIX `pread`/`pwrite`, including the compatibility-mode path.
+  Gds,         ///< cuFile / GPUDirect Storage.
+  Mmap,        ///< Memory-mapped file access.
+  RemoteHttp,  ///< Remote I/O over HTTP(S), including S3.
+  RemoteHdfs   ///< Remote I/O over WebHDFS.
+};
+
+/**
+ * @brief The direction of an I/O operation.
+ */
+enum class TransferDirection : std::uint8_t {
+  Read = 0,  ///< Data moves from the file or endpoint into the buffer.
+  Write      ///< Data moves from the buffer into the file or endpoint.
+};
+
+/**
+ * @brief The kind of memory the caller's buffer lives in.
+ */
+enum class MemoryKind : std::uint8_t {
+  Host = 0,  ///< Host (CPU) memory.
+  Device     ///< Device (GPU) memory.
+};
+
+/**
+ * @brief What layer an observation describes.
+ */
+enum class ObservationKind : std::uint8_t {
+  Logical = 0  ///< One user-facing call, such as one `FileHandle::pread()`.
+};
+
+/**
+ * @brief Human-readable name of an I/O backend.
+ *
+ * @param backend The backend.
+ * @return A static string such as `"Posix"`.
+ */
+[[nodiscard]] std::string_view to_string(IoBackend backend) noexcept;
+
+/**
+ * @brief Human-readable name of a transfer direction.
+ *
+ * @param direction The direction.
+ * @return A static string such as `"Read"`.
+ */
+[[nodiscard]] std::string_view to_string(TransferDirection direction) noexcept;
+
+/**
+ * @brief Human-readable name of a memory kind.
+ *
+ * @param memory_kind The memory kind.
+ * @return A static string such as `"Device"`.
+ */
+[[nodiscard]] std::string_view to_string(MemoryKind memory_kind) noexcept;
+
+/**
+ * @brief Human-readable name of an observation kind.
+ *
+ * @param kind The kind.
+ * @return A static string such as `"Logical"`.
+ */
+[[nodiscard]] std::string_view to_string(ObservationKind kind) noexcept;
+
+/**
+ * @brief One I/O operation, as observed by KvikIO.
+ *
+ * `[start, end)` covers the operation from issue to completion.
+ */
+struct Observation {
+  /// What layer this describes. Always `ObservationKind::Logical` today.
+  ObservationKind kind{ObservationKind::Logical};
+
+  /// When the operation started.
+  TimePoint start{};
+  /// When the operation finished.
+  TimePoint end{};
+  /// Byte offset into the file or remote object.
+  std::size_t offset{};
+  /// Number of bytes requested.
+  std::size_t size{};
+  /// Number of bytes actually transferred. Differs from `size` on a short read, and is zero for an
+  /// operation that failed.
+  std::size_t bytes_transferred{};
+
+  /// The backend that carried out the operation.
+  IoBackend backend{IoBackend::Posix};
+  /// The direction of the operation.
+  TransferDirection direction{TransferDirection::Read};
+  /// The kind of memory the caller's buffer lives in.
+  MemoryKind memory_kind{MemoryKind::Host};
+  /// False if the operation failed.
+  bool ok{true};
+  /// Identifies this operation, uniquely within the process.
+  std::uint64_t id{};
+
+  /// HTTP method, e.g. `"GET"`. Null for local I/O.
+  char const* http_method{nullptr};
+
+  /**
+   * @brief How long the operation took.
+   *
+   * @return `end - start`, or zero if the span is degenerate.
+   */
+  [[nodiscard]] Duration duration() const noexcept
+  {
+    return end > start ? end - start : Duration::zero();
+  }
+
+  /**
+   * @brief Throughput of this single operation.
+   *
+   * @warning Averaging this across operations does *not* give the throughput of the program. For
+   * that, divide total bytes by a span of elapsed time.
+   *
+   * @return Bytes per second, or zero if the operation had no measurable duration.
+   */
+  [[nodiscard]] double bytes_per_sec() const noexcept
+  {
+    auto const seconds = std::chrono::duration<double>{duration()}.count();
+    return seconds > 0.0 ? static_cast<double>(bytes_transferred) / seconds : 0.0;
+  }
+};
+
+/**
+ * @brief Watches operations, from the moment they start until they finish.
+ *
+ * Derive from this and register it to be told what KvikIO is doing. Two notifications per
+ * operation: `on_start()` when it begins, carrying the record as it stands at submission, and
+ * `on_finish()` when it ends, carrying the finished record.
+ *
+ * A monitor is told about user-facing calls: one `FileHandle::pread()` is one operation however
+ * many reads KvikIO issued underneath.
+ *
+ * @note Not everything is reported:
+ * - The cuFile asynchronous API (`FileHandle::read_async()`, `FileHandle::write_async()`) on a
+ *   system with working GDS reports nothing. In compatibility mode those calls fall back to
+ *   `read()`/`write()` and *are* reported, so the same program is seen differently depending on
+ *   whether GDS is available.
+ * - The batch API (`BatchHandle`) reports nothing.
+ * - `RemoteHandle::pread()` into device memory finishes when the last pinned-to-device copy is
+ *   *issued* rather than completed, so its span is slightly short. It is never too long.
+ *
+ * @code
+ * // Reports how many KvikIO operations are in flight at any moment.
+ * class QueueDepth : public kvikio::Monitor {
+ *  public:
+ *   [[nodiscard]] int depth() const noexcept { return _in_flight.load(); }
+ *
+ *  private:
+ *   void on_start(kvikio::Observation const&) noexcept override { ++_in_flight; }
+ *   void on_finish(kvikio::Observation const&) noexcept override { --_in_flight; }
+ *
+ *   std::atomic<int> _in_flight{0};
+ * };
+ *
+ * QueueDepth gauge;
+ * auto const id = kvikio::register_monitor(&gauge);
+ * ...
+ * kvikio::unregister_monitor(id);  // Waits, so `gauge` may now be destroyed.
+ * @endcode
+ *
+ * Every operation that reports a start reports exactly one finish, on whichever thread does the
+ * work.
+ *
+ * @warning A monitor runs inline with the I/O, on the thread performing it, on both the submission
+ * and the completion path. Keep it light, make it thread-safe, and do not call back into KvikIO,
+ * which throws `std::runtime_error`. Neither callback may throw.
+ */
+class Monitor {
+ public:
+  Monitor()                          = default;
+  virtual ~Monitor()                 = default;
+  Monitor(Monitor const&)            = delete;
+  Monitor& operator=(Monitor const&) = delete;
+
+  /**
+   * @brief An operation has started.
+   *
+   * The observation is not finished: `end` and `bytes_transferred` are zero, and `ok` is `true`
+   * only because nothing has failed yet. All three are set by the time `on_finish()` is called.
+   *
+   * @warning Runs inline with the I/O, on the thread performing it. Keep it light, make it
+   * thread-safe, and do not call back into KvikIO, which throws `std::runtime_error`.
+   *
+   * @param observation The operation, as far as it is known. The reference is valid only for the
+   * duration of this call. Copy what is needed later.
+   */
+  virtual void on_start(Observation const& observation) noexcept = 0;
+
+  /**
+   * @brief An operation has completed.
+   *
+   * A monitor registered after `observation.start` never saw the matching `on_start()`, and
+   * should ignore such an operation.
+   *
+   * @warning Runs inline with the I/O, on the thread performing it. Keep it light, make it
+   * thread-safe, and do not call back into KvikIO, which throws `std::runtime_error`.
+   *
+   * @param observation The completed operation. The reference is valid only for the duration of
+   * this call. Copy what is needed later.
+   */
+  virtual void on_finish(Observation const& observation) noexcept = 0;
+};
+
+/**
+ * @brief Register a monitor, which begins receiving both notifications.
+ *
+ * @param monitor The monitor. Not owned, and must outlive the registration.
+ * @param kind Which observations it watches.
+ * @return An id for `unregister_monitor()`.
+ *
+ * @exception std::invalid_argument if `monitor` is null.
+ * @exception std::runtime_error if called from inside a monitor callback.
+ */
+[[nodiscard]] std::uint64_t register_monitor(Monitor* monitor,
+                                             ObservationKind kind = ObservationKind::Logical);
+
+/**
+ * @brief Unregister a monitor.
+ *
+ * Blocks until no thread is inside either callback, so the monitor may be destroyed once this
+ * returns.
+ *
+ * @param id The id from `register_monitor()`.
+ */
+void unregister_monitor(std::uint64_t id);
+
+}  // namespace KVIKIO_EXPORT kvikio

--- a/cpp/include/kvikio/observation.hpp
+++ b/cpp/include/kvikio/observation.hpp
@@ -30,6 +30,45 @@ using TimePoint = Clock::time_point;
 using Duration = std::chrono::nanoseconds;
 
 /**
+ * @brief A reading of `Clock` and of the wall clock, taken together.
+ *
+ * `Clock` cannot be compared with anything outside this process, so an anchor is what relates an
+ * observation to a log line, to another process, or to a profiler trace.
+ */
+struct ClockAnchor {
+  /// The reading of `Clock`.
+  TimePoint steady{};
+  /// The reading of the wall clock, taken at the same moment.
+  std::chrono::system_clock::time_point wall{};
+
+  /**
+   * @brief Read both clocks, one immediately after the other.
+   *
+   * @warning The readings are tens of nanoseconds apart, since the two clocks cannot be read at
+   * once, so the anchor's offset is out by that much. Well below what a wall clock is worth
+   * anyway, NTP agreeing between machines to microseconds at best.
+   *
+   * @return The pair of readings.
+   */
+  [[nodiscard]] static ClockAnchor now() noexcept;
+
+  /**
+   * @brief Convert a point on `Clock` to wall-clock time.
+   *
+   * @warning The wall clock can be stepped or slewed by NTP or an operator, so an
+   * old anchor may no longer be valid. Take an anchor at each end of a long run
+   * and compare them to detect an in-flight adjustment to the system time.
+   *
+   * @param time The point to convert.
+   * @return The corresponding wall-clock time.
+   */
+  [[nodiscard]] std::chrono::system_clock::time_point to_wall_clock(TimePoint time) const noexcept
+  {
+    return wall + std::chrono::duration_cast<std::chrono::system_clock::duration>(time - steady);
+  }
+};
+
+/**
  * @brief The I/O backend that carried out an operation.
  */
 enum class IoBackend : std::uint8_t {

--- a/cpp/include/kvikio/observation.hpp
+++ b/cpp/include/kvikio/observation.hpp
@@ -101,9 +101,6 @@ enum class ObservationKind : std::uint8_t {
  * `[start, end)` covers the operation from issue to completion.
  */
 struct Observation {
-  /// What layer this describes. Always `ObservationKind::Logical` today.
-  ObservationKind kind{ObservationKind::Logical};
-
   /// When the operation started.
   TimePoint start{};
   /// When the operation finished.
@@ -115,7 +112,14 @@ struct Observation {
   /// Number of bytes actually transferred. Differs from `size` on a short read, and is zero for an
   /// operation that failed.
   std::size_t bytes_transferred{};
+  /// Identifies this operation, uniquely within the process.
+  std::uint64_t id{};
 
+  /// HTTP method, e.g. `"GET"`. Null for local I/O.
+  char const* http_method{nullptr};
+
+  /// What layer this describes. Always `ObservationKind::Logical` today.
+  ObservationKind kind{ObservationKind::Logical};
   /// The backend that carried out the operation.
   IoBackend backend{IoBackend::Posix};
   /// The direction of the operation.
@@ -124,11 +128,6 @@ struct Observation {
   MemoryKind memory_kind{MemoryKind::Host};
   /// False if the operation failed.
   bool ok{true};
-  /// Identifies this operation, uniquely within the process.
-  std::uint64_t id{};
-
-  /// HTTP method, e.g. `"GET"`. Null for local I/O.
-  char const* http_method{nullptr};
 
   /**
    * @brief How long the operation took.

--- a/cpp/include/kvikio/remote_handle.hpp
+++ b/cpp/include/kvikio/remote_handle.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -528,6 +528,20 @@ class RemoteHandle {
                                  std::size_t file_offset = 0,
                                  std::size_t task_size   = defaults::task_size(),
                                  ThreadPool* thread_pool = &defaults::thread_pool());
+
+ private:
+  /**
+   * @brief Throw if `[file_offset, file_offset + size)` reaches past the end of the remote object.
+   *
+   * @param size Number of bytes to read.
+   * @param file_offset File offset in bytes.
+   *
+   * @exception std::invalid_argument if the range is out of bounds.
+   */
+  void expect_read_in_bounds(std::size_t size, std::size_t file_offset) const;
+
+  /// The read itself, without what the public `read()` wraps around it.
+  std::size_t read_impl(void* buf, std::size_t size, std::size_t file_offset, bool is_host_mem);
 };
 
 }  // namespace kvikio

--- a/cpp/include/kvikio/remote_handle.hpp
+++ b/cpp/include/kvikio/remote_handle.hpp
@@ -352,6 +352,7 @@ class RemoteHandle {
  private:
   std::unique_ptr<RemoteEndpoint> _endpoint;
   std::size_t _nbytes;
+  std::string _source;  // Reported to the monitors, see `Observation::source`.
 
  public:
   /**

--- a/cpp/src/detail/multi_poll_reactor.cpp
+++ b/cpp/src/detail/multi_poll_reactor.cpp
@@ -103,6 +103,14 @@ void RemoteMultiAggregateContext::on_subrange_complete(std::size_t bytes)
   // it is written and read under _exception_mutex.
   if (_subranges_left.fetch_sub(1, std::memory_order_acq_rel) == 1) {
     std::lock_guard<std::mutex> const lock(_exception_mutex);
+    if (recorder) {
+      if (_first_exception) {
+        recorder->finish_with_failure();
+      } else {
+        // Before the promise, so the observation has landed by the time the caller resumes.
+        recorder->finish(_total_bytes.load(std::memory_order_relaxed));
+      }
+    }
     if (_first_exception) {
       _promise.set_exception(_first_exception);
     } else {
@@ -120,6 +128,7 @@ void RemoteMultiAggregateContext::on_subrange_failed(std::exception_ptr eptr)
   // Last thread to decrement to zero fulfills the promise.
   if (_subranges_left.fetch_sub(1, std::memory_order_acq_rel) == 1) {
     std::lock_guard<std::mutex> const lock(_exception_mutex);
+    if (recorder) { recorder->finish_with_failure(); }
     _promise.set_exception(_first_exception);
   }
 }

--- a/cpp/src/detail/multi_poll_reactor.cpp
+++ b/cpp/src/detail/multi_poll_reactor.cpp
@@ -103,11 +103,12 @@ void RemoteMultiAggregateContext::on_subrange_complete(std::size_t bytes)
   // it is written and read under _exception_mutex.
   if (_subranges_left.fetch_sub(1, std::memory_order_acq_rel) == 1) {
     std::lock_guard<std::mutex> const lock(_exception_mutex);
+    // Finish the observation before fulfilling the promise below. The other order would let the
+    // caller return from `future.get()` before the observation had been delivered.
     if (recorder) {
       if (_first_exception) {
         recorder->finish_with_failure();
       } else {
-        // Before the promise, so the observation has landed by the time the caller resumes.
         recorder->finish(_total_bytes.load(std::memory_order_relaxed));
       }
     }

--- a/cpp/src/detail/observation_recorder.cpp
+++ b/cpp/src/detail/observation_recorder.cpp
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+#include <kvikio/detail/observation_recorder.hpp>
+#include <kvikio/observation.hpp>
+
+namespace kvikio::detail {
+
+TimePoint now() noexcept { return Clock::now(); }
+
+LogicalObservationRecorder::LogicalObservationRecorder(IoBackend backend,
+                                                       TransferDirection direction,
+                                                       MemoryKind memory_kind,
+                                                       std::size_t offset,
+                                                       std::size_t size,
+                                                       std::string_view source,
+                                                       char const* http_method) noexcept
+  : _active{monitoring_enabled()}
+{
+  if (_active) { begin(backend, direction, memory_kind, offset, size, source, http_method); }
+}
+
+LogicalObservationRecorder::~LogicalObservationRecorder() { finish_with_failure(); }
+
+void LogicalObservationRecorder::finish(std::size_t bytes_transferred) noexcept
+{
+  if (!_active) { return; }
+  if (_emitted.exchange(true, std::memory_order_relaxed)) { return; }
+  _observation.bytes_transferred = bytes_transferred;
+  emit();
+}
+
+void LogicalObservationRecorder::finish_with_failure() noexcept
+{
+  if (!_active) { return; }
+  if (_emitted.exchange(true, std::memory_order_relaxed)) { return; }
+  _observation.ok                = false;
+  _observation.bytes_transferred = 0;
+  emit();
+}
+
+void LogicalObservationRecorder::begin(IoBackend backend,
+                                       TransferDirection direction,
+                                       MemoryKind memory_kind,
+                                       std::size_t offset,
+                                       std::size_t size,
+                                       std::string_view source,
+                                       char const* http_method) noexcept
+{
+  // From 1, so that a default-constructed `Observation` (id 0) is never mistaken for a real one.
+  static std::atomic<std::uint64_t> id_counter{1};
+  _observation.backend     = backend;
+  _observation.direction   = direction;
+  _observation.memory_kind = memory_kind;
+  _observation.offset      = offset;
+  _observation.size        = size;
+  _observation.http_method = http_method;
+  _observation.source      = source;
+  _observation.id          = id_counter.fetch_add(1, std::memory_order_relaxed);
+  _observation.start       = now();
+  notify_started(_observation);
+}
+
+void LogicalObservationRecorder::emit() noexcept
+{
+  _observation.end = now();
+  notify_finished(_observation);
+}
+
+}  // namespace kvikio::detail

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -184,9 +184,9 @@ std::size_t FileHandle::read(void* devPtr_base,
   KVIKIO_NVTX_FUNC_RANGE(size);
   detail::expect_not_in_monitor();
   auto const compat = get_compat_mode_manager().is_compat_mode_preferred();
-  detail::LogicalObservationRecorder recorder{compat ? IoBackend::Posix : IoBackend::Gds,
-                                              TransferDirection::Read,
-                                              MemoryKind::Device,
+  detail::LogicalObservationRecorder recorder{compat ? IoBackend::POSIX : IoBackend::GDS,
+                                              TransferDirection::READ,
+                                              MemoryKind::DEVICE,
                                               file_offset,
                                               size};
   auto const nbytes = read_impl(devPtr_base, size, file_offset, devPtr_offset, sync_default_stream);
@@ -229,9 +229,9 @@ std::size_t FileHandle::write(void const* devPtr_base,
   KVIKIO_NVTX_FUNC_RANGE(size);
   detail::expect_not_in_monitor();
   auto const compat = get_compat_mode_manager().is_compat_mode_preferred();
-  detail::LogicalObservationRecorder recorder{compat ? IoBackend::Posix : IoBackend::Gds,
-                                              TransferDirection::Write,
-                                              MemoryKind::Device,
+  detail::LogicalObservationRecorder recorder{compat ? IoBackend::POSIX : IoBackend::GDS,
+                                              TransferDirection::WRITE,
+                                              MemoryKind::DEVICE,
                                               file_offset,
                                               size};
   _nbytes = 0;  // Invalidate the computed file size.
@@ -306,9 +306,9 @@ std::future<std::size_t> FileHandle::pread(void* buf,
   // function returned.
   auto recorder = detail::monitoring_enabled()
                     ? std::make_shared<detail::LogicalObservationRecorder>(
-                        uses_posix ? IoBackend::Posix : IoBackend::Gds,
-                        TransferDirection::Read,
-                        is_host ? MemoryKind::Host : MemoryKind::Device,
+                        uses_posix ? IoBackend::POSIX : IoBackend::GDS,
+                        TransferDirection::READ,
+                        is_host ? MemoryKind::HOST : MemoryKind::DEVICE,
                         file_offset,
                         size)
                     : nullptr;
@@ -427,9 +427,9 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
   // function returned.
   auto recorder = detail::monitoring_enabled()
                     ? std::make_shared<detail::LogicalObservationRecorder>(
-                        uses_posix ? IoBackend::Posix : IoBackend::Gds,
-                        TransferDirection::Write,
-                        is_host ? MemoryKind::Host : MemoryKind::Device,
+                        uses_posix ? IoBackend::POSIX : IoBackend::GDS,
+                        TransferDirection::WRITE,
+                        is_host ? MemoryKind::HOST : MemoryKind::DEVICE,
                         file_offset,
                         size)
                     : nullptr;

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <memory>
+#include <stdexcept>
 #include <unordered_map>
 #include <utility>
 
@@ -298,6 +299,7 @@ std::future<std::size_t> FileHandle::pread(void* buf,
     gds_threshold,
     sync_default_stream);
   KVIKIO_EXPECT(thread_pool != nullptr, "The thread pool must not be nullptr");
+  KVIKIO_EXPECT(task_size > 0, "`task_size` must be positive", std::invalid_argument);
 
   // Use the block-device-specific pool only if it exists and the user didn't explicitly provide a
   // custom pool
@@ -420,6 +422,7 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
     gds_threshold,
     sync_default_stream);
   KVIKIO_EXPECT(thread_pool != nullptr, "The thread pool must not be nullptr");
+  KVIKIO_EXPECT(task_size > 0, "`task_size` must be positive", std::invalid_argument);
 
   // Use the block-device-specific pool only if it exists and the user didn't explicitly provide a
   // custom pool
@@ -446,6 +449,9 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
                         size,
                         _file_path)
                     : nullptr;
+  // Invalidated before the write as well as after each part completes.
+  _nbytes.store(0, std::memory_order_relaxed);
+
   if (is_host) {
     auto op = [this](void const* hostPtr_base,
                      std::size_t size,

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -8,6 +8,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdlib>
 #include <memory>
@@ -110,7 +111,7 @@ FileHandle::FileHandle(FileHandle&& other) noexcept
   : _file_direct_on{std::exchange(other._file_direct_on, {})},
     _file_direct_off{std::exchange(other._file_direct_off, {})},
     _initialized{std::exchange(other._initialized, false)},
-    _nbytes{std::exchange(other._nbytes, 0)},
+    _nbytes{other._nbytes.exchange(0, std::memory_order_relaxed)},
     _cufile_handle{std::exchange(other._cufile_handle, {})},
     _compat_mode_manager{std::move(other._compat_mode_manager)},
     _file_path{std::exchange(other._file_path, {})},
@@ -122,10 +123,10 @@ FileHandle& FileHandle::operator=(FileHandle&& other) noexcept
 {
   if (this != &other) {
     close();
-    _file_direct_on      = std::exchange(other._file_direct_on, {});
-    _file_direct_off     = std::exchange(other._file_direct_off, {});
-    _initialized         = std::exchange(other._initialized, false);
-    _nbytes              = std::exchange(other._nbytes, 0);
+    _file_direct_on  = std::exchange(other._file_direct_on, {});
+    _file_direct_off = std::exchange(other._file_direct_off, {});
+    _initialized     = std::exchange(other._initialized, false);
+    _nbytes.store(other._nbytes.exchange(0, std::memory_order_relaxed), std::memory_order_relaxed);
     _cufile_handle       = std::exchange(other._cufile_handle, {});
     _compat_mode_manager = std::move(other._compat_mode_manager);
     _file_path           = std::exchange(other._file_path, {});
@@ -150,7 +151,7 @@ void FileHandle::close() noexcept
     _cufile_handle.unregister_handle();
     _file_direct_off.close();
     _file_direct_on.close();
-    _nbytes      = 0;
+    _nbytes.store(0, std::memory_order_relaxed);
     _initialized = false;
     _thread_pool = nullptr;
   } catch (...) {
@@ -175,8 +176,12 @@ int FileHandle::fd_open_flags(bool o_direct) const { return open_flags(fd(o_dire
 std::size_t FileHandle::nbytes() const
 {
   if (closed()) { return 0; }
-  if (_nbytes == 0) { _nbytes = get_file_size(_file_direct_off.fd()); }
-  return _nbytes;
+  auto cached = _nbytes.load(std::memory_order_relaxed);
+  if (cached == 0) {
+    cached = get_file_size(_file_direct_off.fd());
+    _nbytes.store(cached, std::memory_order_relaxed);
+  }
+  return cached;
 }
 
 std::size_t FileHandle::read(void* devPtr_base,
@@ -240,7 +245,7 @@ std::size_t FileHandle::write(void const* devPtr_base,
                                               file_offset,
                                               size,
                                               _file_path};
-  _nbytes = 0;  // Invalidate the computed file size.
+  _nbytes.store(0, std::memory_order_relaxed);  // Invalidate the computed file size.
   auto const nbytes =
     write_impl(devPtr_base, size, file_offset, devPtr_offset, sync_default_stream);
   recorder.finish(nbytes);
@@ -449,7 +454,7 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
       char const* buf          = static_cast<char const*>(hostPtr_base) + hostPtr_offset;
       auto const bytes_written = detail::posix_host_write<detail::PartialIO::NO>(
         _file_direct_off.fd(), buf, size, file_offset, _file_direct_on.fd());
-      _nbytes = 0;  // The write may have extended the file.
+      _nbytes.store(0, std::memory_order_relaxed);  // The write may have extended the file.
       return bytes_written;
     };
 
@@ -472,7 +477,7 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
     PushAndPopContext c(ctx);
     auto bytes_write = detail::posix_device_write(
       _file_direct_off.fd(), buf, size, file_offset, 0, _file_direct_on.fd());
-    _nbytes = 0;  // The write may have extended the file.
+    _nbytes.store(0, std::memory_order_relaxed);  // The write may have extended the file.
     // This shortcut bypasses `parallel_io`, so it closes the observation itself.
     if (recorder) { recorder->finish(bytes_write); }
     // Maintain API consistency while making this trivial case synchronous.
@@ -494,7 +499,7 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
     PushAndPopContext c(ctx);
     auto const bytes_written =
       write_impl(devPtr_base, size, file_offset, devPtr_offset, /* sync_default_stream = */ false);
-    _nbytes = 0;  // The write may have extended the file.
+    _nbytes.store(0, std::memory_order_relaxed);  // The write may have extended the file.
     return bytes_written;
   };
   auto [devPtr_base, base_size, devPtr_offset] = get_alloc_info(buf, &ctx);

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -17,6 +17,7 @@
 #include <kvikio/compat_mode.hpp>
 #include <kvikio/defaults.hpp>
 #include <kvikio/detail/nvtx.hpp>
+#include <kvikio/detail/observation_recorder.hpp>
 #include <kvikio/detail/parallel_operation.hpp>
 #include <kvikio/detail/posix_io.hpp>
 #include <kvikio/error.hpp>
@@ -181,9 +182,30 @@ std::size_t FileHandle::read(void* devPtr_base,
                              bool sync_default_stream)
 {
   KVIKIO_NVTX_FUNC_RANGE(size);
-  if (get_compat_mode_manager().is_compat_mode_preferred()) {
-    return detail::posix_device_read(
+  detail::expect_not_in_monitor();
+  auto const compat = get_compat_mode_manager().is_compat_mode_preferred();
+  detail::LogicalObservationRecorder recorder{compat ? IoBackend::Posix : IoBackend::Gds,
+                                              TransferDirection::Read,
+                                              MemoryKind::Device,
+                                              file_offset,
+                                              size};
+  auto const nbytes = read_impl(devPtr_base, size, file_offset, devPtr_offset, sync_default_stream);
+  recorder.finish(nbytes);
+  return nbytes;
+}
+
+std::size_t FileHandle::read_impl(void* devPtr_base,
+                                  std::size_t size,
+                                  std::size_t file_offset,
+                                  std::size_t devPtr_offset,
+                                  bool sync_default_stream)
+{
+  KVIKIO_NVTX_FUNC_RANGE(size);
+  auto const compat = get_compat_mode_manager().is_compat_mode_preferred();
+  if (compat) {
+    auto const nbytes = detail::posix_device_read(
       _file_direct_off.fd(), devPtr_base, size, file_offset, devPtr_offset, _file_direct_on.fd());
+    return nbytes;
   }
   if (sync_default_stream) {
     KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(nullptr));
@@ -205,11 +227,33 @@ std::size_t FileHandle::write(void const* devPtr_base,
                               bool sync_default_stream)
 {
   KVIKIO_NVTX_FUNC_RANGE(size);
-  _nbytes = 0;  // Invalidate the computed file size
+  detail::expect_not_in_monitor();
+  auto const compat = get_compat_mode_manager().is_compat_mode_preferred();
+  detail::LogicalObservationRecorder recorder{compat ? IoBackend::Posix : IoBackend::Gds,
+                                              TransferDirection::Write,
+                                              MemoryKind::Device,
+                                              file_offset,
+                                              size};
+  _nbytes = 0;  // Invalidate the computed file size.
+  auto const nbytes =
+    write_impl(devPtr_base, size, file_offset, devPtr_offset, sync_default_stream);
+  recorder.finish(nbytes);
+  return nbytes;
+}
 
-  if (get_compat_mode_manager().is_compat_mode_preferred()) {
-    return detail::posix_device_write(
+std::size_t FileHandle::write_impl(void const* devPtr_base,
+                                   std::size_t size,
+                                   std::size_t file_offset,
+                                   std::size_t devPtr_offset,
+                                   bool sync_default_stream)
+{
+  KVIKIO_NVTX_FUNC_RANGE(size);
+  auto const compat = get_compat_mode_manager().is_compat_mode_preferred();
+
+  if (compat) {
+    auto const nbytes = detail::posix_device_write(
       _file_direct_off.fd(), devPtr_base, size, file_offset, devPtr_offset, _file_direct_on.fd());
+    return nbytes;
   }
   if (sync_default_stream) {
     KVIKIO_CUDA_DRIVER_TRY(cudaAPI::instance().StreamSynchronize(nullptr));
@@ -252,7 +296,23 @@ std::future<std::size_t> FileHandle::pread(void* buf,
 
   auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
   KVIKIO_NVTX_FUNC_RANGE(size, nvtx_color);
-  if (is_host_memory(buf)) {
+  detail::expect_not_in_monitor();
+  bool const is_host = is_host_memory(buf);
+  bool const uses_posix =
+    is_host || size < gds_threshold || get_compat_mode_manager().is_compat_mode_preferred();
+
+  // One observation for the whole call, whichever branch serves it. `parallel_io` hands it to the
+  // task that completes the work, so the end time is when the I/O finished rather than when this
+  // function returned.
+  auto recorder = detail::monitoring_enabled()
+                    ? std::make_shared<detail::LogicalObservationRecorder>(
+                        uses_posix ? IoBackend::Posix : IoBackend::Gds,
+                        TransferDirection::Read,
+                        is_host ? MemoryKind::Host : MemoryKind::Device,
+                        file_offset,
+                        size)
+                    : nullptr;
+  if (is_host) {
     auto op = [this](void* hostPtr_base,
                      std::size_t size,
                      std::size_t file_offset,
@@ -262,14 +322,16 @@ std::future<std::size_t> FileHandle::pread(void* buf,
         _file_direct_off.fd(), buf, size, file_offset, _file_direct_on.fd());
     };
 
-    return detail::parallel_io(
-      op,
-      buf,
-      size,
-      file_offset,
-      task_size,
-      0,
-      {.thread_pool = actual_thread_pool, .call_idx = call_idx, .nvtx_color = nvtx_color});
+    return detail::parallel_io(op,
+                               buf,
+                               size,
+                               file_offset,
+                               task_size,
+                               0,
+                               {.thread_pool = actual_thread_pool,
+                                .call_idx    = call_idx,
+                                .nvtx_color  = nvtx_color,
+                                .recorder    = recorder});
   }
 
   CUcontext ctx = get_context_from_pointer(buf);
@@ -279,6 +341,8 @@ std::future<std::size_t> FileHandle::pread(void* buf,
     PushAndPopContext c(ctx);
     auto bytes_read = detail::posix_device_read(
       _file_direct_off.fd(), buf, size, file_offset, 0, _file_direct_on.fd());
+    // This shortcut bypasses `parallel_io`, so it closes the observation itself.
+    if (recorder) { recorder->finish(bytes_read); }
     // Maintain API consistency while making this trivial case synchronous.
     // The result in the future is immediately available after the call.
     return make_ready_future(bytes_read);
@@ -296,7 +360,8 @@ std::future<std::size_t> FileHandle::pread(void* buf,
                           std::size_t file_offset,
                           std::size_t devPtr_offset) -> std::size_t {
     PushAndPopContext c(ctx);
-    return read(devPtr_base, size, file_offset, devPtr_offset, /* sync_default_stream = */ false);
+    return read_impl(
+      devPtr_base, size, file_offset, devPtr_offset, /* sync_default_stream = */ false);
   };
   auto [devPtr_base, base_size, devPtr_offset] = get_alloc_info(buf, &ctx);
 
@@ -321,7 +386,8 @@ std::future<std::size_t> FileHandle::pread(void* buf,
                              {.thread_pool     = actual_thread_pool,
                               .call_idx        = call_idx,
                               .nvtx_color      = nvtx_color,
-                              .first_task_size = first_task_size});
+                              .first_task_size = first_task_size,
+                              .recorder        = recorder});
 }
 
 std::future<std::size_t> FileHandle::pwrite(void const* buf,
@@ -351,26 +417,44 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
 
   auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
   KVIKIO_NVTX_FUNC_RANGE(size, nvtx_color);
-  if (is_host_memory(buf)) {
+  detail::expect_not_in_monitor();
+  bool const is_host = is_host_memory(buf);
+  bool const uses_posix =
+    is_host || size < gds_threshold || get_compat_mode_manager().is_compat_mode_preferred();
+
+  // One observation for the whole call, whichever branch serves it. `parallel_io` hands it to the
+  // task that completes the work, so the end time is when the I/O finished rather than when this
+  // function returned.
+  auto recorder = detail::monitoring_enabled()
+                    ? std::make_shared<detail::LogicalObservationRecorder>(
+                        uses_posix ? IoBackend::Posix : IoBackend::Gds,
+                        TransferDirection::Write,
+                        is_host ? MemoryKind::Host : MemoryKind::Device,
+                        file_offset,
+                        size)
+                    : nullptr;
+  if (is_host) {
     auto op = [this](void const* hostPtr_base,
                      std::size_t size,
                      std::size_t file_offset,
                      std::size_t hostPtr_offset) -> std::size_t {
-      char const* buf         = static_cast<char const*>(hostPtr_base) + hostPtr_offset;
+      char const* buf          = static_cast<char const*>(hostPtr_base) + hostPtr_offset;
       auto const bytes_written = detail::posix_host_write<detail::PartialIO::NO>(
         _file_direct_off.fd(), buf, size, file_offset, _file_direct_on.fd());
       _nbytes = 0;  // The write may have extended the file.
       return bytes_written;
     };
 
-    return detail::parallel_io(
-      op,
-      buf,
-      size,
-      file_offset,
-      task_size,
-      0,
-      {.thread_pool = actual_thread_pool, .call_idx = call_idx, .nvtx_color = nvtx_color});
+    return detail::parallel_io(op,
+                               buf,
+                               size,
+                               file_offset,
+                               task_size,
+                               0,
+                               {.thread_pool = actual_thread_pool,
+                                .call_idx    = call_idx,
+                                .nvtx_color  = nvtx_color,
+                                .recorder    = recorder});
   }
 
   CUcontext ctx = get_context_from_pointer(buf);
@@ -381,6 +465,8 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
     auto bytes_write = detail::posix_device_write(
       _file_direct_off.fd(), buf, size, file_offset, 0, _file_direct_on.fd());
     _nbytes = 0;  // The write may have extended the file.
+    // This shortcut bypasses `parallel_io`, so it closes the observation itself.
+    if (recorder) { recorder->finish(bytes_write); }
     // Maintain API consistency while making this trivial case synchronous.
     // The result in the future is immediately available after the call.
     return make_ready_future(bytes_write);
@@ -398,17 +484,22 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
                         std::size_t file_offset,
                         std::size_t devPtr_offset) -> std::size_t {
     PushAndPopContext c(ctx);
-    return write(devPtr_base, size, file_offset, devPtr_offset, /* sync_default_stream = */ false);
+    auto const bytes_written =
+      write_impl(devPtr_base, size, file_offset, devPtr_offset, /* sync_default_stream = */ false);
+    _nbytes = 0;  // The write may have extended the file.
+    return bytes_written;
   };
   auto [devPtr_base, base_size, devPtr_offset] = get_alloc_info(buf, &ctx);
-  return detail::parallel_io(
-    op,
-    devPtr_base,
-    size,
-    file_offset,
-    task_size,
-    devPtr_offset,
-    {.thread_pool = actual_thread_pool, .call_idx = call_idx, .nvtx_color = nvtx_color});
+  return detail::parallel_io(op,
+                             devPtr_base,
+                             size,
+                             file_offset,
+                             task_size,
+                             devPtr_offset,
+                             {.thread_pool = actual_thread_pool,
+                              .call_idx    = call_idx,
+                              .nvtx_color  = nvtx_color,
+                              .recorder    = recorder});
 }
 
 void FileHandle::read_async(void* devPtr_base,

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -356,9 +356,11 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
                      std::size_t size,
                      std::size_t file_offset,
                      std::size_t hostPtr_offset) -> std::size_t {
-      char const* buf = static_cast<char const*>(hostPtr_base) + hostPtr_offset;
-      return detail::posix_host_write<detail::PartialIO::NO>(
+      char const* buf         = static_cast<char const*>(hostPtr_base) + hostPtr_offset;
+      auto const bytes_written = detail::posix_host_write<detail::PartialIO::NO>(
         _file_direct_off.fd(), buf, size, file_offset, _file_direct_on.fd());
+      _nbytes = 0;  // The write may have extended the file.
+      return bytes_written;
     };
 
     return detail::parallel_io(
@@ -378,6 +380,7 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
     PushAndPopContext c(ctx);
     auto bytes_write = detail::posix_device_write(
       _file_direct_off.fd(), buf, size, file_offset, 0, _file_direct_on.fd());
+    _nbytes = 0;  // The write may have extended the file.
     // Maintain API consistency while making this trivial case synchronous.
     // The result in the future is immediately available after the call.
     return make_ready_future(bytes_write);

--- a/cpp/src/file_handle.cpp
+++ b/cpp/src/file_handle.cpp
@@ -98,7 +98,9 @@ FileHandle::FileHandle(std::string const& file_path,
                        std::string const& flags,
                        mode_t mode,
                        CompatMode compat_mode)
-  : _initialized{true}, _compat_mode_manager{file_path, flags, mode, compat_mode, this}
+  : _initialized{true},
+    _compat_mode_manager{file_path, flags, mode, compat_mode, this},
+    _file_path{file_path}
 {
   KVIKIO_NVTX_FUNC_RANGE();
   _thread_pool = get_thread_pool_per_block_device(file_path);
@@ -111,6 +113,7 @@ FileHandle::FileHandle(FileHandle&& other) noexcept
     _nbytes{std::exchange(other._nbytes, 0)},
     _cufile_handle{std::exchange(other._cufile_handle, {})},
     _compat_mode_manager{std::move(other._compat_mode_manager)},
+    _file_path{std::exchange(other._file_path, {})},
     _thread_pool{std::exchange(other._thread_pool, {})}
 {
 }
@@ -125,6 +128,7 @@ FileHandle& FileHandle::operator=(FileHandle&& other) noexcept
     _nbytes              = std::exchange(other._nbytes, 0);
     _cufile_handle       = std::exchange(other._cufile_handle, {});
     _compat_mode_manager = std::move(other._compat_mode_manager);
+    _file_path           = std::exchange(other._file_path, {});
     _thread_pool         = std::exchange(other._thread_pool, {});
   }
   return *this;
@@ -188,7 +192,8 @@ std::size_t FileHandle::read(void* devPtr_base,
                                               TransferDirection::READ,
                                               MemoryKind::DEVICE,
                                               file_offset,
-                                              size};
+                                              size,
+                                              _file_path};
   auto const nbytes = read_impl(devPtr_base, size, file_offset, devPtr_offset, sync_default_stream);
   recorder.finish(nbytes);
   return nbytes;
@@ -233,7 +238,8 @@ std::size_t FileHandle::write(void const* devPtr_base,
                                               TransferDirection::WRITE,
                                               MemoryKind::DEVICE,
                                               file_offset,
-                                              size};
+                                              size,
+                                              _file_path};
   _nbytes = 0;  // Invalidate the computed file size.
   auto const nbytes =
     write_impl(devPtr_base, size, file_offset, devPtr_offset, sync_default_stream);
@@ -310,7 +316,8 @@ std::future<std::size_t> FileHandle::pread(void* buf,
                         TransferDirection::READ,
                         is_host ? MemoryKind::HOST : MemoryKind::DEVICE,
                         file_offset,
-                        size)
+                        size,
+                        _file_path)
                     : nullptr;
   if (is_host) {
     auto op = [this](void* hostPtr_base,
@@ -431,7 +438,8 @@ std::future<std::size_t> FileHandle::pwrite(void const* buf,
                         TransferDirection::WRITE,
                         is_host ? MemoryKind::HOST : MemoryKind::DEVICE,
                         file_offset,
-                        size)
+                        size,
+                        _file_path)
                     : nullptr;
   if (is_host) {
     auto op = [this](void const* hostPtr_base,

--- a/cpp/src/mmap.cpp
+++ b/cpp/src/mmap.cpp
@@ -15,6 +15,7 @@
 
 #include <kvikio/bounce_buffer.hpp>
 #include <kvikio/detail/nvtx.hpp>
+#include <kvikio/detail/observation_recorder.hpp>
 #include <kvikio/detail/parallel_operation.hpp>
 #include <kvikio/detail/stream.hpp>
 #include <kvikio/detail/utils.hpp>
@@ -370,16 +371,24 @@ std::size_t MmapHandle::read(void* buf, std::optional<std::size_t> size, std::si
 {
   KVIKIO_NVTX_FUNC_RANGE();
 
+  detail::expect_not_in_monitor();
   auto actual_size = validate_and_adjust_read_args(size, offset);
   if (actual_size == 0) { return actual_size; }
 
   auto const is_dst_buf_host_mem = is_host_memory(buf);
+  detail::LogicalObservationRecorder recorder{
+    IoBackend::Mmap,
+    TransferDirection::Read,
+    is_dst_buf_host_mem ? MemoryKind::Host : MemoryKind::Device,
+    offset,
+    actual_size};
   CUcontext ctx{};
   if (!is_dst_buf_host_mem) { ctx = get_context_from_pointer(buf); }
 
   // Copy `actual_size` bytes from `src_mapped_buf` (src) to `buf` (dst)
   auto const src_mapped_buf = detail::pointer_add(_buf, offset - _initial_map_offset);
   detail::read_impl(buf, src_mapped_buf, actual_size, 0, is_dst_buf_host_mem, ctx);
+  recorder.finish(actual_size);
   return actual_size;
 }
 
@@ -392,6 +401,7 @@ std::future<std::size_t> MmapHandle::pread(void* buf,
   KVIKIO_EXPECT(task_size <= defaults::bounce_buffer_size(),
                 "bounce buffer size cannot be less than task size.");
   KVIKIO_EXPECT(thread_pool != nullptr, "The thread pool must not be nullptr");
+  detail::expect_not_in_monitor();
   auto actual_size = validate_and_adjust_read_args(size, offset);
   if (actual_size == 0) { return make_ready_future(actual_size); }
 
@@ -415,14 +425,24 @@ std::future<std::size_t> MmapHandle::pread(void* buf,
     return size;
   };
 
-  return detail::parallel_io(
-    op,
-    buf,
-    actual_size,
-    offset,
-    task_size,
-    0,  // dst buffer offset initial value
-    {.thread_pool = thread_pool, .call_idx = call_idx, .nvtx_color = nvtx_color});
+  auto recorder = detail::monitoring_enabled()
+                    ? std::make_shared<detail::LogicalObservationRecorder>(
+                        IoBackend::Mmap,
+                        TransferDirection::Read,
+                        is_host_memory(buf) ? MemoryKind::Host : MemoryKind::Device,
+                        offset,
+                        actual_size)
+                    : nullptr;
+  return detail::parallel_io(op,
+                             buf,
+                             actual_size,
+                             offset,
+                             task_size,
+                             0,  // dst buffer offset initial value
+                             {.thread_pool = thread_pool,
+                              .call_idx    = call_idx,
+                              .nvtx_color  = nvtx_color,
+                              .recorder    = recorder});
 }
 
 std::size_t MmapHandle::validate_and_adjust_read_args(std::optional<std::size_t> const& size,

--- a/cpp/src/mmap.cpp
+++ b/cpp/src/mmap.cpp
@@ -405,6 +405,7 @@ std::future<std::size_t> MmapHandle::pread(void* buf,
   KVIKIO_EXPECT(task_size <= defaults::bounce_buffer_size(),
                 "bounce buffer size cannot be less than task size.");
   KVIKIO_EXPECT(thread_pool != nullptr, "The thread pool must not be nullptr");
+  KVIKIO_EXPECT(task_size > 0, "`task_size` must be positive", std::invalid_argument);
   detail::expect_not_in_monitor();
   auto actual_size = validate_and_adjust_read_args(size, offset);
   if (actual_size == 0) { return make_ready_future(actual_size); }

--- a/cpp/src/mmap.cpp
+++ b/cpp/src/mmap.cpp
@@ -377,9 +377,9 @@ std::size_t MmapHandle::read(void* buf, std::optional<std::size_t> size, std::si
 
   auto const is_dst_buf_host_mem = is_host_memory(buf);
   detail::LogicalObservationRecorder recorder{
-    IoBackend::Mmap,
-    TransferDirection::Read,
-    is_dst_buf_host_mem ? MemoryKind::Host : MemoryKind::Device,
+    IoBackend::MMAP,
+    TransferDirection::READ,
+    is_dst_buf_host_mem ? MemoryKind::HOST : MemoryKind::DEVICE,
     offset,
     actual_size};
   CUcontext ctx{};
@@ -427,9 +427,9 @@ std::future<std::size_t> MmapHandle::pread(void* buf,
 
   auto recorder = detail::monitoring_enabled()
                     ? std::make_shared<detail::LogicalObservationRecorder>(
-                        IoBackend::Mmap,
-                        TransferDirection::Read,
-                        is_host_memory(buf) ? MemoryKind::Host : MemoryKind::Device,
+                        IoBackend::MMAP,
+                        TransferDirection::READ,
+                        is_host_memory(buf) ? MemoryKind::HOST : MemoryKind::DEVICE,
                         offset,
                         actual_size)
                     : nullptr;

--- a/cpp/src/mmap.cpp
+++ b/cpp/src/mmap.cpp
@@ -255,6 +255,7 @@ MmapHandle::MmapHandle(std::string const& file_path,
     }
   }
 
+  _file_path    = file_path;
   _file_wrapper = FileWrapper(file_path, flags, false /* o_direct */, mode);
   _file_size    = get_file_size(_file_wrapper.fd());
   if (_file_size == 0) { return; }
@@ -304,7 +305,8 @@ MmapHandle::MmapHandle(MmapHandle&& other) noexcept
     _initialized{std::exchange(other._initialized, {})},
     _map_protection{std::exchange(other._map_protection, {})},
     _map_flags{std::exchange(other._map_flags, {})},
-    _file_wrapper{std::exchange(other._file_wrapper, {})}
+    _file_wrapper{std::exchange(other._file_wrapper, {})},
+    _file_path{std::exchange(other._file_path, {})}
 {
 }
 
@@ -322,6 +324,7 @@ MmapHandle& MmapHandle::operator=(MmapHandle&& other) noexcept
   _map_protection     = std::exchange(other._map_protection, {});
   _map_flags          = std::exchange(other._map_flags, {});
   _file_wrapper       = std::exchange(other._file_wrapper, {});
+  _file_path          = std::exchange(other._file_path, {});
   return *this;
 }
 
@@ -381,7 +384,8 @@ std::size_t MmapHandle::read(void* buf, std::optional<std::size_t> size, std::si
     TransferDirection::READ,
     is_dst_buf_host_mem ? MemoryKind::HOST : MemoryKind::DEVICE,
     offset,
-    actual_size};
+    actual_size,
+    _file_path};
   CUcontext ctx{};
   if (!is_dst_buf_host_mem) { ctx = get_context_from_pointer(buf); }
 
@@ -431,7 +435,8 @@ std::future<std::size_t> MmapHandle::pread(void* buf,
                         TransferDirection::READ,
                         is_host_memory(buf) ? MemoryKind::HOST : MemoryKind::DEVICE,
                         offset,
-                        actual_size)
+                        actual_size,
+                        _file_path)
                     : nullptr;
   return detail::parallel_io(op,
                              buf,

--- a/cpp/src/observation.cpp
+++ b/cpp/src/observation.cpp
@@ -260,9 +260,6 @@ void LogicalObservationRecorder::begin(IoBackend backend,
 void LogicalObservationRecorder::emit() noexcept
 {
   _observation.end = now();
-  // Delivered to whoever is registered now, which need not be who was registered when the
-  // operation began. A monitor that missed the start ignores this, as `Monitor::on_finish()`
-  // documents, so the recorder does not have to remember which monitors it told.
   notify_finished(_observation);
 }
 

--- a/cpp/src/observation.cpp
+++ b/cpp/src/observation.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
@@ -172,6 +173,14 @@ namespace detail {
 
 bool monitoring_enabled() noexcept { return monitor_count.load(std::memory_order_acquire) != 0; }
 }  // namespace detail
+
+ClockAnchor ClockAnchor::now() noexcept
+{
+  ClockAnchor anchor{};
+  anchor.steady = Clock::now();
+  anchor.wall   = std::chrono::system_clock::now();
+  return anchor;
+}
 
 std::string_view to_string(IoBackend backend) noexcept
 {

--- a/cpp/src/observation.cpp
+++ b/cpp/src/observation.cpp
@@ -249,8 +249,9 @@ void LogicalObservationRecorder::begin(IoBackend backend,
 void LogicalObservationRecorder::emit() noexcept
 {
   _observation.end = now();
-  // A monitor registered after this operation began never saw its start and ignores the finish,
-  // which is why no flag is latched here.
+  // Delivered to whoever is registered now, which need not be who was registered when the
+  // operation began. A monitor that missed the start ignores this, as `Monitor::on_finish()`
+  // documents, so the recorder does not have to remember which monitors it told.
   notify_finished(_observation);
 }
 

--- a/cpp/src/observation.cpp
+++ b/cpp/src/observation.cpp
@@ -240,6 +240,7 @@ void LogicalObservationRecorder::begin(IoBackend backend,
                                        MemoryKind memory_kind,
                                        std::size_t offset,
                                        std::size_t size,
+                                       std::string_view source,
                                        char const* http_method) noexcept
 {
   // From 1, so that a default-constructed `Observation` (id 0) is never mistaken for a real one.
@@ -250,6 +251,7 @@ void LogicalObservationRecorder::begin(IoBackend backend,
   _observation.offset      = offset;
   _observation.size        = size;
   _observation.http_method = http_method;
+  _observation.source      = source;
   _observation.id          = id_counter.fetch_add(1, std::memory_order_relaxed);
   _observation.start       = now();
   if (monitor_count.load(std::memory_order_acquire) != 0) { notify_started(_observation); }

--- a/cpp/src/observation.cpp
+++ b/cpp/src/observation.cpp
@@ -157,7 +157,7 @@ class Registry {
   /// One registered monitor. Not owned, and must outlive its registration.
   struct Entry {
     std::uint64_t id{0};
-    ObservationKind kind{ObservationKind::Logical};
+    ObservationKind kind{ObservationKind::LOGICAL};
     Monitor* monitor{nullptr};
   };
 
@@ -176,11 +176,11 @@ bool monitoring_enabled() noexcept { return monitor_count.load(std::memory_order
 std::string_view to_string(IoBackend backend) noexcept
 {
   switch (backend) {
-    case IoBackend::Posix: return "Posix";
-    case IoBackend::Gds: return "Gds";
-    case IoBackend::Mmap: return "Mmap";
-    case IoBackend::RemoteHttp: return "RemoteHttp";
-    case IoBackend::RemoteHdfs: return "RemoteHdfs";
+    case IoBackend::POSIX: return "POSIX";
+    case IoBackend::GDS: return "GDS";
+    case IoBackend::MMAP: return "MMAP";
+    case IoBackend::REMOTE_HTTP: return "REMOTE_HTTP";
+    case IoBackend::REMOTE_HDFS: return "REMOTE_HDFS";
     default: return "Unknown";
   }
 }
@@ -188,8 +188,8 @@ std::string_view to_string(IoBackend backend) noexcept
 std::string_view to_string(TransferDirection direction) noexcept
 {
   switch (direction) {
-    case TransferDirection::Read: return "Read";
-    case TransferDirection::Write: return "Write";
+    case TransferDirection::READ: return "READ";
+    case TransferDirection::WRITE: return "WRITE";
     default: return "Unknown";
   }
 }
@@ -197,8 +197,8 @@ std::string_view to_string(TransferDirection direction) noexcept
 std::string_view to_string(MemoryKind memory_kind) noexcept
 {
   switch (memory_kind) {
-    case MemoryKind::Host: return "Host";
-    case MemoryKind::Device: return "Device";
+    case MemoryKind::HOST: return "HOST";
+    case MemoryKind::DEVICE: return "DEVICE";
     default: return "Unknown";
   }
 }
@@ -206,7 +206,7 @@ std::string_view to_string(MemoryKind memory_kind) noexcept
 std::string_view to_string(ObservationKind kind) noexcept
 {
   switch (kind) {
-    case ObservationKind::Logical: return "Logical";
+    case ObservationKind::LOGICAL: return "LOGICAL";
     default: return "Unknown";
   }
 }

--- a/cpp/src/observation.cpp
+++ b/cpp/src/observation.cpp
@@ -235,34 +235,6 @@ void expect_not_in_monitor()
     !Registry::in_monitor(), "a monitor must not call back into KvikIO", std::runtime_error);
 }
 
-void LogicalObservationRecorder::begin(IoBackend backend,
-                                       TransferDirection direction,
-                                       MemoryKind memory_kind,
-                                       std::size_t offset,
-                                       std::size_t size,
-                                       std::string_view source,
-                                       char const* http_method) noexcept
-{
-  // From 1, so that a default-constructed `Observation` (id 0) is never mistaken for a real one.
-  static std::atomic<std::uint64_t> id_counter{1};
-  _observation.backend     = backend;
-  _observation.direction   = direction;
-  _observation.memory_kind = memory_kind;
-  _observation.offset      = offset;
-  _observation.size        = size;
-  _observation.http_method = http_method;
-  _observation.source      = source;
-  _observation.id          = id_counter.fetch_add(1, std::memory_order_relaxed);
-  _observation.start       = now();
-  if (monitor_count.load(std::memory_order_acquire) != 0) { notify_started(_observation); }
-}
-
-void LogicalObservationRecorder::emit() noexcept
-{
-  _observation.end = now();
-  notify_finished(_observation);
-}
-
 void notify_started(Observation const& observation) noexcept
 {
   Registry::instance().started(observation);

--- a/cpp/src/observation.cpp
+++ b/cpp/src/observation.cpp
@@ -1,0 +1,269 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <kvikio/detail/observation_recorder.hpp>
+#include <kvikio/error.hpp>
+#include <kvikio/logger.hpp>
+#include <kvikio/logger_macros.hpp>
+#include <kvikio/observation.hpp>
+
+namespace kvikio {
+
+namespace {
+
+/// Number of registered monitors. The gate `monitoring_enabled()` reads.
+std::atomic<std::uint32_t> monitor_count{0};
+
+/**
+ * @brief The registered monitors, the lock over them, and the notification path.
+ */
+class Registry {
+ public:
+  /**
+   * @brief The one registry.
+   *
+   * Intentionally leaked: I/O can complete during static destruction, for instance on a detached
+   * remote-I/O reactor thread, and must still find a valid registry.
+   *
+   * @return The registry.
+   */
+  static Registry& instance()
+  {
+    static auto* registry = new Registry{};
+    return *registry;
+  }
+
+  /**
+   * @brief Add a monitor.
+   *
+   * @param monitor The monitor. Not owned.
+   * @param kind Which observations it watches.
+   * @return The new registration id.
+   */
+  std::uint64_t add(Monitor* monitor, ObservationKind kind)
+  {
+    KVIKIO_EXPECT(monitor != nullptr, "the monitor must not be null", std::invalid_argument);
+    KVIKIO_EXPECT(!t_in_monitor,
+                  "cannot register a monitor from inside a monitor callback",
+                  std::runtime_error);
+
+    auto const id = _next_id.fetch_add(1, std::memory_order_relaxed);
+    std::unique_lock const lock{_mutex};
+    _monitors.push_back(Entry{id, kind, monitor});
+    publish_count();
+    return id;
+  }
+
+  /**
+   * @brief Remove a monitor, waiting for any in-flight call to it to finish.
+   *
+   * @param id The registration id. Unknown ids are ignored.
+   */
+  void remove(std::uint64_t id)
+  {
+    // The notification path holds `_mutex` shared for the duration of the callbacks, so taking it
+    // exclusively from inside one would wait for the caller's own lock to be released.
+    KVIKIO_EXPECT(!t_in_monitor,
+                  "cannot unregister a monitor from inside a monitor callback",
+                  std::runtime_error);
+
+    // Taking the mutex exclusively waits for every in-flight notification to finish, so the caller
+    // may destroy the monitor as soon as this returns.
+    std::unique_lock const lock{_mutex};
+    auto const it =
+      std::find_if(_monitors.begin(), _monitors.end(), [id](auto const& e) { return e.id == id; });
+    if (it == _monitors.end()) { return; }
+    _monitors.erase(it);
+    publish_count();
+  }
+
+  /// Tell the monitors subscribed to its kind that an operation started.
+  void started(Observation const& observation) noexcept { notify(observation, Phase::Start); }
+
+  /// Tell the monitors subscribed to its kind that an operation finished.
+  void finished(Observation const& observation) noexcept { notify(observation, Phase::Finish); }
+
+  /**
+   * @brief Whether the calling thread is currently executing a monitor callback.
+   *
+   * @return True if inside a callback.
+   */
+  [[nodiscard]] static bool in_monitor() noexcept { return t_in_monitor; }
+
+ private:
+  enum class Phase : std::uint8_t { Start, Finish };
+
+  void notify(Observation const& observation, Phase phase) noexcept
+  {
+    // Fast path: with nobody registered we never reach the mutex.
+    if (!detail::monitoring_enabled()) { return; }
+    // Belt and braces: a monitor is forbidden from calling into KvikIO, but should one manage it
+    // through a path that does not check, do not deliver the observation back into the monitors,
+    // which would recurse and re-enter the shared lock.
+    if (t_in_monitor) { return; }
+
+    std::shared_lock const lock{_mutex};
+    InMonitorGuard const guard;
+    for (auto const& entry : _monitors) {
+      // Subscription is per kind, so a layer that starts emitting later cannot flood a monitor that
+      // never asked for it.
+      if (entry.kind != observation.kind) { continue; }
+      if (phase == Phase::Start) {
+        entry.monitor->on_start(observation);
+      } else {
+        entry.monitor->on_finish(observation);
+      }
+    }
+  }
+
+  /// Republish the count. Must be called with `_mutex` held exclusively.
+  void publish_count() const noexcept
+  {
+    monitor_count.store(static_cast<std::uint32_t>(_monitors.size()), std::memory_order_release);
+  }
+
+  /**
+   * @brief Whether this thread is currently executing a monitor callback.
+   *
+   * Guards against two ways a monitor can hang the process. One that performs KvikIO I/O would emit
+   * an observation and recursively acquire the shared lock, which `std::shared_mutex` does not
+   * support, so such observations are dropped instead. And one that unregisters would block
+   * forever waiting for itself, so that is rejected outright.
+   */
+  static inline thread_local bool t_in_monitor{false};
+
+  /// RAII guard for `t_in_monitor`.
+  class InMonitorGuard {
+   public:
+    InMonitorGuard() noexcept { t_in_monitor = true; }
+    ~InMonitorGuard() { t_in_monitor = false; }
+    InMonitorGuard(InMonitorGuard const&)            = delete;
+    InMonitorGuard& operator=(InMonitorGuard const&) = delete;
+  };
+
+  /// One registered monitor. Not owned, and must outlive its registration.
+  struct Entry {
+    std::uint64_t id{0};
+    ObservationKind kind{ObservationKind::Logical};
+    Monitor* monitor{nullptr};
+  };
+
+  std::shared_mutex _mutex;
+  std::vector<Entry> _monitors;
+  std::atomic<std::uint64_t> _next_id{1};
+};
+
+}  // namespace
+
+namespace detail {
+
+bool monitoring_enabled() noexcept { return monitor_count.load(std::memory_order_acquire) != 0; }
+}  // namespace detail
+
+std::string_view to_string(IoBackend backend) noexcept
+{
+  switch (backend) {
+    case IoBackend::Posix: return "Posix";
+    case IoBackend::Gds: return "Gds";
+    case IoBackend::Mmap: return "Mmap";
+    case IoBackend::RemoteHttp: return "RemoteHttp";
+    case IoBackend::RemoteHdfs: return "RemoteHdfs";
+    default: return "Unknown";
+  }
+}
+
+std::string_view to_string(TransferDirection direction) noexcept
+{
+  switch (direction) {
+    case TransferDirection::Read: return "Read";
+    case TransferDirection::Write: return "Write";
+    default: return "Unknown";
+  }
+}
+
+std::string_view to_string(MemoryKind memory_kind) noexcept
+{
+  switch (memory_kind) {
+    case MemoryKind::Host: return "Host";
+    case MemoryKind::Device: return "Device";
+    default: return "Unknown";
+  }
+}
+
+std::string_view to_string(ObservationKind kind) noexcept
+{
+  switch (kind) {
+    case ObservationKind::Logical: return "Logical";
+    default: return "Unknown";
+  }
+}
+
+std::uint64_t register_monitor(Monitor* monitor, ObservationKind kind)
+{
+  return Registry::instance().add(monitor, kind);
+}
+
+void unregister_monitor(std::uint64_t id) { Registry::instance().remove(id); }
+
+namespace detail {
+
+void expect_not_in_monitor()
+{
+  KVIKIO_EXPECT(
+    !Registry::in_monitor(), "a monitor must not call back into KvikIO", std::runtime_error);
+}
+
+void LogicalObservationRecorder::begin(IoBackend backend,
+                                       TransferDirection direction,
+                                       MemoryKind memory_kind,
+                                       std::size_t offset,
+                                       std::size_t size,
+                                       char const* http_method) noexcept
+{
+  // From 1, so that a default-constructed `Observation` (id 0) is never mistaken for a real one.
+  static std::atomic<std::uint64_t> id_counter{1};
+  _observation.backend     = backend;
+  _observation.direction   = direction;
+  _observation.memory_kind = memory_kind;
+  _observation.offset      = offset;
+  _observation.size        = size;
+  _observation.http_method = http_method;
+  _observation.id          = id_counter.fetch_add(1, std::memory_order_relaxed);
+  _observation.start       = now();
+  if (monitor_count.load(std::memory_order_acquire) != 0) { notify_started(_observation); }
+}
+
+void LogicalObservationRecorder::emit() noexcept
+{
+  _observation.end = now();
+  // A monitor registered after this operation began never saw its start and ignores the finish,
+  // which is why no flag is latched here.
+  notify_finished(_observation);
+}
+
+void notify_started(Observation const& observation) noexcept
+{
+  Registry::instance().started(observation);
+}
+
+void notify_finished(Observation const& observation) noexcept
+{
+  Registry::instance().finished(observation);
+}
+
+}  // namespace detail
+
+}  // namespace kvikio

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -723,7 +723,7 @@ RemoteHandle RemoteHandle::open(std::string const& url,
 }
 
 RemoteHandle::RemoteHandle(std::unique_ptr<RemoteEndpoint> endpoint, std::size_t nbytes)
-  : _endpoint{std::move(endpoint)}, _nbytes{nbytes}
+  : _endpoint{std::move(endpoint)}, _nbytes{nbytes}, _source{_endpoint->str()}
 {
   KVIKIO_NVTX_FUNC_RANGE();
 }
@@ -733,6 +733,7 @@ RemoteHandle::RemoteHandle(std::unique_ptr<RemoteEndpoint> endpoint)
   KVIKIO_NVTX_FUNC_RANGE();
   _nbytes   = endpoint->get_file_size();
   _endpoint = std::move(endpoint);
+  _source   = _endpoint->str();
 }
 
 RemoteEndpointType RemoteHandle::remote_endpoint_type() const noexcept
@@ -802,6 +803,7 @@ std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_off
                                               is_host_mem ? MemoryKind::HOST : MemoryKind::DEVICE,
                                               file_offset,
                                               size,
+                                              _source,
                                               "GET"};
   auto const nbytes = read_impl(buf, size, file_offset, is_host_mem);
   recorder.finish(nbytes);
@@ -885,6 +887,7 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
                         is_host_mem ? MemoryKind::HOST : MemoryKind::DEVICE,
                         file_offset,
                         size,
+                        _source,
                         "GET")
                     : nullptr;
 

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -781,8 +781,8 @@ namespace {
 /// WebHDFS is its own backend; everything else this handle speaks is HTTP(S), S3 included.
 [[nodiscard]] IoBackend remote_io_backend_of(RemoteEndpoint const& endpoint) noexcept
 {
-  return endpoint.remote_endpoint_type() == RemoteEndpointType::WEBHDFS ? IoBackend::RemoteHdfs
-                                                                        : IoBackend::RemoteHttp;
+  return endpoint.remote_endpoint_type() == RemoteEndpointType::WEBHDFS ? IoBackend::REMOTE_HDFS
+                                                                        : IoBackend::REMOTE_HTTP;
 }
 
 }  // namespace
@@ -798,8 +798,8 @@ std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_off
   detail::expect_not_in_monitor();
   bool const is_host_mem = is_host_memory(buf);
   detail::LogicalObservationRecorder recorder{remote_io_backend_of(*_endpoint),
-                                              TransferDirection::Read,
-                                              is_host_mem ? MemoryKind::Host : MemoryKind::Device,
+                                              TransferDirection::READ,
+                                              is_host_mem ? MemoryKind::HOST : MemoryKind::DEVICE,
                                               file_offset,
                                               size,
                                               "GET"};
@@ -881,8 +881,8 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
   auto recorder = detail::monitoring_enabled()
                     ? std::make_shared<detail::LogicalObservationRecorder>(
                         remote_io_backend_of(*_endpoint),
-                        TransferDirection::Read,
-                        is_host_mem ? MemoryKind::Host : MemoryKind::Device,
+                        TransferDirection::READ,
+                        is_host_mem ? MemoryKind::HOST : MemoryKind::DEVICE,
                         file_offset,
                         size,
                         "GET")

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -796,7 +796,6 @@ std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_off
   expect_read_in_bounds(size, file_offset);
 
   detail::expect_not_in_monitor();
-  // Classified once here and passed down, since the query is a CUDA driver call.
   bool const is_host_mem = is_host_memory(buf);
   detail::LogicalObservationRecorder recorder{remote_io_backend_of(*_endpoint),
                                               TransferDirection::Read,

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -23,6 +23,7 @@
 #include <kvikio/detail/io_event_barrier.hpp>
 #include <kvikio/detail/multi_poll_reactor.hpp>
 #include <kvikio/detail/nvtx.hpp>
+#include <kvikio/detail/observation_recorder.hpp>
 #include <kvikio/detail/parallel_operation.hpp>
 #include <kvikio/detail/remote_callback.hpp>
 #include <kvikio/detail/stream.hpp>
@@ -775,20 +776,57 @@ std::size_t callback_device_memory(char* data, std::size_t size, std::size_t nme
 }
 }  // namespace detail
 
+namespace {
+
+/// WebHDFS is its own backend; everything else this handle speaks is HTTP(S), S3 included.
+[[nodiscard]] IoBackend remote_io_backend_of(RemoteEndpoint const& endpoint) noexcept
+{
+  return endpoint.remote_endpoint_type() == RemoteEndpointType::WEBHDFS ? IoBackend::RemoteHdfs
+                                                                        : IoBackend::RemoteHttp;
+}
+
+}  // namespace
+
 std::size_t RemoteHandle::read(void* buf, std::size_t size, std::size_t file_offset)
 {
   KVIKIO_NVTX_FUNC_RANGE(size);
+  if (size == 0) { return 0; }
+  // Before the buffer is classified and before any monitor is told: a call rejected on its
+  // arguments never became an I/O operation.
+  expect_read_in_bounds(size, file_offset);
 
+  detail::expect_not_in_monitor();
+  // Classified once here and passed down, since the query is a CUDA driver call.
+  bool const is_host_mem = is_host_memory(buf);
+  detail::LogicalObservationRecorder recorder{remote_io_backend_of(*_endpoint),
+                                              TransferDirection::Read,
+                                              is_host_mem ? MemoryKind::Host : MemoryKind::Device,
+                                              file_offset,
+                                              size,
+                                              "GET"};
+  auto const nbytes = read_impl(buf, size, file_offset, is_host_mem);
+  recorder.finish(nbytes);
+  return nbytes;
+}
+
+void RemoteHandle::expect_read_in_bounds(std::size_t size, std::size_t file_offset) const
+{
+  if (!is_read_out_of_bounds(file_offset, size, _nbytes)) { return; }
+  std::stringstream ss;
+  ss << "cannot read " << file_offset << "+" << size << " bytes into a " << _nbytes
+     << " bytes file (" << _endpoint->str() << ")";
+  KVIKIO_FAIL(ss.str(), std::invalid_argument);
+}
+
+std::size_t RemoteHandle::read_impl(void* buf,
+                                    std::size_t size,
+                                    std::size_t file_offset,
+                                    bool is_host_mem)
+{
   if (size == 0) { return 0; }
 
-  if (is_read_out_of_bounds(file_offset, size, _nbytes)) {
-    std::stringstream ss;
-    ss << "cannot read " << file_offset << "+" << size << " bytes into a " << _nbytes
-       << " bytes file (" << _endpoint->str() << ")";
-    KVIKIO_FAIL(ss.str(), std::invalid_argument);
-  }
-  bool const is_host_mem = is_host_memory(buf);
-  auto curl              = create_curl_handle();
+  expect_read_in_bounds(size, file_offset);
+  auto curl = create_curl_handle();
   _endpoint->setopt(curl);
   _endpoint->setup_range_request(curl, file_offset, size);
 
@@ -834,6 +872,22 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
   KVIKIO_NVTX_FUNC_RANGE(size);
 
   if (size == 0) { return make_ready_future(static_cast<std::size_t>(0)); }
+  // Before the buffer is classified and before any monitor is told, as in `read()`. Both backends
+  // reject an out-of-range call here rather than one of them surfacing it through the future.
+  expect_read_in_bounds(size, file_offset);
+
+  detail::expect_not_in_monitor();
+  bool const is_host_mem = is_host_memory(buf);
+
+  auto recorder = detail::monitoring_enabled()
+                    ? std::make_shared<detail::LogicalObservationRecorder>(
+                        remote_io_backend_of(*_endpoint),
+                        TransferDirection::Read,
+                        is_host_mem ? MemoryKind::Host : MemoryKind::Device,
+                        file_offset,
+                        size,
+                        "GET")
+                    : nullptr;
 
   auto const io_backend = defaults::remote_io_backend();
 
@@ -841,20 +895,23 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
     KVIKIO_EXPECT(thread_pool != nullptr, "The thread pool must not be nullptr");
     auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
 
-    auto task = [this](void* devPtr_base,
-                       std::size_t size,
-                       std::size_t file_offset,
-                       std::size_t devPtr_offset) -> std::size_t {
-      return read(static_cast<char*>(devPtr_base) + devPtr_offset, size, file_offset);
+    auto task = [this, is_host_mem](void* devPtr_base,
+                                    std::size_t size,
+                                    std::size_t file_offset,
+                                    std::size_t devPtr_offset) -> std::size_t {
+      return read_impl(
+        static_cast<char*>(devPtr_base) + devPtr_offset, size, file_offset, is_host_mem);
     };
-    return detail::parallel_io(
-      task,
-      buf,
-      size,
-      file_offset,
-      task_size,
-      0,
-      {.thread_pool = thread_pool, .call_idx = call_idx, .nvtx_color = nvtx_color});
+    return detail::parallel_io(task,
+                               buf,
+                               size,
+                               file_offset,
+                               task_size,
+                               0,
+                               {.thread_pool = thread_pool,
+                                .call_idx    = call_idx,
+                                .nvtx_color  = nvtx_color,
+                                .recorder    = recorder});
   }
 
   KVIKIO_EXPECT(
@@ -875,14 +932,7 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
   //
   // Build all N transfers here, then hand them off in a single pool call.
   KVIKIO_EXPECT(task_size > 0, "`task_size` must be positive", std::invalid_argument);
-  if (is_read_out_of_bounds(file_offset, size, _nbytes)) {
-    std::stringstream ss;
-    ss << "cannot read " << file_offset << "+" << size << " bytes into a " << _nbytes
-       << " bytes file (" << _endpoint->str() << ")";
-    KVIKIO_FAIL(ss.str(), std::invalid_argument);
-  }
 
-  bool const is_host_mem = is_host_memory(buf);
   if (!is_host_mem) {
     KVIKIO_EXPECT(task_size <= defaults::bounce_buffer_size(),
                   "MULTI_POLL backend with a device buffer requires task_size <= "
@@ -892,8 +942,9 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
   }
 
   std::size_t const num_subranges = (task_size >= size) ? 1 : (size + task_size - 1) / task_size;
-  auto aggregate = std::make_shared<detail::RemoteMultiAggregateContext>(num_subranges);
-  auto fut       = aggregate->get_future();
+  auto aggregate      = std::make_shared<detail::RemoteMultiAggregateContext>(num_subranges);
+  aggregate->recorder = recorder;
+  auto fut            = aggregate->get_future();
 
   std::shared_ptr<detail::IoEventBarrier> io_event_barrier;
   if (!is_host_mem) {

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -873,8 +873,6 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
   KVIKIO_NVTX_FUNC_RANGE(size);
 
   if (size == 0) { return make_ready_future(static_cast<std::size_t>(0)); }
-  // Before the buffer is classified and before any monitor is told, as in `read()`. Both backends
-  // reject an out-of-range call here rather than one of them surfacing it through the future.
   expect_read_in_bounds(size, file_offset);
 
   detail::expect_not_in_monitor();

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -877,6 +877,25 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
 
   detail::expect_not_in_monitor();
   bool const is_host_mem = is_host_memory(buf);
+  auto const io_backend  = defaults::remote_io_backend();
+
+  // Everything that can reject the call is checked before the recorder exists, so a call that never
+  // reaches the I/O is not observed. The bounds check above does the same.
+  KVIKIO_EXPECT(task_size > 0, "`task_size` must be positive", std::invalid_argument);
+  if (io_backend == RemoteIOBackend::EASY_THREADPOOL) {
+    KVIKIO_EXPECT(thread_pool != nullptr, "The thread pool must not be nullptr");
+  } else {
+    KVIKIO_EXPECT(io_backend == RemoteIOBackend::MULTI_POLL,
+                  "Unknown RemoteIOBackend value",
+                  std::runtime_error);
+    if (!is_host_mem) {
+      KVIKIO_EXPECT(task_size <= defaults::bounce_buffer_size(),
+                    "MULTI_POLL backend with a device buffer requires task_size <= "
+                    "KVIKIO_BOUNCE_BUFFER_SIZE. Lower KVIKIO_TASK_SIZE or raise "
+                    "KVIKIO_BOUNCE_BUFFER_SIZE.",
+                    std::invalid_argument);
+    }
+  }
 
   auto recorder = detail::monitoring_enabled()
                     ? std::make_shared<detail::LogicalObservationRecorder>(
@@ -889,10 +908,7 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
                         "GET")
                     : nullptr;
 
-  auto const io_backend = defaults::remote_io_backend();
-
   if (io_backend == RemoteIOBackend::EASY_THREADPOOL) {
-    KVIKIO_EXPECT(thread_pool != nullptr, "The thread pool must not be nullptr");
     auto& [nvtx_color, call_idx] = detail::get_next_color_and_call_idx();
 
     auto task = [this, is_host_mem](void* devPtr_base,
@@ -914,9 +930,6 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
                                 .recorder    = recorder});
   }
 
-  KVIKIO_EXPECT(
-    io_backend == RemoteIOBackend::MULTI_POLL, "Unknown RemoteIOBackend value", std::runtime_error);
-
   // MULTI_POLL path. The lifecycle of one pread() call uses four cooperating pieces:
   // - One `RemoteMultiAggregateContext` per pread(). It owns the std::promise that the
   //   caller will observe and counts down as completions arrive.
@@ -931,16 +944,6 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
   //   of them fails).
   //
   // Build all N transfers here, then hand them off in a single pool call.
-  KVIKIO_EXPECT(task_size > 0, "`task_size` must be positive", std::invalid_argument);
-
-  if (!is_host_mem) {
-    KVIKIO_EXPECT(task_size <= defaults::bounce_buffer_size(),
-                  "MULTI_POLL backend with a device buffer requires task_size <= "
-                  "KVIKIO_BOUNCE_BUFFER_SIZE. Lower KVIKIO_TASK_SIZE or raise "
-                  "KVIKIO_BOUNCE_BUFFER_SIZE.",
-                  std::invalid_argument);
-  }
-
   std::size_t const num_subranges = (task_size >= size) ? 1 : (size + task_size - 1) / task_size;
   auto aggregate      = std::make_shared<detail::RemoteMultiAggregateContext>(num_subranges);
   aggregate->recorder = recorder;

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -80,6 +80,8 @@ kvikio_add_test(NAME FILE_UTILS_TEST SOURCES test_file_utils.cpp)
 
 kvikio_add_test(NAME IO_EVENT_BARRIER_TEST SOURCES test_io_event_barrier.cpp)
 
+kvikio_add_test(NAME OBSERVATION_TEST SOURCES test_observation.cpp)
+
 kvikio_add_test(NAME MMAP_TEST SOURCES test_mmap.cpp)
 
 kvikio_add_test(NAME CONCURRENT_REQUEST_LIMITER_TEST SOURCES test_concurrent_request_limiter.cpp)

--- a/cpp/tests/test_observation.cpp
+++ b/cpp/tests/test_observation.cpp
@@ -218,6 +218,34 @@ TEST_F(ObservationTest, one_call_is_one_observation)
   EXPECT_GT(o.end, o.start);
 }
 
+TEST_F(ObservationTest, an_observation_names_what_it_read)
+{
+  Recorder::Capture const capture;
+  std::vector<std::uint64_t> buffer(_data.size());
+  kvikio::FileHandle f{_filepath, "r"};
+  f.pread(buffer.data(), nbytes(), 0).get();
+
+  // Read while the handle is alive, since the handle owns the string the view points at.
+  auto const events = Recorder::instance().observations();
+  ASSERT_EQ(events.size(), 1);
+  // Without this a program reading many files cannot tell their operations apart.
+  EXPECT_EQ(events.front().source, _filepath);
+}
+
+TEST_F(ObservationTest, a_moved_handle_still_names_what_it_reads)
+{
+  Recorder::Capture const capture;
+  std::vector<std::uint64_t> buffer(_data.size());
+
+  kvikio::MmapHandle moved_from{_filepath, "r"};
+  kvikio::MmapHandle mapped{std::move(moved_from)};
+  mapped.read(buffer.data(), nbytes(), 0);
+
+  auto const events = Recorder::instance().observations();
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_EQ(events.front().source, _filepath) << "the path did not survive the move";
+}
+
 TEST_F(ObservationTest, the_span_covers_the_work_not_the_call)
 {
   // `pread()` returns as soon as the parts are submitted, so a naive recorder would stop the clock

--- a/cpp/tests/test_observation.cpp
+++ b/cpp/tests/test_observation.cpp
@@ -162,6 +162,25 @@ TEST(ObservationBasics, derived_quantities)
   EXPECT_EQ(empty.bytes_per_sec(), 0.0);
 }
 
+TEST(ObservationBasics, an_anchor_maps_the_clock_onto_the_wall_clock)
+{
+  // The two clocks are read as close together as the platform allows, so the anchor's own reading
+  // maps back onto itself.
+  auto const anchor = kvikio::ClockAnchor::now();
+  EXPECT_EQ(anchor.to_wall_clock(anchor.steady), anchor.wall);
+
+  // An offset on one clock is the same offset on the other.
+  auto const later = anchor.steady + std::chrono::seconds{5};
+  EXPECT_EQ(anchor.to_wall_clock(later) - anchor.wall, std::chrono::seconds{5});
+  auto const earlier = anchor.steady - std::chrono::milliseconds{250};
+  EXPECT_EQ(anchor.wall - anchor.to_wall_clock(earlier), std::chrono::milliseconds{250});
+
+  // An observation's timestamps land near the wall-clock time of the run, within the second it
+  // took to get here.
+  auto const now = std::chrono::system_clock::now();
+  EXPECT_LT(anchor.to_wall_clock(kvikio::detail::now()) - now, std::chrono::seconds{1});
+}
+
 TEST(ObservationBasics, a_null_monitor_is_rejected)
 {
   EXPECT_THROW(std::ignore = kvikio::register_monitor(nullptr), std::invalid_argument);

--- a/cpp/tests/test_observation.cpp
+++ b/cpp/tests/test_observation.cpp
@@ -218,6 +218,19 @@ TEST_F(ObservationTest, one_call_is_one_observation)
   EXPECT_GT(o.end, o.start);
 }
 
+TEST_F(ObservationTest, a_rejected_call_is_not_an_observation)
+{
+  std::vector<std::uint64_t> buffer(_data.size());
+  Recorder::Capture const capture;
+  kvikio::FileHandle f{_filepath, "r"};
+
+  // Rejected on its arguments, so it never reaches the file. An operation that did nothing is not
+  // one the monitors should be told about, in either direction.
+  EXPECT_THROW(f.pread(buffer.data(), nbytes(), 0, 0).get(), std::invalid_argument);
+  EXPECT_THROW(f.pwrite(buffer.data(), nbytes(), 0, 0).get(), std::invalid_argument);
+  EXPECT_TRUE(Recorder::instance().observations().empty());
+}
+
 TEST_F(ObservationTest, an_observation_names_what_it_read)
 {
   Recorder::Capture const capture;
@@ -522,6 +535,9 @@ TEST_F(ObservationTest, a_remote_read_rejected_on_its_arguments_is_not_observed)
   EXPECT_THROW(handle.read(&sink, 1024, 0), std::invalid_argument);
   // `pread()` rejects it at the call too, on either backend, rather than through the future.
   EXPECT_THROW(std::ignore = handle.pread(&sink, 1024, 0), std::invalid_argument);
+  // In bounds, but rejected on the task size, which is checked on both backends before anything
+  // is submitted.
+  EXPECT_THROW(std::ignore = handle.pread(&sink, 8, 0, 0), std::invalid_argument);
   EXPECT_TRUE(Recorder::instance().observations().empty());
 }
 #endif

--- a/cpp/tests/test_observation.cpp
+++ b/cpp/tests/test_observation.cpp
@@ -141,11 +141,11 @@ class ObservationTest : public testing::Test {
 
 TEST(ObservationBasics, enum_names)
 {
-  EXPECT_EQ(to_string(IoBackend::Posix), "Posix");
-  EXPECT_EQ(to_string(IoBackend::Mmap), "Mmap");
-  EXPECT_EQ(to_string(TransferDirection::Write), "Write");
-  EXPECT_EQ(to_string(MemoryKind::Device), "Device");
-  EXPECT_EQ(to_string(ObservationKind::Logical), "Logical");
+  EXPECT_EQ(to_string(IoBackend::POSIX), "POSIX");
+  EXPECT_EQ(to_string(IoBackend::MMAP), "MMAP");
+  EXPECT_EQ(to_string(TransferDirection::WRITE), "WRITE");
+  EXPECT_EQ(to_string(MemoryKind::DEVICE), "DEVICE");
+  EXPECT_EQ(to_string(ObservationKind::LOGICAL), "LOGICAL");
 }
 
 TEST(ObservationBasics, derived_quantities)
@@ -185,12 +185,12 @@ TEST_F(ObservationTest, one_call_is_one_observation)
   // However many reads KvikIO issued underneath, the caller made one call.
   ASSERT_EQ(events.size(), 1);
   auto const& o = events.front();
-  EXPECT_EQ(o.kind, ObservationKind::Logical);
-  EXPECT_EQ(o.direction, TransferDirection::Read);
-  EXPECT_EQ(o.memory_kind, MemoryKind::Host);
+  EXPECT_EQ(o.kind, ObservationKind::LOGICAL);
+  EXPECT_EQ(o.direction, TransferDirection::READ);
+  EXPECT_EQ(o.memory_kind, MemoryKind::HOST);
   // A host buffer goes through `posix_host_read` whatever the handle is capable of, so the label
   // must not follow the handle's compatibility mode.
-  EXPECT_EQ(o.backend, IoBackend::Posix);
+  EXPECT_EQ(o.backend, IoBackend::POSIX);
   EXPECT_EQ(o.offset, 0);
   EXPECT_EQ(o.size, nbytes());
   EXPECT_EQ(o.bytes_transferred, nbytes());
@@ -243,7 +243,7 @@ TEST_F(ObservationTest, a_write_is_described_as_a_write)
   }
   auto const events = Recorder::instance().observations();
   ASSERT_EQ(events.size(), 1);
-  EXPECT_EQ(events.front().direction, TransferDirection::Write);
+  EXPECT_EQ(events.front().direction, TransferDirection::WRITE);
   EXPECT_EQ(events.front().bytes_transferred, nbytes());
 }
 
@@ -257,7 +257,7 @@ TEST_F(ObservationTest, an_mmap_read_is_tagged_mmap)
   }
   auto const events = Recorder::instance().observations();
   ASSERT_EQ(events.size(), 1);
-  EXPECT_EQ(events.front().backend, IoBackend::Mmap);
+  EXPECT_EQ(events.front().backend, IoBackend::MMAP);
   EXPECT_EQ(events.front().bytes_transferred, sizeof(value));
 }
 
@@ -432,8 +432,8 @@ TEST_F(ObservationTest, a_sub_threshold_device_call_is_observed_as_posix)
 
   ASSERT_EQ(events.size(), 1);
   auto const& o = events.front();
-  EXPECT_EQ(o.backend, IoBackend::Posix);
-  EXPECT_EQ(o.memory_kind, MemoryKind::Device);
+  EXPECT_EQ(o.backend, IoBackend::POSIX);
+  EXPECT_EQ(o.memory_kind, MemoryKind::DEVICE);
   EXPECT_EQ(o.size, nbytes());
   EXPECT_EQ(o.bytes_transferred, nbytes()) << "the inline path reported no bytes";
   EXPECT_TRUE(o.ok);
@@ -454,8 +454,8 @@ TEST_F(ObservationTest, a_device_call_is_one_observation_too)
 
   ASSERT_EQ(events.size(), 1);
   auto const& o = events.front();
-  EXPECT_EQ(o.memory_kind, MemoryKind::Device);
-  EXPECT_EQ(o.direction, TransferDirection::Read);
+  EXPECT_EQ(o.memory_kind, MemoryKind::DEVICE);
+  EXPECT_EQ(o.direction, TransferDirection::READ);
   EXPECT_EQ(o.size, nbytes());
   EXPECT_EQ(o.bytes_transferred, nbytes());
   EXPECT_TRUE(o.ok);
@@ -490,7 +490,7 @@ TEST_F(ObservationTest, a_device_write_is_one_observation_too)
   auto const events = Recorder::instance().observations();
 
   ASSERT_EQ(events.size(), 1);
-  EXPECT_EQ(events.front().memory_kind, MemoryKind::Device);
-  EXPECT_EQ(events.front().direction, TransferDirection::Write);
+  EXPECT_EQ(events.front().memory_kind, MemoryKind::DEVICE);
+  EXPECT_EQ(events.front().direction, TransferDirection::WRITE);
   EXPECT_EQ(events.front().bytes_transferred, nbytes());
 }

--- a/cpp/tests/test_observation.cpp
+++ b/cpp/tests/test_observation.cpp
@@ -1,0 +1,493 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <mutex>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <kvikio/defaults.hpp>
+#include <kvikio/detail/observation_recorder.hpp>
+#include <kvikio/file_handle.hpp>
+#include <kvikio/mmap.hpp>
+#include <kvikio/observation.hpp>
+#ifdef KVIKIO_LIBCURL_FOUND
+#include <kvikio/remote_handle.hpp>
+#endif
+
+#include "utils/utils.hpp"
+
+using kvikio::IoBackend;
+using kvikio::MemoryKind;
+using kvikio::Observation;
+using kvikio::ObservationKind;
+using kvikio::TransferDirection;
+
+namespace {
+
+/// A monitor that keeps every observation it is given, for the duration of a `Capture`.
+class Recorder final : public kvikio::Monitor {
+ public:
+  static Recorder& instance()
+  {
+    static Recorder recorder;
+    return recorder;
+  }
+
+  void on_start(Observation const&) noexcept override {}
+
+  void on_finish(Observation const& observation) noexcept override
+  {
+    std::lock_guard const lock{_mutex};
+    if (_capturing) { _observations.push_back(observation); }
+  }
+
+  /**
+   * @brief RAII: register the recorder and capture observations, for the duration of a test.
+   */
+  class Capture {
+   public:
+    Capture()
+    {
+      auto& self = Recorder::instance();
+      {
+        std::lock_guard const lock{self._mutex};
+        self._observations.clear();
+        self._capturing = true;
+      }
+      self._id = kvikio::register_monitor(&self);
+    }
+    ~Capture()
+    {
+      auto& self = Recorder::instance();
+      kvikio::unregister_monitor(self._id);
+      std::lock_guard const lock{self._mutex};
+      self._capturing = false;
+    }
+    Capture(Capture const&)            = delete;
+    Capture& operator=(Capture const&) = delete;
+  };
+
+  [[nodiscard]] std::vector<Observation> observations() const
+  {
+    std::lock_guard const lock{_mutex};
+    return _observations;
+  }
+
+ private:
+  mutable std::mutex _mutex;
+  std::uint64_t _id{0};
+  bool _capturing{false};
+  std::vector<Observation> _observations;
+};
+
+}  // namespace
+
+/// A monitor that runs a callable on finish, so a test can express one inline.
+class CallbackMonitor final : public kvikio::Monitor {
+ public:
+  explicit CallbackMonitor(std::function<void(Observation const&)> on_finish)
+    : _on_finish{std::move(on_finish)}
+  {
+    _id = kvikio::register_monitor(this);
+  }
+  ~CallbackMonitor() override { kvikio::unregister_monitor(_id); }
+  CallbackMonitor(CallbackMonitor const&)            = delete;
+  CallbackMonitor& operator=(CallbackMonitor const&) = delete;
+
+ private:
+  void on_start(Observation const&) noexcept override {}
+  void on_finish(Observation const& observation) noexcept override { _on_finish(observation); }
+
+  std::function<void(Observation const&)> _on_finish;
+  std::uint64_t _id{0};
+};
+
+class ObservationTest : public testing::Test {
+ protected:
+  void SetUp() override
+  {
+    _filepath = _tmp_dir.path() / "test_observation";
+    _data.resize(_num_elements);
+    std::iota(_data.begin(), _data.end(), 0);
+
+    kvikio::FileHandle f{_filepath, "w"};
+    f.pwrite(_data.data(), nbytes()).get();
+  }
+
+  [[nodiscard]] std::size_t nbytes() const { return _data.size() * sizeof(std::uint64_t); }
+
+  kvikio::test::TempDir _tmp_dir{};
+  std::string _filepath;
+  // 8 MiB, enough to be split into several tasks at the default task size.
+  static constexpr std::size_t _num_elements = 1024ull * 1024ull;
+  std::vector<std::uint64_t> _data;
+};
+
+TEST(ObservationBasics, enum_names)
+{
+  EXPECT_EQ(to_string(IoBackend::Posix), "Posix");
+  EXPECT_EQ(to_string(IoBackend::Mmap), "Mmap");
+  EXPECT_EQ(to_string(TransferDirection::Write), "Write");
+  EXPECT_EQ(to_string(MemoryKind::Device), "Device");
+  EXPECT_EQ(to_string(ObservationKind::Logical), "Logical");
+}
+
+TEST(ObservationBasics, derived_quantities)
+{
+  Observation o{};
+  o.start             = kvikio::TimePoint{std::chrono::nanoseconds{1'000}};
+  o.end               = kvikio::TimePoint{std::chrono::nanoseconds{3'000}};
+  o.bytes_transferred = 4096;
+  EXPECT_EQ(o.duration(), std::chrono::nanoseconds{2'000});
+  EXPECT_DOUBLE_EQ(o.bytes_per_sec(), 4096.0 * 1e9 / 2000.0);
+
+  Observation const empty{};
+  EXPECT_EQ(empty.duration(), kvikio::Duration::zero());
+  EXPECT_EQ(empty.bytes_per_sec(), 0.0);
+}
+
+TEST(ObservationBasics, a_null_monitor_is_rejected)
+{
+  EXPECT_THROW(std::ignore = kvikio::register_monitor(nullptr), std::invalid_argument);
+}
+
+TEST(ObservationBasics, nothing_is_emitted_without_a_monitor)
+{
+  EXPECT_FALSE(kvikio::detail::monitoring_enabled());
+}
+
+TEST_F(ObservationTest, one_call_is_one_observation)
+{
+  std::vector<std::uint64_t> buffer(_data.size());
+  {
+    Recorder::Capture const capture;
+    kvikio::FileHandle f{_filepath, "r"};
+    f.pread(buffer.data(), nbytes(), 0).get();
+  }
+  auto const events = Recorder::instance().observations();
+
+  // However many reads KvikIO issued underneath, the caller made one call.
+  ASSERT_EQ(events.size(), 1);
+  auto const& o = events.front();
+  EXPECT_EQ(o.kind, ObservationKind::Logical);
+  EXPECT_EQ(o.direction, TransferDirection::Read);
+  EXPECT_EQ(o.memory_kind, MemoryKind::Host);
+  // A host buffer goes through `posix_host_read` whatever the handle is capable of, so the label
+  // must not follow the handle's compatibility mode.
+  EXPECT_EQ(o.backend, IoBackend::Posix);
+  EXPECT_EQ(o.offset, 0);
+  EXPECT_EQ(o.size, nbytes());
+  EXPECT_EQ(o.bytes_transferred, nbytes());
+  EXPECT_TRUE(o.ok);
+  EXPECT_NE(o.id, 0);
+  EXPECT_GT(o.end, o.start);
+}
+
+TEST_F(ObservationTest, the_span_covers_the_work_not_the_call)
+{
+  // `pread()` returns as soon as the parts are submitted, so a naive recorder would stop the clock
+  // far too early. The observation must cover the I/O, and must already be delivered by the time
+  // the caller's future is ready.
+  std::vector<std::uint64_t> buffer(_data.size());
+  kvikio::TimePoint after_submit{};
+  {
+    Recorder::Capture const capture;
+    kvikio::FileHandle f{_filepath, "r"};
+    auto future  = f.pread(buffer.data(), nbytes(), 0);
+    after_submit = kvikio::detail::now();
+    future.get();
+
+    auto const events = Recorder::instance().observations();
+    ASSERT_EQ(events.size(), 1) << "delivered before the future became ready";
+    EXPECT_GT(events.front().end, after_submit) << "the clock ran past the submit";
+  }
+}
+
+TEST_F(ObservationTest, ids_are_unique_per_call)
+{
+  std::vector<std::uint64_t> buffer(_data.size());
+  {
+    Recorder::Capture const capture;
+    kvikio::FileHandle f{_filepath, "r"};
+    f.pread(buffer.data(), nbytes(), 0).get();
+    f.pread(buffer.data(), nbytes(), 0).get();
+  }
+
+  auto const events = Recorder::instance().observations();
+  ASSERT_EQ(events.size(), 2);
+  EXPECT_NE(events[0].id, events[1].id);
+}
+
+TEST_F(ObservationTest, a_write_is_described_as_a_write)
+{
+  {
+    Recorder::Capture const capture;
+    kvikio::FileHandle f{_filepath + ".w", "w"};
+    f.pwrite(_data.data(), nbytes(), 0).get();
+  }
+  auto const events = Recorder::instance().observations();
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_EQ(events.front().direction, TransferDirection::Write);
+  EXPECT_EQ(events.front().bytes_transferred, nbytes());
+}
+
+TEST_F(ObservationTest, an_mmap_read_is_tagged_mmap)
+{
+  std::uint64_t value{0};
+  {
+    Recorder::Capture const capture;
+    kvikio::MmapHandle m{_filepath, "r"};
+    m.read(&value, sizeof(value), 0);
+  }
+  auto const events = Recorder::instance().observations();
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_EQ(events.front().backend, IoBackend::Mmap);
+  EXPECT_EQ(events.front().bytes_transferred, sizeof(value));
+}
+
+TEST_F(ObservationTest, a_failed_call_is_recorded_as_failed)
+{
+  {
+    Recorder::Capture const capture;
+    // Opened read-only, so the write fails and the failure must surface as one failed logical
+    // operation rather than being lost.
+    kvikio::FileHandle f{_filepath, "r"};
+    EXPECT_ANY_THROW(f.pwrite(_data.data(), nbytes(), 0).get());
+  }
+  auto const events = Recorder::instance().observations();
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_FALSE(events.front().ok);
+  EXPECT_EQ(events.front().bytes_transferred, 0);
+}
+
+TEST_F(ObservationTest, a_failed_blocking_call_is_recorded_as_failed)
+{
+  // The scope-bound use of the recorder: nobody calls `finish()`, so the destructor does it, and
+  // it has to notice that the scope is being left by an exception.
+  kvikio::test::DevBuffer<std::uint64_t> const dev{_data};
+  {
+    Recorder::Capture const capture;
+    kvikio::FileHandle f{_filepath, "r"};  // Read-only, so the write cannot succeed.
+    EXPECT_ANY_THROW(f.write(dev.ptr, nbytes(), 0, 0));
+  }
+  auto const events = Recorder::instance().observations();
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_FALSE(events.front().ok);
+  EXPECT_EQ(events.front().bytes_transferred, 0);
+}
+
+TEST_F(ObservationTest, a_monitor_that_calls_into_kvikio_is_rejected)
+{
+  std::vector<std::uint64_t> buffer(_data.size());
+  std::atomic<int> rejected{0};
+  {
+    CallbackMonitor const monitor{[&](Observation const&) {
+      try {
+        kvikio::FileHandle f{_filepath, "r"};
+        std::vector<std::uint64_t> nested(16);
+        f.pread(nested.data(), nested.size() * sizeof(std::uint64_t), 0).get();
+      } catch (std::runtime_error const&) {
+        ++rejected;
+      }
+    }};
+    kvikio::FileHandle f{_filepath, "r"};
+    f.pread(buffer.data(), nbytes(), 0).get();
+  }
+  EXPECT_GT(rejected.load(), 0);
+}
+
+TEST_F(ObservationTest, unregistering_waits_for_an_in_flight_monitor)
+{
+  std::vector<std::uint64_t> buffer(_data.size());
+  auto state = std::make_shared<std::atomic<int>>(0);
+  {
+    CallbackMonitor const monitor{[state](Observation const&) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      ++*state;
+    }};
+    kvikio::FileHandle f{_filepath, "r"};
+    f.pread(buffer.data(), nbytes(), 0).get();
+  }
+  // Once the monitor is gone, no thread can still be inside it.
+  EXPECT_EQ(state.use_count(), 1);
+}
+
+TEST_F(ObservationTest, a_monitor_can_correlate_a_start_with_its_completion)
+{
+  // Written against the public interface only: this is what a user's monitor looks like. It keys
+  // per-operation state by `Observation::id`, which is the reason the start carries the record
+  // rather than a bare timestamp, because two operations can be stamped in the same nanosecond.
+  class Correlator final : public kvikio::Monitor {
+   public:
+    void on_start(Observation const& o) noexcept override
+    {
+      std::lock_guard const lock{_mutex};
+      _open[o.id] = o.size;
+      // What is known at submission is set. What is not, is not.
+      if (o.size == 0 || o.id == 0 || o.start == kvikio::TimePoint{}) { ++_malformed; }
+      if (o.end != kvikio::TimePoint{} || o.bytes_transferred != 0) { ++_malformed; }
+    }
+
+    void on_finish(Observation const& o) noexcept override
+    {
+      std::lock_guard const lock{_mutex};
+      auto const it = _open.find(o.id);
+      if (it == _open.end()) {
+        ++_unmatched;
+        return;
+      }
+      if (it->second == o.size && o.end > o.start) { ++_matched; }
+      _open.erase(it);
+    }
+
+    std::mutex _mutex;
+    std::unordered_map<std::uint64_t, std::size_t> _open;
+    int _matched{0};
+    int _unmatched{0};
+    int _malformed{0};
+  };
+
+  Correlator correlator;
+  auto const id = kvikio::register_monitor(&correlator);
+  {
+    kvikio::FileHandle f{_filepath, "r"};
+    std::vector<std::uint64_t> buffer(_data.size());
+    f.pread(buffer.data(), nbytes(), 0).get();
+    f.pread(buffer.data(), nbytes(), 0).get();
+  }
+  kvikio::unregister_monitor(id);  // Blocks, so nothing is inside `correlator` after this.
+
+  EXPECT_EQ(correlator._matched, 2) << "a completion did not find its start";
+  EXPECT_EQ(correlator._unmatched, 0);
+  EXPECT_EQ(correlator._malformed, 0) << "the record at start was not as documented";
+  EXPECT_TRUE(correlator._open.empty()) << "an operation started and never completed";
+}
+
+TEST_F(ObservationTest, unregistering_a_monitor_from_a_callback_is_rejected)
+{
+  // The notification path holds the registry lock shared while a monitor runs, so taking it
+  // exclusively from inside would wait on the caller's own lock.
+  class Noop final : public kvikio::Monitor {
+   public:
+    void on_start(Observation const&) noexcept override {}
+    void on_finish(Observation const&) noexcept override {}
+  };
+  Noop noop;
+  auto const monitor_id = kvikio::register_monitor(&noop);
+
+  std::atomic<int> rejected{0};
+  {
+    CallbackMonitor const canary{[&](Observation const&) {
+      try {
+        kvikio::unregister_monitor(monitor_id);
+      } catch (std::runtime_error const&) {
+        ++rejected;
+      }
+    }};
+    kvikio::MmapHandle m{_filepath, "r"};
+    std::uint64_t sink{0};
+    m.read(&sink, sizeof(sink), 0);
+  }
+  EXPECT_EQ(rejected.load(), 1) << "the re-entrant removal was not rejected";
+
+  kvikio::unregister_monitor(monitor_id);  // Still registered, and removable from outside.
+}
+
+TEST_F(ObservationTest, a_sub_threshold_device_call_is_observed_as_posix)
+{
+  // Below the GDS threshold `pread()` skips the thread pool and reads inline through
+  // `posix_device_read`, a path that never reaches `parallel_io` and so has to close the
+  // observation itself.
+  kvikio::test::DevBuffer<std::uint64_t> const dev{_data.size()};
+  {
+    Recorder::Capture const capture;
+    kvikio::FileHandle f{_filepath, "r"};
+    f.pread(dev.ptr,
+            nbytes(),
+            0,
+            kvikio::defaults::task_size(),
+            /* gds_threshold = */ nbytes() + 1)
+      .get();
+  }
+  auto const events = Recorder::instance().observations();
+
+  ASSERT_EQ(events.size(), 1);
+  auto const& o = events.front();
+  EXPECT_EQ(o.backend, IoBackend::Posix);
+  EXPECT_EQ(o.memory_kind, MemoryKind::Device);
+  EXPECT_EQ(o.size, nbytes());
+  EXPECT_EQ(o.bytes_transferred, nbytes()) << "the inline path reported no bytes";
+  EXPECT_TRUE(o.ok);
+}
+
+TEST_F(ObservationTest, a_device_call_is_one_observation_too)
+{
+  // The device path fans the call out over the thread pool, and each worker performs a whole
+  // `read()` of its own part. Those must not surface as observations in their own right: the
+  // caller made one call, of the full size.
+  kvikio::test::DevBuffer<std::uint64_t> const dev{_data.size()};
+  {
+    Recorder::Capture const capture;
+    kvikio::FileHandle f{_filepath, "r"};
+    f.pread(dev.ptr, nbytes(), 0).get();
+  }
+  auto const events = Recorder::instance().observations();
+
+  ASSERT_EQ(events.size(), 1);
+  auto const& o = events.front();
+  EXPECT_EQ(o.memory_kind, MemoryKind::Device);
+  EXPECT_EQ(o.direction, TransferDirection::Read);
+  EXPECT_EQ(o.size, nbytes());
+  EXPECT_EQ(o.bytes_transferred, nbytes());
+  EXPECT_TRUE(o.ok);
+}
+
+#ifdef KVIKIO_LIBCURL_FOUND
+TEST_F(ObservationTest, a_remote_read_rejected_on_its_arguments_is_not_observed)
+{
+  // Opened with an explicit size and never contacted, so the read is rejected on its arguments
+  // before any I/O is attempted. A call that never became an operation must not be reported as a
+  // failed one.
+  Recorder::Capture const capture;
+  auto handle = kvikio::RemoteHandle::open(
+    "http://127.0.0.1:1/nothing", kvikio::RemoteEndpointType::HTTP, std::nullopt, 8);
+  std::uint64_t sink{0};
+
+  EXPECT_THROW(handle.read(&sink, 1024, 0), std::invalid_argument);
+  // `pread()` rejects it at the call too, on either backend, rather than through the future.
+  EXPECT_THROW(std::ignore = handle.pread(&sink, 1024, 0), std::invalid_argument);
+  EXPECT_TRUE(Recorder::instance().observations().empty());
+}
+#endif
+
+TEST_F(ObservationTest, a_device_write_is_one_observation_too)
+{
+  kvikio::test::DevBuffer<std::uint64_t> const dev{_data};
+  {
+    Recorder::Capture const capture;
+    kvikio::FileHandle f{_filepath + ".w", "w"};
+    f.pwrite(dev.ptr, nbytes(), 0).get();
+  }
+  auto const events = Recorder::instance().observations();
+
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_EQ(events.front().memory_kind, MemoryKind::Device);
+  EXPECT_EQ(events.front().direction, TransferDirection::Write);
+  EXPECT_EQ(events.front().bytes_transferred, nbytes());
+}

--- a/cpp/tests/test_observation.cpp
+++ b/cpp/tests/test_observation.cpp
@@ -338,9 +338,9 @@ TEST_F(ObservationTest, a_monitor_can_correlate_a_start_with_its_completion)
     void on_start(Observation const& o) noexcept override
     {
       std::lock_guard const lock{_mutex};
-      _open[o.id] = o.size;
-      // What is known at submission is set. What is not, is not.
-      if (o.size == 0 || o.id == 0 || o.start == kvikio::TimePoint{}) { ++_malformed; }
+      _open[o.id] = o;
+      // What is known at submission is set. What `on_start()` documents as not yet set, is not.
+      if (o.size == 0 || o.id == 0) { ++_malformed; }
       if (o.end != kvikio::TimePoint{} || o.bytes_transferred != 0) { ++_malformed; }
     }
 
@@ -352,12 +352,15 @@ TEST_F(ObservationTest, a_monitor_can_correlate_a_start_with_its_completion)
         ++_unmatched;
         return;
       }
-      if (it->second == o.size && o.end > o.start) { ++_matched; }
+      // The completion carries the same operation, now with an end.
+      if (it->second.size == o.size && it->second.start == o.start && o.end > o.start) {
+        ++_matched;
+      }
       _open.erase(it);
     }
 
     std::mutex _mutex;
-    std::unordered_map<std::uint64_t, std::size_t> _open;
+    std::unordered_map<std::uint64_t, Observation> _open;
     int _matched{0};
     int _unmatched{0};
     int _malformed{0};


### PR DESCRIPTION
This PR introduces a hook into monitoring KvikIO operations, with the goal of building statistics, Quent timelines, and whatever else wants to know what the I/O layer is doing. This PR is the base. A follow-up introduces a concrete `Monitor` that makes statistics easy to get.

The hook reports whole KvikIO operations (the logical level) so a `pread()` is a single observation however many reads the thread pool issued underneath. Physical operations can be added along the same path later, which could be the basis of #1016.

Each call produces a `kvikio::Observation`: its span, the offset and size etc. To receive them, derive from `kvikio::Monitor` and register it. A monitor is told when an operation *starts* as well as when it finishes.

```c++
// Example of a Monitor that tracks how many KvikIO operations are in flight at any moment.
class QueueDepth : public kvikio::Monitor {
  void on_start(kvikio::Observation const&) noexcept override { ++_in_flight; }
  void on_finish(kvikio::Observation const&) noexcept override { --_in_flight; }
  std::atomic<int> _in_flight{0};
};

QueueDepth gauge;
auto id = kvikio::register_monitor(&gauge);
```

### Overhead

Measured on my local workstation:

- **~3 ns per call when nobody is observing**, which is a gate check and a branch.
- **~60 ns per call when somebody is**, or 1 % of a 64 KiB `pread()`, and nothing detectable at a megabyte.

Confirmed against a real workload: cudf-polars PDS-H query 1 at scale 10, with and without a monitor attached, showed no difference outside noise.

### What is not observed

The cuFile asynchronous API on a GDS system, and the batch API, complete without KvikIO seeing it, so they emit nothing. Handling those needs a stream-completion callback, which is future work.

### Follow-up: statistics

The next PR adds `kvikio::statistics::SummaryMonitor`, which is a `Monitor` and nothing more:

```python
monitor = kvikio.SummaryMonitor()   # statistics are now on
...
print(monitor.get())
```

```
KvikIO I/O summary
  wall time            1.876 s
  busy time            366.592 ms (19.54 % of the wall time)
  busy bandwidth       8.95 GB/s
  operations           7970
  bytes requested      3.06 GiB
  bytes transferred    3.06 GiB
  errors               0
```
Those are real numbers, from a cudf-polars run, and they show a very useful `busy bandwidth`.  **8.95 GB/s** is the rate while KvikIO actually had work in flight, where dividing the same bytes by the wall clock would have said **1.75 GB/s** and described the query rather than the storage.

A `TimelineMonitor`, for *when* things happened rather than how much, is planned after that.
