### PR TITLE
X-ORG-1038: Fixup Sphinx build

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,7 +14,7 @@ KvikIO is a part of the `RAPIDS <https://rapids.ai/>`_ suite of open-source soft
 
 
 Contents
---------
+========
 
 .. toctree::
    :maxdepth: 1
@@ -26,4 +26,10 @@ Contents
    remote_file
    runtime_settings
    api
-   genindex
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
Contributes to #1038 

The `genindex` item in the Sphinx root ToC was breaking the [docs build](https://github.com/rapidsai/kvikio/actions/runs/32405988399/job/96546934444).

```
      File "/opt/conda/envs/docs/lib/python3.14/site-packages/sphinx/builders/html/__init__.py", line 1238, in handle_page
        raise ThemeError(msg) from exc
    sphinx.errors.ThemeError: An error happened in rendering the page api.
    Reason: KeyError('genindex')
```

Removing this special item from the root ToC unbreaks it.

We'll replace it with the same pattern used in other patterns, with `genindex`, `modindex` and `search` referenced via `:ref:...` directives, as in `cucim`: https://raw.githubusercontent.com/rapidsai/cucim/main/docs/source/index.rst