### PR TITLE
[DO NOT MERGE] ci: release catalog canary

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,8 +54,6 @@ jobs:
       node_type: cpu8
       date: ${{ inputs.date }}
       script: ci/build_cpp.sh
-      release-build-output: true
-      release-unit: conda:kvikio-cpp
       sha: ${{ inputs.sha }}
   python-build:
     needs: [build-details, cpp-build]
@@ -73,8 +71,6 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh
-      release-build-output: true
-      release-unit: conda:kvikio-python
       sha: ${{ inputs.sha }}
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
@@ -155,8 +151,6 @@ jobs:
       script: ci/build_wheel_cpp.sh
       package-name: libkvikio
       package-type: cpp
-      release-build-output: true
-      release-unit: wheel:libkvikio
   wheel-build-python:
     needs: [build-details, wheel-build-cpp]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -177,8 +171,6 @@ jobs:
       script: ci/build_wheel_python.sh
       package-name: kvikio
       package-type: python
-      release-build-output: true
-      release-unit: wheel:kvikio
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-publish-cpp:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,10 @@ on:
         description: "Canonical SHA-256 of the release train; required for release-candidate builds."
         type: string
         default: ""
+      candidate_release_tag:
+        description: "Final source tag created locally for a release-candidate build."
+        type: string
+        default: "v26.10.00"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build_type || 'branch' }}
@@ -60,6 +64,7 @@ jobs:
       script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
   python-build:
     needs: [build-details, cpp-build]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -80,6 +85,7 @@ jobs:
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
   upload-conda:
     needs: [cpp-build, python-build]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -158,6 +164,7 @@ jobs:
       package-name: libkvikio
       package-type: cpp
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
   wheel-build-python:
     needs: [build-details, wheel-build-cpp]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -181,6 +188,7 @@ jobs:
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
   wheel-publish-cpp:
     needs: wheel-build-cpp
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
@@ -54,6 +54,8 @@ jobs:
       node_type: cpu8
       date: ${{ inputs.date }}
       script: ci/build_cpp.sh
+      release-build-output: true
+      release-unit: conda:kvikio-cpp
       sha: ${{ inputs.sha }}
   python-build:
     needs: [build-details, cpp-build]
@@ -64,13 +66,15 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh
+      release-build-output: true
+      release-unit: conda:kvikio-python
       sha: ${{ inputs.sha }}
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
@@ -139,7 +143,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       build_type: ${{ inputs.build_type || 'branch' }}
@@ -151,6 +155,8 @@ jobs:
       script: ci/build_wheel_cpp.sh
       package-name: libkvikio
       package-type: cpp
+      release-build-output: true
+      release-unit: wheel:libkvikio
   wheel-build-python:
     needs: [build-details, wheel-build-cpp]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -160,7 +166,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
@@ -171,6 +177,8 @@ jobs:
       script: ci/build_wheel_python.sh
       package-name: kvikio
       package-type: python
+      release-build-output: true
+      release-unit: wheel:kvikio
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-publish-cpp:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,13 @@ on:
         required: true
         type: string
       build_type:
-        description: "build_type: one of [branch, nightly, pull-request]"
+        description: "build_type: one of [branch, nightly, pull-request, release-candidate]"
         type: string
         default: nightly
+      candidate_train_sha256:
+        description: "Canonical SHA-256 of the release train; required for release-candidate builds."
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build_type || 'branch' }}
@@ -55,6 +59,7 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
   python-build:
     needs: [build-details, cpp-build]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -74,6 +79,7 @@ jobs:
       sha: ${{ inputs.sha }}
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
   upload-conda:
     needs: [cpp-build, python-build]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -151,6 +157,7 @@ jobs:
       script: ci/build_wheel_cpp.sh
       package-name: libkvikio
       package-type: cpp
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
   wheel-build-python:
     needs: [build-details, wheel-build-cpp]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -173,6 +180,7 @@ jobs:
       package-type: python
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
   wheel-publish-cpp:
     needs: wheel-build-cpp
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -221,8 +221,6 @@ jobs:
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       node_type: cpu8
       script: ci/build_cpp.sh
-      release-build-output: true
-      release-unit: conda:kvikio-cpp
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -267,8 +265,6 @@ jobs:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_python.sh
-      release-build-output: true
-      release-unit: conda:kvikio-python
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   conda-python-tests:
@@ -363,8 +359,6 @@ jobs:
       script: ci/build_wheel_cpp.sh
       package-name: libkvikio
       package-type: cpp
-      release-build-output: true
-      release-unit: wheel:libkvikio
   wheel-python-build:
     needs: [build-details, wheel-cpp-build]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -382,8 +376,6 @@ jobs:
       script: ci/build_wheel_python.sh
       package-name: kvikio
       package-type: python
-      release-build-output: true
-      release-unit: wheel:kvikio
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-python-tests:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -215,12 +215,14 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       node_type: cpu8
       script: ci/build_cpp.sh
+      release-build-output: true
+      release-unit: conda:kvikio-cpp
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -260,11 +262,13 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_python.sh
+      release-build-output: true
+      release-unit: conda:kvikio-python
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   conda-python-tests:
@@ -350,7 +354,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       build_type: pull-request
@@ -359,6 +363,8 @@ jobs:
       script: ci/build_wheel_cpp.sh
       package-name: libkvikio
       package-type: cpp
+      release-build-output: true
+      release-unit: wheel:libkvikio
   wheel-python-build:
     needs: [build-details, wheel-cpp-build]
     secrets: inherit # zizmor: ignore[secrets-inherit]
@@ -368,7 +374,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
@@ -376,6 +382,8 @@ jobs:
       script: ci/build_wheel_python.sh
       package-name: kvikio
       package-type: python
+      release-build-output: true
+      release-unit: wheel:kvikio
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-python-tests:

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -30,8 +30,12 @@ source rapids-init-pip
 export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="${package_name}/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/wheel/preprocessor-cache"
 export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true
 
-RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" \
+if [[ "${RAPIDS_RELEASE_CANDIDATE:-false}" == "true" ]]; then
   rapids-generate-version > ./VERSION
+else
+  RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" \
+    rapids-generate-version > ./VERSION
+fi
 
 cd "${package_dir}"
 


### PR DESCRIPTION
**Posted by Codex (GPT-5.6) on behalf of Michael Sarahan; treat this LLM-generated content as a proposed implementation requiring human review.**

## Why

RAPIDS release-platform needs real, immutable build evidence before it can safely assemble a release candidate. This canary lets us validate that evidence against KvikIO’s existing Conda and wheel build jobs before asking every repository to adopt the shared release-catalog contract.

The branch deliberately uses the unmerged shared-workflows release-catalog revision. It must not merge until that shared workflow is approved and its contract is understood.

## Scope

The change only points KvikIO’s existing shared Conda and wheel workflow callers at the canary shared-workflows revision. Those workflows should continue to produce their normal artifacts and additionally emit the single `release-catalog-entries.json` companion per source artifact.

## Success criteria

A fresh build at this PR commit produces release-catalog companions whose source SHA and artifact name match the build. Release-platform will then consume those artifacts directly in an end-to-end collection test; it will not support the deprecated release-build-output contract.

## Validation

- Full applicable pre-commit checks for both changed workflow files
- `git diff --check`