### PR TITLE
pre-commit: update 'cython-lint' to 0.21.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.15.0
+    rev: v0.21.1
     hooks:
       - id: cython-lint
   - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/317

Updates `cython-lint` to 0.21.1, which contains a fix for compatibility with Cython 3.3.0+ (see linked issue for details).
