### PR TITLE
Share DNS caches among easy handles to prevent DNS storm

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -195,6 +195,7 @@ if(KvikIO_REMOTE_SUPPORT)
     SOURCES
     "src/hdfs.cpp"
     "src/remote_handle.cpp"
+    "src/detail/curl_share.cpp"
     "src/detail/http_retry.cpp"
     "src/detail/multi_poll_reactor.cpp"
     "src/detail/remote_callback.cpp"

--- a/cpp/include/kvikio/detail/curl_share.hpp
+++ b/cpp/include/kvikio/detail/curl_share.hpp
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <array>
+#include <mutex>
+
+#include <curl/curl.h>
+
+namespace kvikio::detail {
+
+/**
+ * @brief Process-wide libcurl share holding a single DNS cache for all curl handles.
+ *
+ * An attached share overrides the multi handle's cache. `curl_multi_add_handle()` installs its own
+ * only when the easy handle has none, so `CURLOPT_SHARE` has to be set first. Setting it in the
+ * `CurlHandle` constructor guarantees that order.
+ *
+ * Setting the environment variable `KVIKIO_REMOTE_SHARE_DNS_CACHE` to a false value to disable
+ * cache sharing and prevent this class from construction.
+ */
+class CurlShare {
+ public:
+  /**
+   * @brief Get the process-wide share, creating it on first use.
+   */
+  static CurlShare& instance();
+
+  CurlShare(CurlShare const&)            = delete;
+  CurlShare& operator=(CurlShare const&) = delete;
+  CurlShare(CurlShare&&)                 = delete;
+  CurlShare& operator=(CurlShare&&)      = delete;
+
+  /**
+   * @brief The underlying share handle, for `curl_easy_setopt(CURLOPT_SHARE, ...)`.
+   */
+  [[nodiscard]] CURLSH* handle() const noexcept { return _share; }
+
+ private:
+  CurlShare();
+  ~CurlShare() = default;
+
+  /**
+   * @brief `CURLSHOPT_LOCKFUNC` callback. Takes the mutex guarding @p data.
+   *
+   * libcurl does no locking of its own, so without this callback the shared cache is accessed
+   * unsynchronized.
+   *
+   * @param handle The easy handle libcurl is serving. Unused. The mutex is chosen by @p data alone.
+   * @param data Which shared cache is about to be accessed.
+   * @param access Whether libcurl wants shared or exclusive access. Unused, since the DNS cache is
+   * locked exclusively.
+   * @param userptr The `CurlShare*` registered via `CURLSHOPT_USERDATA`.
+   */
+  static void lock_callback(CURL* handle,
+                            curl_lock_data data,
+                            curl_lock_access access,
+                            void* userptr);
+
+  /**
+   * @brief `CURLSHOPT_UNLOCKFUNC` callback. Releases the mutex taken by `lock_callback`.
+   *
+   * @param handle The easy handle libcurl is serving. Unused.
+   * @param data Which shared cache was accessed.
+   * @param userptr The `CurlShare*` registered via `CURLSHOPT_USERDATA`.
+   */
+  static void unlock_callback(CURL* handle, curl_lock_data data, void* userptr);
+
+  CURLSH* _share{nullptr};
+  // One mutex per shareable data kind in libcurl
+  std::array<std::mutex, CURL_LOCK_DATA_LAST> _mutexes;
+};
+
+}  // namespace kvikio::detail

--- a/cpp/include/kvikio/detail/curl_share.hpp
+++ b/cpp/include/kvikio/detail/curl_share.hpp
@@ -12,35 +12,36 @@
 namespace kvikio::detail {
 
 /**
- * @brief Process-wide libcurl share holding a single DNS cache for all curl handles.
+ * @brief A libcurl share handle holding a DNS cache for a group of curl easy handles.
  *
- * An attached share overrides the multi handle's cache. `curl_multi_add_handle()` installs its own
- * only when the easy handle has none, so `CURLOPT_SHARE` has to be set first. Setting it in the
- * `CurlHandle` constructor guarantees that order.
+ * An attached share handle overrides the multi handle's cache. `curl_multi_add_handle()` installs
+ * its own only when the easy handle has none, so `CURLOPT_SHARE` has to be set first. Setting it in
+ * the `CurlHandle` constructor guarantees that order.
  *
  * Setting the environment variable `KVIKIO_REMOTE_SHARE_DNS_CACHE` to a false value to disable
  * cache sharing and prevent this class from construction.
  */
-class CurlShare {
+class CurlShareHandle {
  public:
   /**
-   * @brief Get the process-wide share, creating it on first use.
+   * @brief Get the share handle serving the calling thread, creating the share handles on first
+   * use.
    */
-  static CurlShare& instance();
+  static CurlShareHandle& share_handle_for_current_thread();
 
-  CurlShare(CurlShare const&)            = delete;
-  CurlShare& operator=(CurlShare const&) = delete;
-  CurlShare(CurlShare&&)                 = delete;
-  CurlShare& operator=(CurlShare&&)      = delete;
+  CurlShareHandle(CurlShareHandle const&)            = delete;
+  CurlShareHandle& operator=(CurlShareHandle const&) = delete;
+  CurlShareHandle(CurlShareHandle&&)                 = delete;
+  CurlShareHandle& operator=(CurlShareHandle&&)      = delete;
 
   /**
-   * @brief The underlying share handle, for `curl_easy_setopt(CURLOPT_SHARE, ...)`.
+   * @brief The underlying libcurl share handle, for `curl_easy_setopt(CURLOPT_SHARE, ...)`.
    */
-  [[nodiscard]] CURLSH* handle() const noexcept { return _share; }
+  [[nodiscard]] CURLSH* handle() const noexcept { return _share_handle; }
 
  private:
-  CurlShare();
-  ~CurlShare() = default;
+  CurlShareHandle();
+  ~CurlShareHandle() = default;
 
   /**
    * @brief `CURLSHOPT_LOCKFUNC` callback. Takes the mutex guarding @p data.
@@ -52,7 +53,7 @@ class CurlShare {
    * @param data Which shared cache is about to be accessed.
    * @param access Whether libcurl wants shared or exclusive access. Unused, since the DNS cache is
    * locked exclusively.
-   * @param userptr The `CurlShare*` registered via `CURLSHOPT_USERDATA`.
+   * @param userptr The `CurlShareHandle*` registered via `CURLSHOPT_USERDATA`.
    */
   static void lock_callback(CURL* handle,
                             curl_lock_data data,
@@ -64,11 +65,11 @@ class CurlShare {
    *
    * @param handle The easy handle libcurl is serving. Unused.
    * @param data Which shared cache was accessed.
-   * @param userptr The `CurlShare*` registered via `CURLSHOPT_USERDATA`.
+   * @param userptr The `CurlShareHandle*` registered via `CURLSHOPT_USERDATA`.
    */
   static void unlock_callback(CURL* handle, curl_lock_data data, void* userptr);
 
-  CURLSH* _share{nullptr};
+  CURLSH* _share_handle{nullptr};
   // One mutex per shareable data kind in libcurl
   std::array<std::mutex, CURL_LOCK_DATA_LAST> _mutexes;
 };

--- a/cpp/include/kvikio/detail/curl_share.hpp
+++ b/cpp/include/kvikio/detail/curl_share.hpp
@@ -51,8 +51,8 @@ class CurlShareHandle {
    *
    * @param handle The easy handle libcurl is serving. Unused. The mutex is chosen by @p data alone.
    * @param data Which shared cache is about to be accessed.
-   * @param access Whether libcurl wants shared or exclusive access. Unused, since the DNS cache is
-   * locked exclusively.
+   * @param access Whether libcurl wants shared or exclusive access. Unused. Libcurl always asks for
+   * exclusive access on the DNS cache.
    * @param userptr The `CurlShareHandle*` registered via `CURLSHOPT_USERDATA`.
    */
   static void lock_callback(CURL* handle,

--- a/cpp/include/kvikio/detail/curl_share.hpp
+++ b/cpp/include/kvikio/detail/curl_share.hpp
@@ -5,11 +5,15 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <mutex>
+#include <vector>
 
 #include <curl/curl.h>
 
 namespace kvikio::detail {
+
+class CurlShareRegistry;
 
 /**
  * @brief A libcurl share handle holding a DNS cache for a group of curl easy handles.
@@ -40,6 +44,8 @@ class CurlShareHandle {
   [[nodiscard]] CURLSH* handle() const noexcept { return _share_handle; }
 
  private:
+  friend class CurlShareRegistry;
+
   CurlShareHandle();
   ~CurlShareHandle() = default;
 
@@ -72,6 +78,46 @@ class CurlShareHandle {
   CURLSH* _share_handle{nullptr};
   // One mutex per shareable data kind in libcurl
   std::array<std::mutex, CURL_LOCK_DATA_LAST> _mutexes;
+};
+
+/**
+ * @brief Assigns threads to share handles, at most `max_threads_per_cache` threads per handle.
+ *
+ * A share handle is created only when every existing one is full. A slot returned by an exiting
+ * thread is taken by the next thread instead of adding a cache.
+ */
+class CurlShareRegistry {
+ public:
+  explicit CurlShareRegistry(std::size_t max_threads_per_cache);
+
+  /**
+   * @brief Take a slot in the first cache with room, or create a cache when all are full.
+   *
+   * @return The cache the caller is assigned to.
+   */
+  [[nodiscard]] CurlShareHandle* acquire();
+
+  /**
+   * @brief Return the slot taken by `acquire()`.
+   *
+   * @param handle The cache returned by `acquire()`.
+   */
+  void release(CurlShareHandle* handle);
+
+  /**
+   * @brief The number of caches created so far.
+   */
+  [[nodiscard]] std::size_t num_caches() const;
+
+ private:
+  struct Cache {
+    CurlShareHandle* handle;
+    std::size_t num_threads;  // How many live threads have been assigned to this cache.
+  };
+
+  std::size_t const _max_threads_per_cache;
+  mutable std::mutex _mutex;
+  std::vector<Cache> _caches;
 };
 
 }  // namespace kvikio::detail

--- a/cpp/include/kvikio/shim/libcurl.hpp
+++ b/cpp/include/kvikio/shim/libcurl.hpp
@@ -91,8 +91,12 @@ class CurlHandle {
    * @param handle An unused curl easy handle pointer, which is retained on destruction.
    * @param source_file Path of source file of the caller (for error messages).
    * @param source_line Line of source file of the caller (for error messages).
+   * @param use_shared_dns_cache Whether to use shared DNS caches provided by the share handles.
    */
-  CurlHandle(LibCurl::UniqueHandlePtr handle, std::string source_file, std::string source_line);
+  CurlHandle(LibCurl::UniqueHandlePtr handle,
+             std::string source_file,
+             std::string source_line,
+             bool use_shared_dns_cache = true);
   ~CurlHandle() noexcept;
 
   /**

--- a/cpp/src/detail/curl_share.cpp
+++ b/cpp/src/detail/curl_share.cpp
@@ -41,7 +41,7 @@ CurlShareHandle::CurlShareHandle()
 
   // Only DNS is shared.
   // libcurl does not support sharing connections, cookies or HSTS state across concurrent threads.
-  // TLS sessions are excluded here for a different reason. A resumption ticket is consumed by
+  // TLS sessions are excluded here for a different reason: A resumption ticket is consumed by
   // whoever takes it, and libcurl caps every cache at 2 tickets per remote endpoint. Merging the N
   // per-worker caches into one would therefore drop the tickets available for a given endpoint
   // from 2N to 2.

--- a/cpp/src/detail/curl_share.cpp
+++ b/cpp/src/detail/curl_share.cpp
@@ -4,8 +4,8 @@
  */
 
 #include <algorithm>
-#include <atomic>
 #include <cstddef>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -19,6 +19,38 @@
 #include <kvikio/shim/libcurl.hpp>
 
 namespace kvikio::detail {
+
+namespace {
+// Caches are added as threads arrive rather than allocated up front, because the number of
+// threads that will ask is not known here. Most are EASY_THREADPOOL workers, whose count can
+// change through `defaults::set_num_threads()`, and the rest are application threads opening a
+// remote file, which go through `get_file_size()`. MULTI_POLL never gets here, because it shares
+// DNS through its multi handle instead.
+struct Registry {
+  struct Cache {
+    CurlShareHandle* handle;
+    std::size_t num_threads;  // How many live threads have been assigned to this cache.
+  };
+  std::mutex mutex;
+  std::vector<Cache> caches;
+};
+
+// A thread holds its assignment for its lifetime and drops it on exit. Releasing is what bounds
+// the cache count: `defaults::set_num_threads()` resets the pool, destroying every worker and
+// starting new ones, and without it each generation would add caches that nothing goes on to
+// use.
+struct Assignment {
+  Registry* registry;
+  std::size_t cache_idx;
+  CurlShareHandle* handle;  // Held directly, because reading `caches` needs the lock.
+
+  ~Assignment()
+  {
+    std::lock_guard const lock(registry->mutex);
+    --registry->caches[cache_idx].num_threads;
+  }
+};
+}  // namespace
 
 CurlShareHandle::CurlShareHandle()
 {
@@ -49,25 +81,29 @@ CurlShareHandle::CurlShareHandle()
 
 CurlShareHandle& CurlShareHandle::share_handle_for_current_thread()
 {
-  static std::size_t const num_dns_caches = []() {
-    auto const result = getenv_or<std::size_t>("KVIKIO_REMOTE_NUM_DNS_CACHES", 16);
-    return std::max<std::size_t>(result, 1);
+  static std::size_t const max_threads_per_cache = []() {
+    ssize_t const env = getenv_or("KVIKIO_REMOTE_MAX_THREADS_PER_DNS_CACHE", ssize_t{16});
+    KVIKIO_EXPECT(env >= 0,
+                  "KVIKIO_REMOTE_MAX_THREADS_PER_DNS_CACHE has to be a non-negative integer",
+                  std::invalid_argument);
+    return std::max<std::size_t>(static_cast<std::size_t>(env), 1);
   }();
 
   // Leaked on purpose.
-  static std::vector<CurlShareHandle*> const share_handles = [&]() {
-    std::vector<CurlShareHandle*> result;
-    result.reserve(num_dns_caches);
-    for (std::size_t i = 0; i < num_dns_caches; ++i) {
-      result.push_back(new CurlShareHandle());
-    }
-    return result;
-  }();
+  static auto* const registry = new Registry{};
 
-  // Threads take the caches round-robin.
-  static std::atomic<std::size_t> counter{0};
-  thread_local std::size_t const assigned_index = counter.fetch_add(1) % num_dns_caches;
-  return *share_handles[assigned_index];
+  thread_local Assignment const assignment = [&]() {
+    std::lock_guard const lock(registry->mutex);
+    for (std::size_t i = 0; i < registry->caches.size(); ++i) {
+      if (registry->caches[i].num_threads < max_threads_per_cache) {
+        ++registry->caches[i].num_threads;
+        return Assignment{registry, i, registry->caches[i].handle};
+      }
+    }
+    registry->caches.push_back({new CurlShareHandle(), 1});
+    return Assignment{registry, registry->caches.size() - 1, registry->caches.back().handle};
+  }();
+  return *assignment.handle;
 }
 
 void CurlShareHandle::lock_callback(CURL* /*handle*/,

--- a/cpp/src/detail/curl_share.cpp
+++ b/cpp/src/detail/curl_share.cpp
@@ -33,7 +33,7 @@ struct Registry {
 struct Assignment {
   Registry* registry;
   std::size_t cache_idx;
-  CurlShareHandle* handle;  // Held directly, because reading `caches` needs the lock.
+  CurlShareHandle* handle;
 
   ~Assignment()
   {

--- a/cpp/src/detail/curl_share.cpp
+++ b/cpp/src/detail/curl_share.cpp
@@ -21,11 +21,6 @@
 namespace kvikio::detail {
 
 namespace {
-// Caches are added as threads arrive rather than allocated up front, because the number of
-// threads that will ask is not known here. Most are EASY_THREADPOOL workers, whose count can
-// change through `defaults::set_num_threads()`, and the rest are application threads opening a
-// remote file, which go through `get_file_size()`. MULTI_POLL never gets here, because it shares
-// DNS through its multi handle instead.
 struct Registry {
   struct Cache {
     CurlShareHandle* handle;
@@ -35,10 +30,6 @@ struct Registry {
   std::vector<Cache> caches;
 };
 
-// A thread holds its assignment for its lifetime and drops it on exit. Releasing is what bounds
-// the cache count: `defaults::set_num_threads()` resets the pool, destroying every worker and
-// starting new ones, and without it each generation would add caches that nothing goes on to
-// use.
 struct Assignment {
   Registry* registry;
   std::size_t cache_idx;

--- a/cpp/src/detail/curl_share.cpp
+++ b/cpp/src/detail/curl_share.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+
+#include <curl/curl.h>
+
+#include <kvikio/detail/curl_share.hpp>
+#include <kvikio/error.hpp>
+#include <kvikio/shim/libcurl.hpp>
+
+namespace kvikio::detail {
+
+CurlShare::CurlShare()
+{
+  // Force LibCurl global init before we create the share handle.
+  std::ignore = LibCurl::instance();
+
+  _share = curl_share_init();
+  KVIKIO_EXPECT(_share != nullptr, "curl_share_init() failed", std::runtime_error);
+
+  auto set_option = [this](CURLSHoption option, auto value) {
+    auto const sc = curl_share_setopt(_share, option, value);
+    KVIKIO_EXPECT(sc == CURLSHE_OK,
+                  std::string("curl_share_setopt: ") + curl_share_strerror(sc),
+                  std::runtime_error);
+  };
+  set_option(CURLSHOPT_LOCKFUNC, &CurlShare::lock_callback);
+  set_option(CURLSHOPT_UNLOCKFUNC, &CurlShare::unlock_callback);
+  set_option(CURLSHOPT_USERDATA, this);
+  set_option(CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+
+  // Only DNS is shared.
+  // libcurl does not support sharing connections, cookies or HSTS state across concurrent threads.
+  // TLS sessions are excluded here for a different reason. A resumption ticket is consumed by
+  // whoever takes it, and libcurl caps every cache at 2 tickets per remote endpoint. Merging the N
+  // per-worker caches into one would therefore drop the tickets available for a given endpoint
+  // from 2N to 2.
+}
+
+CurlShare& CurlShare::instance()
+{
+  // Leaked on purpose.
+  static CurlShare* inst = new CurlShare();
+  return *inst;
+}
+
+void CurlShare::lock_callback(CURL* /*handle*/,
+                              curl_lock_data data,
+                              curl_lock_access /*access*/,
+                              void* userptr)
+{
+  auto* share = static_cast<CurlShare*>(userptr);
+  share->_mutexes[static_cast<std::size_t>(data)].lock();
+}
+
+void CurlShare::unlock_callback(CURL* /*handle*/, curl_lock_data data, void* userptr)
+{
+  auto* share = static_cast<CurlShare*>(userptr);
+  share->_mutexes[static_cast<std::size_t>(data)].unlock();
+}
+
+}  // namespace kvikio::detail

--- a/cpp/src/detail/curl_share.cpp
+++ b/cpp/src/detail/curl_share.cpp
@@ -3,35 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <stdexcept>
 #include <string>
 #include <tuple>
+#include <vector>
 
 #include <curl/curl.h>
 
+#include <kvikio/defaults.hpp>
 #include <kvikio/detail/curl_share.hpp>
 #include <kvikio/error.hpp>
 #include <kvikio/shim/libcurl.hpp>
 
 namespace kvikio::detail {
 
-CurlShare::CurlShare()
+CurlShareHandle::CurlShareHandle()
 {
   // Force LibCurl global init before we create the share handle.
   std::ignore = LibCurl::instance();
 
-  _share = curl_share_init();
-  KVIKIO_EXPECT(_share != nullptr, "curl_share_init() failed", std::runtime_error);
+  _share_handle = curl_share_init();
+  KVIKIO_EXPECT(_share_handle != nullptr, "curl_share_init() failed", std::runtime_error);
 
   auto set_option = [this](CURLSHoption option, auto value) {
-    auto const sc = curl_share_setopt(_share, option, value);
+    auto const sc = curl_share_setopt(_share_handle, option, value);
     KVIKIO_EXPECT(sc == CURLSHE_OK,
                   std::string("curl_share_setopt: ") + curl_share_strerror(sc),
                   std::runtime_error);
   };
-  set_option(CURLSHOPT_LOCKFUNC, &CurlShare::lock_callback);
-  set_option(CURLSHOPT_UNLOCKFUNC, &CurlShare::unlock_callback);
+  set_option(CURLSHOPT_LOCKFUNC, &CurlShareHandle::lock_callback);
+  set_option(CURLSHOPT_UNLOCKFUNC, &CurlShareHandle::unlock_callback);
   set_option(CURLSHOPT_USERDATA, this);
   set_option(CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
 
@@ -43,26 +47,42 @@ CurlShare::CurlShare()
   // from 2N to 2.
 }
 
-CurlShare& CurlShare::instance()
+CurlShareHandle& CurlShareHandle::share_handle_for_current_thread()
 {
+  static std::size_t const num_dns_caches = []() {
+    auto const result = getenv_or<std::size_t>("KVIKIO_REMOTE_NUM_DNS_CACHES", 16);
+    return std::max<std::size_t>(result, 1);
+  }();
+
   // Leaked on purpose.
-  static CurlShare* inst = new CurlShare();
-  return *inst;
+  static std::vector<CurlShareHandle*> const share_handles = [&]() {
+    std::vector<CurlShareHandle*> result;
+    result.reserve(num_dns_caches);
+    for (std::size_t i = 0; i < num_dns_caches; ++i) {
+      result.push_back(new CurlShareHandle());
+    }
+    return result;
+  }();
+
+  // Threads take the caches round-robin.
+  static std::atomic<std::size_t> counter{0};
+  thread_local std::size_t const assigned_index = counter.fetch_add(1) % num_dns_caches;
+  return *share_handles[assigned_index];
 }
 
-void CurlShare::lock_callback(CURL* /*handle*/,
-                              curl_lock_data data,
-                              curl_lock_access /*access*/,
-                              void* userptr)
+void CurlShareHandle::lock_callback(CURL* /*handle*/,
+                                    curl_lock_data data,
+                                    curl_lock_access /*access*/,
+                                    void* userptr)
 {
-  auto* share = static_cast<CurlShare*>(userptr);
-  share->_mutexes[static_cast<std::size_t>(data)].lock();
+  auto* share_handle = static_cast<CurlShareHandle*>(userptr);
+  share_handle->_mutexes[static_cast<std::size_t>(data)].lock();
 }
 
-void CurlShare::unlock_callback(CURL* /*handle*/, curl_lock_data data, void* userptr)
+void CurlShareHandle::unlock_callback(CURL* /*handle*/, curl_lock_data data, void* userptr)
 {
-  auto* share = static_cast<CurlShare*>(userptr);
-  share->_mutexes[static_cast<std::size_t>(data)].unlock();
+  auto* share_handle = static_cast<CurlShareHandle*>(userptr);
+  share_handle->_mutexes[static_cast<std::size_t>(data)].unlock();
 }
 
 }  // namespace kvikio::detail

--- a/cpp/src/detail/curl_share.cpp
+++ b/cpp/src/detail/curl_share.cpp
@@ -21,25 +21,12 @@
 namespace kvikio::detail {
 
 namespace {
-struct Registry {
-  struct Cache {
-    CurlShareHandle* handle;
-    std::size_t num_threads;  // How many live threads have been assigned to this cache.
-  };
-  std::mutex mutex;
-  std::vector<Cache> caches;
-};
 
 struct Assignment {
-  Registry* registry;
-  std::size_t cache_idx;
+  CurlShareRegistry* registry;
   CurlShareHandle* handle;
 
-  ~Assignment()
-  {
-    std::lock_guard const lock(registry->mutex);
-    --registry->caches[cache_idx].num_threads;
-  }
+  ~Assignment() { registry->release(handle); }
 };
 }  // namespace
 
@@ -70,6 +57,44 @@ CurlShareHandle::CurlShareHandle()
   // from 2N to 2.
 }
 
+CurlShareRegistry::CurlShareRegistry(std::size_t max_threads_per_cache)
+  : _max_threads_per_cache{max_threads_per_cache}
+{
+  KVIKIO_EXPECT(
+    max_threads_per_cache > 0, "`max_threads_per_cache` must be positive", std::invalid_argument);
+}
+
+CurlShareHandle* CurlShareRegistry::acquire()
+{
+  std::lock_guard const lock(_mutex);
+  for (auto& cache : _caches) {
+    if (cache.num_threads < _max_threads_per_cache) {
+      ++cache.num_threads;
+      return cache.handle;
+    }
+  }
+  // Leaked on purpose.
+  _caches.push_back({new CurlShareHandle(), 1});
+  return _caches.back().handle;
+}
+
+void CurlShareRegistry::release(CurlShareHandle* handle)
+{
+  std::lock_guard const lock(_mutex);
+  for (auto& cache : _caches) {
+    if (cache.handle == handle) {
+      --cache.num_threads;
+      return;
+    }
+  }
+}
+
+std::size_t CurlShareRegistry::num_caches() const
+{
+  std::lock_guard const lock(_mutex);
+  return _caches.size();
+}
+
 CurlShareHandle& CurlShareHandle::share_handle_for_current_thread()
 {
   static std::size_t const max_threads_per_cache = []() {
@@ -81,19 +106,9 @@ CurlShareHandle& CurlShareHandle::share_handle_for_current_thread()
   }();
 
   // Leaked on purpose.
-  static auto* const registry = new Registry{};
+  static auto* const registry = new CurlShareRegistry(max_threads_per_cache);
 
-  thread_local Assignment const assignment = [&]() {
-    std::lock_guard const lock(registry->mutex);
-    for (std::size_t i = 0; i < registry->caches.size(); ++i) {
-      if (registry->caches[i].num_threads < max_threads_per_cache) {
-        ++registry->caches[i].num_threads;
-        return Assignment{registry, i, registry->caches[i].handle};
-      }
-    }
-    registry->caches.push_back({new CurlShareHandle(), 1});
-    return Assignment{registry, registry->caches.size() - 1, registry->caches.back().handle};
-  }();
+  thread_local Assignment const assignment{registry, registry->acquire()};
   return *assignment.handle;
 }
 

--- a/cpp/src/remote_handle.cpp
+++ b/cpp/src/remote_handle.cpp
@@ -966,9 +966,11 @@ std::future<std::size_t> RemoteHandle::pread(void* buf,
   for (std::size_t i = 0; i < num_subranges; ++i) {
     std::size_t const subrange_size = std::min(task_size, remaining);
     auto transfer                   = std::make_unique<detail::RemoteMultiTransfer>();
-    transfer->curl                  = std::make_unique<CurlHandle>(LibCurl::instance().get_handle(),
+    // MULTI_POLL uses multi handle's DNS cache sharing, and does not need the share handle.
+    transfer->curl = std::make_unique<CurlHandle>(LibCurl::instance().get_handle(),
                                                   detail::fix_conda_file_path_hack(__FILE__),
-                                                  KVIKIO_STRINGIFY(__LINE__));
+                                                  KVIKIO_STRINGIFY(__LINE__),
+                                                  /* use_shared_dns_cache = */ false);
     _endpoint->setopt(*transfer->curl);
     _endpoint->setup_range_request(*transfer->curl, cur_off, subrange_size);
     transfer->ctx.size     = subrange_size;

--- a/cpp/src/shim/libcurl.cpp
+++ b/cpp/src/shim/libcurl.cpp
@@ -16,6 +16,7 @@
 #include <curl/curl.h>
 
 #include <kvikio/defaults.hpp>
+#include <kvikio/detail/curl_share.hpp>
 #include <kvikio/detail/http_retry.hpp>
 #include <kvikio/detail/parallel_operation.hpp>
 #include <kvikio/detail/posix_io.hpp>
@@ -103,6 +104,10 @@ CurlHandle::CurlHandle(LibCurl::UniqueHandlePtr handle,
 
   // Make requests time out after `value` seconds.
   setopt(CURLOPT_TIMEOUT, kvikio::defaults::http_timeout());
+
+  // Resolve a hostname once per process rather than once per worker.
+  static bool const share_dns_cache = getenv_or("KVIKIO_REMOTE_SHARE_DNS_CACHE", true);
+  if (share_dns_cache) { setopt(CURLOPT_SHARE, detail::CurlShare::instance().handle()); }
 
   // Optionally enable verbose output if it's configured.
   auto const verbose = getenv_or("KVIKIO_REMOTE_VERBOSE", false);

--- a/cpp/src/shim/libcurl.cpp
+++ b/cpp/src/shim/libcurl.cpp
@@ -88,7 +88,8 @@ void LibCurl::retain_handle(UniqueHandlePtr handle)
 
 CurlHandle::CurlHandle(LibCurl::UniqueHandlePtr handle,
                        std::string source_file,
-                       std::string source_line)
+                       std::string source_line,
+                       bool use_shared_dns_cache)
   : _handle{std::move(handle)}
 {
   // Need CURLOPT_NOSIGNAL to support threading, see
@@ -105,9 +106,13 @@ CurlHandle::CurlHandle(LibCurl::UniqueHandlePtr handle,
   // Make requests time out after `value` seconds.
   setopt(CURLOPT_TIMEOUT, kvikio::defaults::http_timeout());
 
-  // Resolve a hostname once per process rather than once per worker.
+  // Resolve a hostname once per DNS cache.
   static bool const share_dns_cache = getenv_or("KVIKIO_REMOTE_SHARE_DNS_CACHE", true);
-  if (share_dns_cache) { setopt(CURLOPT_SHARE, detail::CurlShare::instance().handle()); }
+  if (use_shared_dns_cache && share_dns_cache) {
+    setopt(CURLOPT_SHARE, detail::CurlShareHandle::share_handle_for_current_thread().handle());
+  } else {
+    setopt(CURLOPT_SHARE, static_cast<CURLSH*>(nullptr));
+  }
 
   // Optionally enable verbose output if it's configured.
   auto const verbose = getenv_or("KVIKIO_REMOTE_VERBOSE", false);

--- a/cpp/src/shim/libcurl.cpp
+++ b/cpp/src/shim/libcurl.cpp
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 #include <curl/curl.h>
@@ -123,7 +124,11 @@ CurlHandle::CurlHandle(LibCurl::UniqueHandlePtr handle,
   detail::set_up_ca_paths(*this);
 }
 
-CurlHandle::~CurlHandle() noexcept { LibCurl::instance().retain_handle(std::move(_handle)); }
+CurlHandle::~CurlHandle() noexcept
+{
+  std::ignore = curl_easy_setopt(_handle.get(), CURLOPT_SHARE, static_cast<CURLSH*>(nullptr));
+  LibCurl::instance().retain_handle(std::move(_handle));
+}
 
 CURL* CurlHandle::handle() noexcept { return _handle.get(); }
 

--- a/cpp/src/shim/libcurl.cpp
+++ b/cpp/src/shim/libcurl.cpp
@@ -110,8 +110,12 @@ CurlHandle::CurlHandle(LibCurl::UniqueHandlePtr handle,
   setopt(CURLOPT_TIMEOUT, kvikio::defaults::http_timeout());
 
   // Resolve a hostname once per DNS cache.
-  static bool const share_dns_cache = getenv_or("KVIKIO_REMOTE_SHARE_DNS_CACHE", true);
-  if (use_shared_dns_cache && share_dns_cache) {
+  bool share_dns_cache = false;
+  if (use_shared_dns_cache) {
+    static bool const env = getenv_or("KVIKIO_REMOTE_SHARE_DNS_CACHE", true);
+    share_dns_cache       = env;
+  }
+  if (share_dns_cache) {
     setopt(CURLOPT_SHARE, detail::CurlShareHandle::share_handle_for_current_thread().handle());
   } else {
     setopt(CURLOPT_SHARE, static_cast<CURLSH*>(nullptr));

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -169,6 +169,7 @@ if(KvikIO_REMOTE_SUPPORT)
   kvikio_add_test(NAME HDFS_TEST SOURCES test_hdfs.cpp utils/hdfs_helper.cpp)
   kvikio_add_test(NAME TLS_TEST SOURCES test_tls.cpp utils/env.cpp)
   kvikio_add_test(NAME URL_TEST SOURCES test_url.cpp)
+  kvikio_add_test(NAME CURL_SHARE_TEST SOURCES test_curl_share.cpp)
   kvikio_add_test(NAME MULTI_POLL_REACTOR_TEST SOURCES test_multi_poll_reactor.cpp utils/env.cpp)
 endif()
 

--- a/cpp/tests/test_curl_share.cpp
+++ b/cpp/tests/test_curl_share.cpp
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstddef>
+#include <stdexcept>
+#include <thread>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <kvikio/detail/curl_share.hpp>
+
+using kvikio::detail::CurlShareRegistry;
+
+TEST(CurlShareRegistryTest, a_cache_is_filled_before_another_is_created)
+{
+  CurlShareRegistry registry{2};
+  EXPECT_EQ(registry.num_caches(), std::size_t{0});
+
+  auto* const first  = registry.acquire();
+  auto* const second = registry.acquire();
+  EXPECT_EQ(registry.num_caches(), std::size_t{1});
+  EXPECT_EQ(first, second) << "threads below the limit share one cache";
+
+  auto* const third = registry.acquire();
+  EXPECT_EQ(registry.num_caches(), std::size_t{2}) << "a full cache forces a new one";
+  EXPECT_NE(third, first);
+}
+
+TEST(CurlShareRegistryTest, a_released_slot_is_reused)
+{
+  CurlShareRegistry registry{1};
+  auto* const first = registry.acquire();
+  registry.release(first);
+
+  auto* const second = registry.acquire();
+  EXPECT_EQ(registry.num_caches(), std::size_t{1}) << "the free slot is taken instead of adding";
+  EXPECT_EQ(second, first);
+}
+
+TEST(CurlShareRegistryTest, concurrent_threads_do_not_oversubscribe_a_cache)
+{
+  constexpr std::size_t num_threads           = 8;
+  constexpr std::size_t max_threads_per_cache = 3;
+  CurlShareRegistry registry{max_threads_per_cache};
+
+  std::vector<std::thread> threads;
+  for (std::size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&registry] { std::ignore = registry.acquire(); });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  // A cache is added only once every existing one is full.
+  EXPECT_EQ(registry.num_caches(), std::size_t{3});
+}
+
+TEST(CurlShareRegistryTest, a_cache_must_hold_at_least_one_thread)
+{
+  EXPECT_THROW(CurlShareRegistry{0}, std::invalid_argument);
+}

--- a/docs/source/runtime_settings.rst
+++ b/docs/source/runtime_settings.rst
@@ -103,14 +103,16 @@ The global budget is divided into an equal private share per reactor (``KVIKIO_R
 
 The even split assumes sub-ranges are spread across reactors, which holds under ``PER_CHUNK``. Under ``PER_PREAD`` all sub-ranges of one large :py:func:`kvikio.RemoteFile.pread` land on a single reactor, so that read is effectively limited to one reactor's share while the others stay idle.
 
-Shared DNS Caches ``KVIKIO_REMOTE_SHARE_DNS_CACHE``, ``KVIKIO_REMOTE_NUM_DNS_CACHES``
---------------------------------------------------------------------------------------
+Shared DNS Caches ``KVIKIO_REMOTE_SHARE_DNS_CACHE``, ``KVIKIO_REMOTE_MAX_THREADS_PER_DNS_CACHE``
+-------------------------------------------------------------------------------------------------
 
 Let the easy handles in ``EASY_THREADPOOL`` share DNS caches to reduce lookups.
 
 Sharing is enabled by default. Set ``KVIKIO_REMOTE_SHARE_DNS_CACHE`` to ``false``, ``off``, ``no``, or ``0`` (case-insensitive) to disable sharing.
 
-``KVIKIO_REMOTE_NUM_DNS_CACHES`` sets how many DNS caches the process creates. The default value is ``16``, and a value below ``1`` is clamped to ``1``. Each worker thread is assigned one cache round-robin on first use, which means roughly ``KVIKIO_NTHREADS`` divided by this count threads share a cache.
+``KVIKIO_REMOTE_MAX_THREADS_PER_DNS_CACHE`` sets how many threads may share one DNS cache. The default value is ``16``. A thread is assigned a cache on first use and keeps it for its lifetime, and a new cache is created once the current one is full. The total number of caches is roughly the number of threads divided by this value.
+
+Each cache holds one DNS result per host, which for S3 is a set of addresses drawn afresh on every resolution. Smaller ``KVIKIO_REMOTE_MAX_THREADS_PER_DNS_CACHE`` value leads to more caches, spreading connections over more addresses, at the cost of more lookups and less reuse. A thread returns its cache assignment when it exits, and resizing the thread pool with :py:func:`kvikio.defaults.set` reuses the existing caches rather than adding more.
 
 Both variables are read only from the environment, and only when the caches are first used. Neither has any effect under ``MULTI_POLL``.
 

--- a/docs/source/runtime_settings.rst
+++ b/docs/source/runtime_settings.rst
@@ -103,6 +103,18 @@ The global budget is divided into an equal private share per reactor (``KVIKIO_R
 
 The even split assumes sub-ranges are spread across reactors, which holds under ``PER_CHUNK``. Under ``PER_PREAD`` all sub-ranges of one large :py:func:`kvikio.RemoteFile.pread` land on a single reactor, so that read is effectively limited to one reactor's share while the others stay idle.
 
+Shared DNS Caches ``KVIKIO_REMOTE_SHARE_DNS_CACHE``, ``KVIKIO_REMOTE_NUM_DNS_CACHES``
+--------------------------------------------------------------------------------------
+
+Let the easy handles in ``EASY_THREADPOOL`` share DNS caches to reduce lookups.
+
+Sharing is enabled by default. Set ``KVIKIO_REMOTE_SHARE_DNS_CACHE`` to ``false``, ``off``, ``no``, or ``0`` (case-insensitive) to disable sharing.
+
+``KVIKIO_REMOTE_NUM_DNS_CACHES`` determines how many DNS caches are used. The default value is ``16``. The count also determines how many server addresses the process connects to, since a cache holds one address list and libcurl always connects to its first entry.
+
+Both variables are read only from the environment, and only when the caches are first used. Neither has any effect under ``MULTI_POLL``.
+
+
 CA bundle file and CA directory ``CURL_CA_BUNDLE``, ``SSL_CERT_FILE``, ``SSL_CERT_DIR``
 ---------------------------------------------------------------------------------------
 

--- a/docs/source/runtime_settings.rst
+++ b/docs/source/runtime_settings.rst
@@ -110,7 +110,7 @@ Let the easy handles in ``EASY_THREADPOOL`` share DNS caches to reduce lookups.
 
 Sharing is enabled by default. Set ``KVIKIO_REMOTE_SHARE_DNS_CACHE`` to ``false``, ``off``, ``no``, or ``0`` (case-insensitive) to disable sharing.
 
-``KVIKIO_REMOTE_NUM_DNS_CACHES`` determines how many DNS caches are used. The default value is ``16``. The count also determines how many server addresses the process connects to, since a cache holds one address list and libcurl always connects to its first entry.
+``KVIKIO_REMOTE_NUM_DNS_CACHES`` sets how many DNS caches the process creates. The default value is ``16``, and a value below ``1`` is clamped to ``1``. Each worker thread is assigned one cache round-robin on first use, which means roughly ``KVIKIO_NTHREADS`` divided by this count threads share a cache.
 
 Both variables are read only from the environment, and only when the caches are first used. Neither has any effect under ``MULTI_POLL``.
 


### PR DESCRIPTION
This PR only applies to the easy thread pool backend.

Saturating a fast NIC needs a large `KVIKIO_NTHREADS`. Each easy handle resolves the endpoint on its own, and the number of DNS lookups grows with the thread pool. When too many happen at once, some queries go unanswered, and libcurl reports this as `CURLE_COULDNT_RESOLVE_HOST` ("Could not resolve host").

This PR helps to avoid this problem by sharing the DNS cache among easy handles. Two knobs are provided:
- `KVIKIO_REMOTE_SHARE_DNS_CACHE`: Whether to share DNS cache. Default to 1 (enabled).
- `KVIKIO_REMOTE_MAX_THREADS_PER_DNS_CACHE`: How many threads share a DNS cache. Default to 16.