### PR TITLE
Turn on autosectionlabel in sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,11 +50,15 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
     "sphinx.ext.autosummary",
+    "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
     "numpydoc",
     "sphinx_click",
 ]
+
+# Disambiguate section anchors across documents
+autosectionlabel_prefix_document = True
 
 numpydoc_show_class_members = False
 


### PR DESCRIPTION
This will allow linking to arbitrary sections through intersphinx inventories. Without these one can only link to a given page or some kind of object name.