### PR TITLE
Fix missing-field-initializers build failure in kvikio_nic nsys plugin

### DIFF
--- a/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp
+++ b/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp
@@ -73,6 +73,8 @@ constexpr nvtxSemanticsCounter_t rate_semantics{
   .unitScaleNumerator   = 1,
   .unitScaleDenominator = 1,
   .limitType            = NVTX_COUNTER_LIMIT_UNDEFINED,
+  .min                  = {},
+  .max                  = {},
 };
 }  // namespace constants
 
@@ -256,14 +258,22 @@ std::uint64_t register_rate_schema(nvtxDomainHandle_t domain)
 {
   static_assert(std::is_standard_layout_v<NicRates>);
   std::array const entries = {
-    nvtxPayloadSchemaEntry_t{.type        = NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE,
-                             .name        = "rx",
-                             .description = "Receive rate",
-                             .offset      = offsetof(NicRates, rx)},
-    nvtxPayloadSchemaEntry_t{.type        = NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE,
-                             .name        = "tx",
-                             .description = "Transmit rate",
-                             .offset      = offsetof(NicRates, tx)},
+    nvtxPayloadSchemaEntry_t{.flags              = NVTX_PAYLOAD_ENTRY_FLAG_UNUSED,
+                             .type               = NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE,
+                             .name               = "rx",
+                             .description        = "Receive rate",
+                             .arrayOrUnionDetail = 0,
+                             .offset             = offsetof(NicRates, rx),
+                             .semantics          = nullptr,
+                             .reserved           = nullptr},
+    nvtxPayloadSchemaEntry_t{.flags              = NVTX_PAYLOAD_ENTRY_FLAG_UNUSED,
+                             .type               = NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE,
+                             .name               = "tx",
+                             .description        = "Transmit rate",
+                             .arrayOrUnionDetail = 0,
+                             .offset             = offsetof(NicRates, tx),
+                             .semantics          = nullptr,
+                             .reserved           = nullptr},
   };
   nvtxPayloadSchemaAttr_t attr{};
   attr.fieldMask = NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |

--- a/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp
+++ b/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp
@@ -63,19 +63,19 @@ constexpr int exit_success       = 0;
 constexpr int exit_no_interfaces = 1;
 constexpr int exit_usage_error   = 2;
 
-constexpr nvtxSemanticsCounter_t rate_semantics{
-  .header               = {.structSize = sizeof(nvtxSemanticsCounter_t),
-                           .semanticId = NVTX_SEMANTIC_ID_COUNTERS_V1,
-                           .version    = NVTX_COUNTER_SEMANTIC_VERSION,
-                           .next       = nullptr},
-  .flags                = NVTX_COUNTER_FLAGS_NONE,
-  .unit                 = "MiB/s",
-  .unitScaleNumerator   = 1,
-  .unitScaleDenominator = 1,
-  .limitType            = NVTX_COUNTER_LIMIT_UNDEFINED,
-  .min                  = {},
-  .max                  = {},
-};
+constexpr nvtxSemanticsCounter_t rate_semantics = [] {
+  nvtxSemanticsCounter_t semantics{};
+  semantics.header.structSize    = sizeof(nvtxSemanticsCounter_t);
+  semantics.header.semanticId    = NVTX_SEMANTIC_ID_COUNTERS_V1;
+  semantics.header.version       = NVTX_COUNTER_SEMANTIC_VERSION;
+  semantics.header.next          = nullptr;
+  semantics.flags                = NVTX_COUNTER_FLAGS_NONE;
+  semantics.unit                 = "MiB/s";
+  semantics.unitScaleNumerator   = 1;
+  semantics.unitScaleDenominator = 1;
+  semantics.limitType            = NVTX_COUNTER_LIMIT_UNDEFINED;
+  return semantics;
+}();
 }  // namespace constants
 
 /**
@@ -257,23 +257,17 @@ std::vector<std::string> select_interfaces(Config const& config)
 std::uint64_t register_rate_schema(nvtxDomainHandle_t domain)
 {
   static_assert(std::is_standard_layout_v<NicRates>);
+  auto make_entry = [](char const* name, char const* description, std::size_t offset) {
+    nvtxPayloadSchemaEntry_t entry{};
+    entry.type        = NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE;
+    entry.name        = name;
+    entry.description = description;
+    entry.offset      = offset;
+    return entry;
+  };
   std::array const entries = {
-    nvtxPayloadSchemaEntry_t{.flags              = NVTX_PAYLOAD_ENTRY_FLAG_UNUSED,
-                             .type               = NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE,
-                             .name               = "rx",
-                             .description        = "Receive rate",
-                             .arrayOrUnionDetail = 0,
-                             .offset             = offsetof(NicRates, rx),
-                             .semantics          = nullptr,
-                             .reserved           = nullptr},
-    nvtxPayloadSchemaEntry_t{.flags              = NVTX_PAYLOAD_ENTRY_FLAG_UNUSED,
-                             .type               = NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE,
-                             .name               = "tx",
-                             .description        = "Transmit rate",
-                             .arrayOrUnionDetail = 0,
-                             .offset             = offsetof(NicRates, tx),
-                             .semantics          = nullptr,
-                             .reserved           = nullptr},
+    make_entry("rx", "Receive rate", offsetof(NicRates, rx)),
+    make_entry("tx", "Transmit rate", offsetof(NicRates, tx)),
   };
   nvtxPayloadSchemaAttr_t attr{};
   attr.fieldMask = NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |


### PR DESCRIPTION
Attempt at fixing the nightly [velox-cudf](https://github.com/NVIDIA/cudf/actions/runs/34568181965/job/103164498430#step:9:1676) build job

<details>

```
FAILED: _deps/kvikio-build/nsys_plugins/nic/CMakeFiles/kvikio_nic_nsys_plugin.dir/kvikio_nic_nsys_plugin.cpp.o 
sccache /opt/rh/gcc-toolset-14/root/usr/bin/g++ -DVELOX_ENABLE_PARQUET -I/__w/cudf/cudf/_build/release/_deps/nvtx3-src/c/include -mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2 -DUSE_VELOX_COMMON_BASE -DHAS_UNCAUGHT_EXCEPTIONS -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-implicit-fallthrough          -Wno-class-memaccess          -Wno-comment          -Wno-int-in-bool-context          -Wno-redundant-move          -Wno-array-bounds          -Wno-maybe-uninitialized          -Wno-unused-result          -Wno-format-overflow          -Wno-strict-aliasing -Wno-error=template-id-cdtor -Wno-overloaded-virtual -Wno-error=tautological-compare -O3 -DNDEBUG -std=gnu++20 -fPIE -fdiagnostics-color=always -Wall -Werror -Wno-unknown-pragmas -MD -MT _deps/kvikio-build/nsys_plugins/nic/CMakeFiles/kvikio_nic_nsys_plugin.dir/kvikio_nic_nsys_plugin.cpp.o -MF _deps/kvikio-build/nsys_plugins/nic/CMakeFiles/kvikio_nic_nsys_plugin.dir/kvikio_nic_nsys_plugin.cpp.o.d -o _deps/kvikio-build/nsys_plugins/nic/CMakeFiles/kvikio_nic_nsys_plugin.dir/kvikio_nic_nsys_plugin.cpp.o -c /__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:76:1: error: missing initializer for member 'nvtxSemanticsCounter_v1::min' [-Werror=missing-field-initializers]
   76 | };
      | ^
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:76:1: error: missing initializer for member 'nvtxSemanticsCounter_v1::max' [-Werror=missing-field-initializers]
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp: In function 'uint64_t {anonymous}::register_rate_schema(nvtxDomainHandle_t)':
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:262:66: error: missing initializer for member 'nvtxPayloadSchemaEntry_v1::flags' [-Werror=missing-field-initializers]
  262 |                              .offset      = offsetof(NicRates, rx)},
      |                                                                  ^
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:262:66: error: missing initializer for member 'nvtxPayloadSchemaEntry_v1::arrayOrUnionDetail' [-Werror=missing-field-initializers]
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:262:66: error: missing initializer for member 'nvtxPayloadSchemaEntry_v1::semantics' [-Werror=missing-field-initializers]
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:262:66: error: missing initializer for member 'nvtxPayloadSchemaEntry_v1::reserved' [-Werror=missing-field-initializers]
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:266:66: error: missing initializer for member 'nvtxPayloadSchemaEntry_v1::flags' [-Werror=missing-field-initializers]
  266 |                              .offset      = offsetof(NicRates, tx)},
      |                                                                  ^
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:266:66: error: missing initializer for member 'nvtxPayloadSchemaEntry_v1::arrayOrUnionDetail' [-Werror=missing-field-initializers]
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:266:66: error: missing initializer for member 'nvtxPayloadSchemaEntry_v1::semantics' [-Werror=missing-field-initializers]
/__w/cudf/cudf/_build/release/_deps/kvikio-src/cpp/nsys_plugins/nic/kvikio_nic_nsys_plugin.cpp:266:66: error: missing initializer for member 'nvtxPayloadSchemaEntry_v1::reserved' [-Werror=missing-field-initializers]
cc1plus: all warnings being treated as errors
[457/3401] Building CXX object velox/buffer/CMakeFiles/velox.dir/__/common/base/Exceptions.cpp.o
[458/3401] Generating JIT embed for cudf_cuda_embed into /__w/cudf/cudf/_build/release/_deps/cudf-build/rtcx_embed
-- Compressed cudf_cuda_embed's binary from 13452099 bytes to 1134801 bytes (compression ratio: 0.08)
[459/3401] Building CXX object velox/buffer/CMakeFiles/velox.dir/__/common/base/BloomFilter.cpp.o
[460/3401] Building CXX object velox/buffer/CMakeFiles/velox.dir/__/common/base/BitUtil.cpp.o
[461/3401] Building CXX object velox/buffer/CMakeFiles/velox.dir/__/common/base/VeloxException.cpp.o
[462/3401] Building CXX object velox/buffer/CMakeFiles/velox.dir/__/common/base/AdmissionController.cpp.o
[463/3401] Building CXX object velox/buffer/CMakeFiles/velox.dir/__/dwio/common/SortingWriter.cpp.o
ninja: build stopped: subcommand failed.
make[1]: *** [Makefile:112: build] Error 1
make[1]: Leaving directory '/__w/cudf/cudf'
make: *** [Makefile:143: cudf] Error 2

```

</details>

Closes #1061 
